### PR TITLE
Add boardroom voting example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,12 +7,14 @@ stages:
     - au
   before_script:
     - cd execution
+    - opam repo add coq-released https://coq.inria.fr/opam/released
     - opam repo add iris-dev https://gitlab.mpi-sws.org/iris/opam.git
     - opam update -y
     - opam config list
     - opam repo list
     - opam list
     - opam install -y coq-stdpp
+    - opam install -y coq-bignums
   script:
     - sudo chown -R coq:coq "$CI_PROJECT_DIR"
     - make -j
@@ -30,6 +32,10 @@ execution:coq:8.10:
   extends: .build-execution
   image: coqorg/coq:8.10
 
+execution:coq:8.11:
+  extends: .build-execution
+  image: coqorg/coq:8.11
+
 execution:coq:dev:
   extends: .build-execution
   image: coqorg/coq:dev
@@ -39,6 +45,13 @@ full:coq:8.9.1:
   image: aucobra/concert:coq-8.9.1-with-metacoq
   tags:
     - au
+  before_script:
+    - opam repo add coq-released https://coq.inria.fr/opam/released
+    - opam update -y
+    - opam config list
+    - opam repo list
+    - opam list
+    - opam install -y coq-bignums
   script:
     - sudo chown -R coq:coq "$CI_PROJECT_DIR"
     - make -j

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A framework for smart contract verification in Coq
 ## How to build
 
 
-Our development works with Coq 8.9.1. and depends on MetaCoq 1.0~alpha+8.9 and
-the std++ library v.1.2.1. These dependencies can be installed through
-`opam`.
+Our development works with Coq 8.9.1. and depends on MetaCoq 1.0~alpha+8.9,
+std++ library v.1.2.1 and coq-bignums. These dependencies can be installed
+through `opam`.
 
 Install Coq (see https://coq.inria.fr/opam-using.html for detailed instructions on how to manage
 multiple Coq installations using opam).:
@@ -16,11 +16,12 @@ multiple Coq installations using opam).:
 opam install coq.8.9.1
 ```
 
-Then MetaCoq:
+Then MetaCoq and bignums:
 
 ```bash
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install coq-metacoq.1.0~alpha+8.9
+opam install coq-bignums
 ```
 And std++:
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -6,7 +6,11 @@ vendor/record-update/RecordUpdate.v
 
 -R execution/theories ConCert.Execution
 execution/theories/Automation.v
+execution/theories/BignumsSerializable.v
 execution/theories/Blockchain.v
+execution/theories/BoardroomMath.v
+execution/theories/BoardroomVoting.v
+execution/theories/BoardroomVotingTest.v
 execution/theories/BoundedN.v
 execution/theories/ChainedList.v
 execution/theories/Circulation.v
@@ -14,7 +18,9 @@ execution/theories/Congress.v
 execution/theories/Congress_Buggy.v
 execution/theories/Containers.v
 execution/theories/ContractMonads.v
+execution/theories/Egcd.v
 execution/theories/Escrow.v
+execution/theories/Euler.v
 execution/theories/Extras.v
 execution/theories/Finite.v
 execution/theories/LocalBlockchain.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,3 +1,5 @@
+-arg -w -arg -undeclared-scope
+
 -R vendor/record-update RecordUpdate
 vendor/record-update/RecordSet.v
 vendor/record-update/RecordUpdate.v
@@ -11,6 +13,7 @@ execution/theories/Circulation.v
 execution/theories/Congress.v
 execution/theories/Congress_Buggy.v
 execution/theories/Containers.v
+execution/theories/ContractMonads.v
 execution/theories/Escrow.v
 execution/theories/Extras.v
 execution/theories/Finite.v

--- a/execution/README.md
+++ b/execution/README.md
@@ -91,6 +91,81 @@ Note that the second point above is for the case where the buyer never commits
 any money to the escrow, in which case the seller is allowed to withdraw his own
 commitment after a deadline.
 
+In [BoardroomVoting.v](theories/BoardroomVoting.v) we verify functional
+correctness of a private boardroom voting contract based on [1] under some
+simplifying assumptions. In particular we do not verify anything about the
+zero-knowledge proofs required to make sure that everyone participates correctly
+in the smart contract. Instead we assume that everyone participates correctly
+and then show that the smart contract in this case computes the correct result
+(i.e. a public tally of the private votes). The statement is the following:
+
+```coq
+Theorem boardroom_voting_correct
+        bstate caddr (trace : ChainTrace empty_state bstate)
+        (* list of all public keys, in the order of signups *)
+        (pks : list A)
+        (* function mapping a party to his signup index *)
+        (index : Address -> nat)
+        (* function mapping a party to his secret key *)
+        (sks : Address -> Z)
+        (* function mapping a party to his vote *)
+        (svs : Address -> bool) :
+    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+    exists (cstate : State)
+           (depinfo : DeploymentInfo Setup)
+           (inc_calls : list (ContractCallInfo Msg)),
+      deployment_info Setup trace caddr = Some depinfo /\
+      contract_state bstate caddr = Some cstate /\
+      incoming_calls Msg trace caddr = Some inc_calls /\
+
+      (* assuming that the message sent were created with the
+          functions provided by this smart contract *)
+      MsgAssumption pks index sks svs inc_calls ->
+
+      (* ..and that people signed up in the order given by 'index'
+          and 'pks' *)
+      SignupOrderAssumption pks index inc_calls ->
+
+      (* ..and that the correct number of people register *)
+      (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
+       length pks = length (signups inc_calls)) ->
+
+      (* then if we have not tallied yet, the result is none *)
+      ((has_tallied inc_calls = false -> result cstate = None) /\
+       (* or if we have tallied yet, the result is correct *)
+       (has_tallied inc_calls = true ->
+        result cstate = Some (sumnat (fun party => if svs party then 1 else 0)%nat
+                                     (FMap.keys (registered_voters cstate))))).
+```
+The simplifying assumptions are expressed over the messages seen in the
+blockchain state. For instance, `MsgAssumption` above captures that everyone
+participates correctly by saying that all messages sent to the contract were
+created using functions provided by the smart contract:
+
+```coq
+Fixpoint MsgAssumption
+         (pks : list A)
+         (index : Address -> nat)
+         (sks : Address -> Z)
+         (svs : Address -> bool)
+         (calls : list (ContractCallInfo Msg)) : Prop :=
+  match calls with
+  | call :: calls =>
+    let caller := Blockchain.call_from call in
+    match Blockchain.call_msg call with
+    | Some (signup pk as m) => m = make_signup_msg (sks caller)
+    | Some (submit_vote _ _ as m) =>
+      m = make_vote_msg pks (index caller) (sks caller) (svs caller)
+    | _ => True
+    end /\ MsgAssumption pks index sks svs calls
+  | [] => True
+  end.
+```
+
+Here `make_signup_msg` and `make_vote_msg` are the functions provided by the
+smart contract and could potentially be extracted with the rest of the smart
+contract to have functionally verified boardroom voting contract with privacy.
+
 In [Circulation.v](theories/Circulation.v) we prove a small sanity check for our
 semantics. Specifically we prove that the total sum of the money in the system
 is equal to the sum of the rewards handed out in blocks.
@@ -101,15 +176,24 @@ one of our implementations of blockchains. We also specialize the proof shown
 about to our actual implementations of the execution layer described above.
 
 ## Building/Developing
-This project uses the std++ library. This must be installed first and can be
-installed via Opam, after adding the dev repo of Iris:
+This project uses the std++ and bignums library. These must be installed first
+and can be installed via Opam in the following way:
 ```bash
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam install coq-bignums
+
 opam repo add iris-dev https://gitlab.mpi-sws.org/iris/opam.git
 opam install coq-stdpp
 ```
+
 For more instructions, see [the stdpp readme](https://gitlab.mpi-sws.org/iris/stdpp).
 
-After stdpp is installed, this project should build with
+After the dependencies are installed this project should build with
 ```bash
 make
 ```
+
+## References
+[1] McCorry, Patrick, Siamak F. Shahandashti, and Feng Hao. "A smart contract for
+boardroom voting with maximum voter privacy." International Conference on
+Financial Cryptography and Data Security. Springer, Cham, 2017.

--- a/execution/_CoqProject
+++ b/execution/_CoqProject
@@ -1,3 +1,5 @@
+-arg -w -arg -undeclared-scope
+
 -R ../vendor/record-update RecordUpdate
 ../vendor/record-update/RecordSet.v
 ../vendor/record-update/RecordUpdate.v
@@ -11,6 +13,7 @@ theories/Circulation.v
 theories/Congress.v
 theories/Congress_Buggy.v
 theories/Containers.v
+theories/ContractMonads.v
 theories/Escrow.v
 theories/Extras.v
 theories/Finite.v

--- a/execution/_CoqProject
+++ b/execution/_CoqProject
@@ -6,7 +6,11 @@
 
 -R theories ConCert.Execution
 theories/Automation.v
+theories/BignumsSerializable.v
 theories/Blockchain.v
+theories/BoardroomMath.v
+theories/BoardroomVoting.v
+theories/BoardroomVotingTest.v
 theories/BoundedN.v
 theories/ChainedList.v
 theories/Circulation.v
@@ -14,7 +18,9 @@ theories/Congress.v
 theories/Congress_Buggy.v
 theories/Containers.v
 theories/ContractMonads.v
+theories/Egcd.v
 theories/Escrow.v
+theories/Euler.v
 theories/Extras.v
 theories/Finite.v
 theories/LocalBlockchain.v

--- a/execution/make_graph.sh
+++ b/execution/make_graph.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+make
+FILES=$(find . -type f -iname "*.v" -exec basename {} .v ';')
+IMP="From ConCert.Execution Require ${FILES}. Require dpdgraph.dpdgraph. Print FileDependGraph ${FILES}."
+
+echo $IMP | coqtop -R ../vendor/record-update RecordUpdate -R theories ConCert.Execution

--- a/execution/theories/Automation.v
+++ b/execution/theories/Automation.v
@@ -214,3 +214,22 @@ Ltac unset_all :=
     | [var := ?body : ?T |- _] =>
       pose proof (eq_refl : var = body); clearbody var
     end.
+
+Ltac destruct_hyps :=
+  repeat
+    match goal with
+    | [H: _ /\ _ |- _] => destruct H
+    | [H: exists _, _ |- _] => destruct H
+    | [H: _ * _ |- _] => destruct H
+    | [H: { x : _ & _ } |- _] => destruct H
+    end.
+
+Ltac destruct_and_split :=
+  repeat
+    match goal with
+    | [H: _ /\ _ |- _] => destruct H
+    | [H: exists _, _ |- _] => destruct H
+    | [H: _ * _ |- _] => destruct H
+    | [H: { x : _ & _ } |- _] => destruct H
+    | [|- _ /\ _] => split
+    end.

--- a/execution/theories/BignumsSerializable.v
+++ b/execution/theories/BignumsSerializable.v
@@ -1,0 +1,115 @@
+From Bignums Require Import BigN.
+From Bignums Require Import BigZ.
+From Coq Require Import ZArith.
+From Coq Require Import DoubleType.
+Require Import Monads.
+Require Import Serializable.
+
+Section IntSer.
+  Definition int_serializable
+             (T := BigN.dom_t 0)
+             (to_Z : T -> Z)
+             (of_Z : Z -> T)
+             (of_to_Z : forall t, of_Z (to_Z t) = t) : Serializable T.
+  Proof.
+    refine
+      {| serialize t := serialize (to_Z t);
+         deserialize p := do z <- deserialize p; ret (of_Z z); |}.
+    intros x.
+    rewrite deserialize_serialize.
+    cbn.
+    now rewrite of_to_Z.
+  Defined.
+
+  (* Massive hack: ltac inside notation is only checked at expansion time.
+   This allows the proof below to work for Coq 8.10 where Bignums uses int63
+   and Coq 8.9 where Bignums uses int31 and int63 does not even exist. *)
+  Local Set Warnings "-non-reversible-notation".
+  Notation "'lazyexp' x" := ltac:(exact x) (at level 70).
+
+  Global Instance int_serializable_inst : Serializable (BigN.dom_t 0).
+  Proof.
+    first
+      [exact
+         (int_serializable
+            (lazyexp Int31.phi)
+            (lazyexp Int31.phi_inv)
+            (lazyexp Cyclic31.phi_inv_phi))|
+       exact
+         (int_serializable
+            (lazyexp Int63.to_Z)
+            (lazyexp Int63.of_Z)
+            (lazyexp Int63.of_to_Z))].
+  Defined.
+End IntSer.
+
+Global Instance zn2z_serializable {A} `{Serializable A} : Serializable (zn2z A).
+Proof.
+  refine
+    {| serialize w1 :=
+         serialize
+           match w1 with
+           | W0 => (0%nat, serialize tt)
+           | WW a b => (1%nat, serialize (a, b))
+           end;
+       deserialize p :=
+         do '(tag, p) <- deserialize p;
+         match tag with
+         | 0%nat => ret W0
+         | _ => do '(a, b) <- deserialize p;
+                ret (WW a b)
+         end |}.
+  intros.
+  rewrite deserialize_serialize.
+  cbn.
+  destruct x; auto.
+  now rewrite deserialize_serialize.
+Defined.
+Global Instance word_serializable {A} `{Serializable A} (n : nat) : Serializable (word A n) :=
+  (fix f (n : nat) :=
+     match n return (Serializable (word A n)) with
+     | 0%nat => _ : Serializable A
+     | S n => zn2z_serializable
+     end) n.
+
+Global Instance BigNw1_serializable : Serializable BigN.w1 := ltac:(apply zn2z_serializable).
+Global Instance BigNw2_serializable : Serializable BigN.w2 := ltac:(apply zn2z_serializable).
+Global Instance BigNw3_serializable : Serializable BigN.w3 := ltac:(apply zn2z_serializable).
+Global Instance BigNw4_serializable : Serializable BigN.w4 := ltac:(apply zn2z_serializable).
+Global Instance BigNw5_serializable : Serializable BigN.w5 := ltac:(apply zn2z_serializable).
+Global Instance BigNw6_serializable : Serializable BigN.w6 := ltac:(apply zn2z_serializable).
+Global Instance BigN_serializable : Serializable bigN.
+Proof.
+  refine
+    {| serialize n :=
+         match n with
+         | BigN.N0 i => serialize (0, serialize i)
+         | BigN.N1 w => serialize (1, serialize w)
+         | BigN.N2 w => serialize (2, serialize w)
+         | BigN.N3 w => serialize (3, serialize w)
+         | BigN.N4 w => serialize (4, serialize w)
+         | BigN.N5 w => serialize (5, serialize w)
+         | BigN.N6 w => serialize (6, serialize w)
+         | BigN.Nn n w => serialize (7, serialize (n, serialize w))
+         end%nat;
+       deserialize p :=
+         do '(tag, p) <- deserialize p;
+         match tag with
+         | 0 => option_map BigN.N0 (deserialize p)
+         | 1 => option_map BigN.N1 (deserialize p)
+         | 2 => option_map BigN.N2 (deserialize p)
+         | 3 => option_map BigN.N3 (deserialize p)
+         | 4 => option_map BigN.N4 (deserialize p)
+         | 5 => option_map BigN.N5 (deserialize p)
+         | 6 => option_map BigN.N6 (deserialize p)
+         | 7 => do '(n, p) <- deserialize p;
+                do w <- deserialize p;
+                ret (BigN.Nn n w)
+         | _ => None
+         end%nat |}.
+  intros [].
+  all: rewrite ?deserialize_serialize; cbn.
+  all: rewrite ?deserialize_serialize; easy.
+Defined.
+Global Instance BigZ_serializable : Serializable bigZ :=
+  Derive Serializable BigZ.t__rect<BigZ.Pos, BigZ.Neg>.

--- a/execution/theories/BoardroomMath.v
+++ b/execution/theories/BoardroomMath.v
@@ -1,0 +1,1774 @@
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+From Coq Require Import PArith.
+From Coq Require Import Permutation.
+From Coq Require Import Psatz.
+From Coq Require Import SetoidTactics.
+From Coq Require Import Field.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+From Bignums Require Import BigZ.
+Import List.
+
+Require Import Egcd.
+Require Import Euler.
+Require Import Extras.
+Import ListNotations.
+
+Local Open Scope Z.
+
+Class BoardroomAxioms {A : Type} :=
+  {
+    elmeq : A -> A -> Prop;
+    elmeqb : A -> A -> bool;
+    elmeqb_spec x y : Bool.reflect (elmeq x y) (elmeqb x y);
+    zero : A;
+    one : A;
+
+    add : A -> A -> A;
+    mul : A -> A -> A;
+
+    opp : A -> A;
+    inv : A -> A;
+    pow : A -> Z -> A;
+
+    order : Z;
+    expeq e e' := e mod (order - 1) = e' mod (order - 1);
+
+    order_ge_2 : order >= 2;
+
+    elmeq_equiv :> Equivalence elmeq;
+    add_proper :> Proper (elmeq ==> elmeq ==> elmeq) add;
+    mul_proper :> Proper (elmeq ==> elmeq ==> elmeq) mul;
+    opp_proper :> Proper (elmeq ==> elmeq) opp;
+    inv_proper :> Proper (elmeq ==> elmeq) inv;
+    pow_exp_proper a :
+      ~(elmeq a zero) -> Proper (expeq ==> elmeq) (pow a);
+
+    one_neq_zero : ~(elmeq one zero);
+
+    add_comm a b : elmeq (add a b) (add b a);
+    add_assoc a b c : elmeq (add a (add b c)) (add (add a b) c);
+
+    mul_comm a b : elmeq (mul a b) (mul b a);
+    mul_assoc a b c : elmeq (mul a (mul b c)) (mul (mul a b) c);
+
+    add_0_l a : elmeq (add zero a) a;
+    mul_0_l a : elmeq (mul zero a) zero;
+    mul_1_l a : elmeq (mul one a) a;
+
+    opp_inv_l a : elmeq (add (opp a) a) zero;
+    inv_inv_l a : ~(elmeq a zero) -> elmeq (mul (inv a) a) one;
+
+    mul_add a b c : elmeq (mul (add a b) c) (add (mul a c) (mul b c));
+
+    pow_0_r a :
+      ~(elmeq a zero) ->
+      elmeq (pow a 0) one;
+
+    pow_1_r a : elmeq (pow a 1) a;
+
+    pow_opp_1 a :
+      ~(elmeq a zero) ->
+      elmeq (pow a (-1)) (inv a);
+
+    pow_plus a e e' :
+      ~(elmeq a zero) ->
+      elmeq (pow a (e + e')) (mul (pow a e) (pow a e'));
+
+    pow_nonzero a e :
+      ~(elmeq a zero) ->
+      ~(elmeq (pow a e) zero);
+
+    inv_nonzero a :
+      ~(elmeq a zero) ->
+      ~(elmeq (inv a) zero);
+  }.
+
+Arguments BoardroomAxioms : clear implicits.
+
+Delimit Scope ffield_scope with ffield.
+
+Infix "==" := elmeq (at level 70) : ffield.
+Notation "a !== b" := (~(elmeq a b)) (at level 70) : ffield.
+Notation "0" := zero : ffield.
+Notation "1" := one : ffield.
+Infix "+" := add : ffield.
+Infix "*" := mul : ffield.
+Infix "^" := pow : ffield.
+Notation "a 'exp=' b" := (expeq a b) (at level 70) : ffield.
+Notation "a 'exp<>' b" := (~(expeq a b)) (at level 70) : ffield.
+
+Local Open Scope ffield.
+Global Instance oeq_equivalence {A : Type} (field : BoardroomAxioms A) : Equivalence expeq.
+Proof.
+  unfold expeq.
+  constructor.
+  - constructor.
+  - repeat intro; auto.
+  - now intros ? ? ? -> ->.
+Qed.
+
+Definition BoardroomAxioms_field_theory {A : Type} (field : BoardroomAxioms A) :
+  field_theory
+    zero one
+    add mul
+    (fun x y => x + (opp y)) opp
+    (fun x y => x * inv y) inv
+    elmeq.
+Proof.
+  constructor; [constructor| | |].
+  - apply add_0_l.
+  - apply add_comm.
+  - apply add_assoc.
+  - apply mul_1_l.
+  - apply mul_comm.
+  - apply mul_assoc.
+  - apply mul_add.
+  - reflexivity.
+  - intros x. rewrite add_comm. apply opp_inv_l.
+  - apply one_neq_zero.
+  - reflexivity.
+  - apply inv_inv_l.
+Qed.
+
+Class Generator {A : Type} (field : BoardroomAxioms A) :=
+  build_generator {
+    generator : A;
+    generator_nonzero : generator !== 0;
+    generator_generates a : a !== 0 -> exists! e, 0 <= e < order - 1 /\ generator^e == a;
+  }.
+
+Class DiscreteLog {A : Type} (field : BoardroomAxioms A) (g : Generator field) :=
+  build_log {
+    (* This is computationally intractable, but we still elmequire it
+    for ease of specification *)
+    log : A -> Z;
+    log_proper :> Proper (elmeq ==> expeq) log;
+    pow_log a :
+      a !== 0 ->
+      generator ^ (log a) == a;
+
+    log_1_l : log 1 exp= 0%Z;
+    log_mul a b :
+      a !== 0 ->
+      b !== 0 ->
+      log (a * b) exp= log a + log b;
+
+    log_inv a : log (inv a) exp= -log a;
+    log_generator : log generator = 1%Z;
+  }.
+
+Section WithBoardroomAxioms.
+  Context {A : Type}.
+  Context {field : BoardroomAxioms A}.
+  Context {gen : Generator field}.
+  Context {disc_log : DiscreteLog field gen}.
+
+  Add Field ff : (BoardroomAxioms_field_theory field).
+
+  Local Open Scope ffield.
+
+  Hint Resolve one_neq_zero pow_nonzero generator_nonzero inv_nonzero : core.
+
+  Fixpoint prod (l : list A) : A :=
+    match l with
+    | [] => one
+    | x :: xs => x * prod xs
+    end.
+
+  Instance plus_expeq_proper : Proper (expeq ==> expeq ==> expeq) Z.add.
+  Proof.
+    intros x x' xeq y y' yeq.
+    unfold "exp=" in *.
+    assert (order - 1 <> 0)%Z by (pose proof order_ge_2; lia).
+    now rewrite Z.add_mod, xeq, yeq, <- Z.add_mod.
+  Qed.
+
+  Instance mul_expeq_proper : Proper (expeq ==> expeq ==> expeq) Z.mul.
+  Proof.
+    intros x x' xeq y y' yeq.
+    unfold "exp=" in *.
+    assert (order - 1 <> 0)%Z by (pose proof order_ge_2; lia).
+    now rewrite Z.mul_mod, xeq, yeq, <- Z.mul_mod.
+  Qed.
+
+  Instance sub_expeq_proper : Proper (expeq ==> expeq ==> expeq) Z.sub.
+  Proof.
+    intros x x' xeq y y' yeq.
+    unfold "exp=" in *.
+    assert (order - 1 <> 0)%Z by (pose proof order_ge_2; lia).
+    now rewrite Zminus_mod, xeq, yeq, <- Zminus_mod.
+  Qed.
+
+  Instance opp_expeq_proper : Proper (expeq ==> expeq) Z.opp.
+  Proof.
+    intros x x' xeq.
+    rewrite <- !Z.sub_0_l.
+    now rewrite xeq.
+  Qed.
+
+  Lemma log_pow a e :
+    a !== 0 ->
+    log (a ^ e) exp= e * log a.
+  Proof.
+    intros anz.
+    induction e using Z.peano_ind.
+    - rewrite pow_0_r; auto.
+      apply log_1_l.
+    - replace (Z.succ e) with (e + 1)%Z by lia.
+      rewrite pow_plus by auto.
+      rewrite log_mul; auto.
+      rewrite IHe.
+      replace ((e + 1) * log a)%Z with (e * log a + log a)%Z by lia.
+      now rewrite pow_1_r.
+    - replace (Z.pred e) with (e + (-1))%Z by lia.
+      rewrite pow_plus by auto.
+      rewrite log_mul by auto.
+      rewrite IHe.
+      rewrite (pow_opp_1 a) by auto.
+      rewrite log_inv.
+      now replace ((e + -1) * log a)%Z with (e * log a + - log a)%Z by lia.
+  Qed.
+
+  Instance pow_generator_proper : Proper (expeq ==> elmeq) (pow generator) :=
+    pow_exp_proper _ generator_nonzero.
+
+  Lemma log_both a b :
+    a !== 0 ->
+    b !== 0 ->
+    log a exp= log b ->
+    a == b.
+  Proof.
+    intros an0 bn0 dleq.
+    assert (generator ^ log a == generator ^ log a) as H by reflexivity.
+    rewrite dleq in H at 1.
+    now rewrite !pow_log in H by auto.
+  Qed.
+
+  Lemma log_pow_generator e :
+    log (generator ^ e) exp= e.
+  Proof.
+    rewrite log_pow; auto.
+    rewrite log_generator.
+    now rewrite Z.mul_1_r.
+  Qed.
+
+  Lemma int_domain a b :
+    a !== 0 ->
+    b !== 0 ->
+    a * b !== 0.
+  Proof.
+    intros an0 bn0.
+    apply (@field_is_integral_domain
+             A
+             0 1
+             add
+             mul
+             (fun a b => a + (opp b))
+             opp
+             (fun a b => a * (inv b))
+             inv); eauto.
+    - typeclasses eauto.
+    - constructor; typeclasses eauto.
+    - apply F2AF.
+      + typeclasses eauto.
+      + constructor; typeclasses eauto.
+      + apply (BoardroomAxioms_field_theory field).
+  Qed.
+
+  Hint Resolve int_domain : core.
+
+  Lemma prod_units (xs : list A) :
+    All (fun x => x !== 0) xs <-> prod xs !== 0.
+  Proof.
+    induction xs as [|x xs IH]; cbn in *; auto.
+    - split; auto.
+    - split.
+      + intros.
+        apply int_domain; intuition.
+      + intros xprod.
+        split.
+        * intros eq; rewrite eq in *; rewrite mul_0_l in xprod.
+          destruct (xprod ltac:(reflexivity)).
+        * apply IH.
+          intros eq; rewrite eq in *; rewrite mul_comm, mul_0_l in xprod.
+          destruct (xprod ltac:(reflexivity)).
+  Qed.
+
+  Hint Resolve -> prod_units : core.
+  Hint Resolve <- prod_units : core.
+
+  Definition compute_public_key (sk : Z) : A :=
+    generator ^ sk.
+
+  Definition reconstructed_key (pks : list A) (n : nat) : A :=
+    let lprod := prod (firstn n pks) in
+    let rprod := inv (prod (skipn (S n) pks)) in
+    lprod * rprod.
+
+  Definition compute_public_vote (rk : A) (sk : Z) (sv : bool) : A :=
+    rk ^ sk * if sv then generator else 1.
+
+  Fixpoint bruteforce_tally_aux
+           (n : nat)
+           (votes_product : A) : option nat :=
+    if elmeqb (generator ^ (Z.of_nat n)) votes_product then
+      Some n
+    else
+      match n with
+      | 0 => None
+      | S n => bruteforce_tally_aux n votes_product
+      end%nat.
+
+  Definition bruteforce_tally (votes : list A) : option nat :=
+    bruteforce_tally_aux (length votes) (prod votes).
+
+  Lemma compute_public_key_unit sk :
+    compute_public_key sk !== 0.
+  Proof. apply pow_nonzero, generator_nonzero. Qed.
+  Hint Resolve compute_public_key_unit : core.
+
+  Lemma compute_public_keys_units sks :
+    All (fun x => x !== 0) (map compute_public_key sks).
+  Proof.
+    induction sks as [|sk sks IH]; cbn; auto.
+  Qed.
+  Hint Resolve compute_public_keys_units : core.
+
+  Lemma reconstructed_key_unit pks i :
+    All (fun a => a !== 0) pks ->
+    reconstructed_key pks i !== 0.
+  Proof.
+    intros all.
+    unfold reconstructed_key.
+    apply int_domain.
+    - apply prod_units.
+      apply (all_incl (firstn i pks) pks); auto.
+      apply firstn_incl.
+    - apply inv_nonzero.
+      apply prod_units.
+      apply (all_incl (skipn (S i) pks) pks); auto.
+      apply skipn_incl.
+  Qed.
+
+  Lemma compute_public_vote_unit rk sk sv :
+    rk !== 0 ->
+    compute_public_vote rk sk sv !== 0.
+  Proof.
+    intros rk_unit.
+    unfold compute_public_vote.
+    destruct sv; auto.
+  Qed.
+
+  Hint Resolve
+       compute_public_key_unit compute_public_keys_units
+       reconstructed_key_unit compute_public_vote_unit : core.
+
+  Lemma log_prod (l : list A) :
+    All (fun a => a !== 0) l ->
+    log (prod l) exp= sumZ log l.
+  Proof.
+    intros all.
+    induction l as [|x xs IH]; cbn in *.
+    - now rewrite log_1_l.
+    - specialize (IH (proj2 all)).
+      destruct all.
+      rewrite log_mul by auto.
+      now rewrite IH.
+  Qed.
+
+  Lemma prod_firstn_units n l :
+    prod l !== 0 ->
+    prod (firstn n l) !== 0.
+  Proof.
+    intros prodl.
+    apply prod_units.
+    pose proof (firstn_incl n l).
+    apply all_incl with l; auto.
+  Qed.
+
+  Hint Resolve prod_firstn_units : core.
+
+  Lemma prod_skipn_units n l :
+    prod l !== 0 ->
+    prod (skipn n l) !== 0.
+  Proof.
+    intros prodl.
+    apply prod_units.
+    pose proof (skipn_incl n l).
+    apply all_incl with l; auto.
+  Qed.
+
+  Hint Resolve prod_skipn_units : core.
+
+  Local Open Scope Z.
+  Lemma sum_lemma l :
+    sumZ (fun i => nth i l 0 *
+                   (sumZ id (firstn i l) -
+                    sumZ id (skipn (S i) l)))
+         (seq 0 (length l)) = 0.
+  Proof.
+    rewrite (sumZ_seq_feq
+               (fun i => sumZ (fun j => if Nat.ltb j i then nth i l 0 * nth j l 0 else 0)
+                              (seq 0 (length l)) -
+                         sumZ (fun j => if Nat.ltb i j then nth i l 0 * nth j l 0 else 0)
+                              (seq 0 (length l))));
+      cycle 1.
+    {
+
+      intros i ?.
+      rewrite Z.mul_sub_distr_l.
+      rewrite 2!sumZ_mul.
+      unfold id.
+      rewrite (sumZ_firstn 0) by (right; lia).
+      rewrite (sumZ_skipn 0).
+      apply f_equal2.
+      - rewrite (sumZ_seq_split i) by lia.
+        rewrite Z.add_comm.
+        cbn -[Nat.ltb].
+        rewrite sumZ_seq_n.
+        rewrite (sumZ_seq_feq (fun _ => 0)); cycle 1.
+        { intros j jlt. destruct (Nat.ltb_spec (j + i) i); auto; lia. }
+        rewrite sumZ_zero.
+        cbn -[Nat.ltb].
+        apply sumZ_seq_feq.
+        intros j jlt.
+        destruct (Nat.ltb_spec j i); lia.
+      - rewrite (sumZ_seq_split (S i)) by lia.
+        rewrite (sumZ_seq_feq (fun _ => 0)); cycle 1.
+        { intros j jlt. destruct (Nat.ltb_spec i j); auto; lia. }
+        rewrite sumZ_zero.
+        cbn.
+        rewrite sumZ_seq_n.
+        replace (length l - S i)%nat with (length l - i - 1)%nat by lia.
+        apply sumZ_seq_feq.
+        intros j jlt.
+        replace (j + S i)%nat with (S (i + j))%nat by lia.
+        destruct (Nat.leb_spec i (i + j)); lia.
+    }
+
+    rewrite sumZ_sub.
+    rewrite sumZ_sumZ_swap.
+    match goal with
+    | [|- ?a - ?b = 0] => enough (a = b) by lia
+    end.
+    apply sumZ_seq_feq.
+    intros i ilt.
+    apply sumZ_seq_feq.
+    intros j jlt.
+    destruct (i <? j)%nat; lia.
+  Qed.
+
+  Local Open Scope ffield.
+  Lemma mul_public_votes
+        (sks : list Z)
+        (votes : nat -> bool) :
+    prod (map (fun (i : nat) =>
+                 compute_public_vote
+                   (reconstructed_key (map compute_public_key sks) i)
+                   (nth i sks 0%Z)
+                   (votes i))
+                 (seq 0 (length sks)))
+    == generator ^ sumZ (fun i => if votes i then 1 else 0)%Z (seq 0 (length sks)).
+  Proof.
+    apply log_both; auto.
+    - induction (seq 0 (length sks)); cbn; auto.
+    - rewrite log_pow_generator, log_prod; cycle 1.
+      {
+        induction (seq 0 (length sks)); cbn; auto.
+      }
+
+      rewrite sumZ_map.
+      unfold compute_public_vote.
+      etransitivity.
+      {
+        apply sumZ_seq_feq_rel; try typeclasses eauto.
+        intros i ilt.
+        rewrite log_mul at 1 by (destruct (votes i); auto).
+        setoid_replace (log (if votes i then generator else 1))
+          with (if votes i then 1%Z else 0%Z) at 1;
+          cycle 1.
+        - destruct (votes i).
+          + rewrite <- (pow_1_r generator).
+            apply log_pow_generator.
+          + apply log_1_l.
+        - rewrite log_pow at 1 by auto.
+          unfold reconstructed_key.
+          rewrite log_mul at 1 by auto.
+          rewrite log_prod at 1 by auto.
+          rewrite log_inv at 1.
+          rewrite log_prod at 1 by auto.
+          rewrite 2!(sumZ_map_id log) at 1.
+          rewrite firstn_map, skipn_map, !map_map.
+          unfold compute_public_key.
+          assert (forall l, sumZ id (map (fun x => log (generator ^ x)) l) exp= sumZ id l).
+          { clear.
+            intros l.
+            induction l; cbn; auto.
+            - reflexivity.
+            - unfold id at 1 3.
+              rewrite log_pow_generator.
+              now rewrite IHl.
+          }
+          rewrite 2!H at 1.
+          rewrite Z.add_opp_r.
+          reflexivity.
+      }
+
+      rewrite sumZ_add.
+      rewrite sum_lemma.
+      reflexivity.
+  Qed.
+
+  Global Instance prod_perm_proper :
+    Proper (@Permutation A ==> elmeq) prod.
+  Proof.
+    intros l l' permeq.
+    induction permeq.
+    - reflexivity.
+    - cbn.
+      now rewrite IHpermeq.
+    - cbn.
+      rewrite !mul_assoc.
+      now rewrite (mul_comm y).
+    - now rewrite IHpermeq1, IHpermeq2.
+  Qed.
+
+  Global Instance bruteforce_tally_aux_proper :
+    Proper (eq ==> elmeq ==> eq) bruteforce_tally_aux.
+  Proof.
+    intros n ? <- p p' prodeq.
+    induction n as [|n IH].
+    - cbn.
+      destruct (elmeqb_spec (generator^0) p),
+               (elmeqb_spec (generator^0) p'); auto.
+      + rewrite prodeq in e; contradiction.
+      + rewrite <- prodeq in e; contradiction.
+    - cbn.
+      destruct (elmeqb_spec (generator^Z.pos (Pos.of_succ_nat n)) p),
+               (elmeqb_spec (generator^Z.pos (Pos.of_succ_nat n)) p'); auto.
+      + rewrite prodeq in e; contradiction.
+      + rewrite <- prodeq in e; contradiction.
+  Qed.
+
+  Global Instance bruteforce_tally_proper :
+    Proper (@Permutation A ==> eq) bruteforce_tally.
+  Proof.
+    unfold bruteforce_tally.
+    now intros ? ? <-.
+  Qed.
+
+  Lemma bruteforce_tally_aux_correct result max :
+    Z.of_nat max < order - 1 ->
+    (result <= max)%nat ->
+    bruteforce_tally_aux max (generator ^ Z.of_nat result) = Some result.
+  Proof.
+    intros max_lt result_le.
+    induction max as [|max IH].
+    - replace result with 0%nat by lia.
+      cbn.
+      destruct (elmeqb_spec (generator^0) (generator^0)); auto.
+      contradiction n; reflexivity.
+    - destruct (Nat.eq_dec result (S max)) as [->|?].
+      + cbn.
+        destruct (elmeqb_spec (generator ^ Z.pos (Pos.of_succ_nat max))
+                              (generator ^ Z.pos (Pos.of_succ_nat max))); auto.
+        contradiction n; reflexivity.
+      + cbn -[Z.of_nat].
+        destruct (elmeqb_spec (generator ^ Z.of_nat (S max))
+                              (generator ^ Z.of_nat result)) as [eq|?]; auto.
+        * pose proof (generator_generates (generator ^ Z.of_nat result) ltac:(auto)).
+          destruct H as [e [sat unique]].
+          unshelve epose proof (unique (Z.of_nat (S max)) _) as smax.
+          { split; auto; lia. }
+          unshelve epose proof (unique (Z.of_nat result) _) as res.
+          { split; [lia|reflexivity]. }
+          rewrite <- (Z2Nat.id e) in smax, res by lia.
+          apply Nat2Z.inj in smax.
+          apply Nat2Z.inj in res.
+          congruence.
+        * apply IH; lia.
+  Qed.
+
+  Lemma sumZ_sumnat_votes (svs : nat -> bool) l :
+    sumZ (fun i => if svs i then 1%Z else 0%Z) l =
+    Z.of_nat (sumnat (fun i => if svs i then 1%nat else 0%nat) l).
+  Proof.
+    induction l as [|x xs IH]; auto.
+    cbn.
+    rewrite IH, Nat2Z.inj_add.
+    destruct (svs x); lia.
+  Qed.
+
+  Lemma bruteforce_tally_correct
+        {B}
+        (bs : list B)
+        (index : B -> nat)
+        (sks : B -> Z)
+        (pks : list A)
+        (svs : B -> bool)
+        (pvs : B -> A) :
+    Z.of_nat (length bs) < order - 1 ->
+    Permutation (map index bs) (seq 0 (length bs)) ->
+    length pks = length bs ->
+    (forall b, In b bs -> nth_error pks (index b) = Some (compute_public_key (sks b))) ->
+    (forall b, In b bs -> pvs b = compute_public_vote
+                                    (reconstructed_key pks (index b))
+                                    (sks b)
+                                    (svs b)) ->
+    bruteforce_tally (map pvs bs) =
+    Some (sumnat (fun b => if svs b then 1 else 0)%nat bs).
+  Proof.
+    intros countlt perm len_pks pks_sks pvs_svs.
+    set (geti i := find (fun b => index b =? i)%nat bs).
+    set (sks_list := map (fun i => match geti i with
+                                   | Some x => sks x
+                                   | None => 0%Z
+                                   end)
+                         (seq 0 (length bs))).
+    set (svsi i := match geti i with
+                   | Some x => svs x
+                   | None => false
+                   end).
+    pose proof (mul_public_votes sks_list svsi).
+    assert (geti_i: forall b i,
+               In b bs ->
+               index b = i ->
+               geti i = Some b).
+    {
+      clear -perm.
+      intros b i isin index_eq.
+      pose proof (seq_NoDup (length bs) 0).
+      rewrite <- perm in H.
+      clear perm.
+      subst geti.
+      cbn.
+      induction bs as [|b' bs IH]; cbn in *; try easy.
+      destruct isin as [<-|?].
+      - now rewrite index_eq, Nat.eqb_refl.
+      - inversion H; subst.
+        destruct (Nat.eqb_spec (index b') (index b)).
+        + rewrite e in H.
+          apply (in_map index) in H0.
+          rewrite <- e in H0.
+          contradiction.
+        + inversion H; apply IH; auto.
+    }
+
+    assert (map_on_bs:
+              forall {C} (f : B -> C) (def : C),
+                Permutation (map f bs)
+                            (map (fun i => match geti i with
+                                           | Some b => f b
+                                           | None => def
+                                           end) (seq 0 (length bs)))).
+    {
+      intros C f def.
+      rewrite <- perm.
+      rewrite map_map.
+      match goal with
+      | [|- Permutation ?l ?l'] => enough (l = l') as eq by (now rewrite eq)
+      end.
+      apply map_ext_in.
+      intros b inbbs.
+      now rewrite geti_i with (b := b) by auto.
+    }
+
+    assert (Permutation
+              (map (fun i : nat =>
+                      compute_public_vote
+                        (reconstructed_key
+                           (map compute_public_key sks_list) i)
+                        (nth i sks_list 0%Z) (svsi i))
+                   (seq 0 (length sks_list)))
+              (map pvs bs))%nat.
+    {
+      rewrite (map_on_bs _ pvs 0).
+      unfold sks_list.
+      rewrite map_length, seq_length.
+      match goal with
+      | [|- Permutation ?l ?l'] => enough (l = l') as eq by (now rewrite eq)
+      end.
+      apply map_ext_in.
+      intros i iin.
+      assert (i < length bs)%nat by (apply in_seq in iin; lia).
+      rewrite map_nth_alt with (d2 := 0%nat) by (now rewrite seq_length).
+      rewrite seq_nth.
+      cbn.
+      rewrite <- perm in iin.
+      apply in_map_iff in iin.
+      destruct iin as [b [indexb inbbs]].
+      unfold svsi.
+      rewrite geti_i with (b := b) by auto.
+      rewrite pvs_svs by auto.
+      subst i.
+      rewrite map_map.
+      f_equal.
+      - f_equal.
+        clear -perm len_pks pks_sks geti_i.
+        apply list_eq_nth.
+        { now rewrite map_length, seq_length. }
+        intros i a a' ntha ntha'.
+        assert (isin: In i (seq 0 (length bs))).
+        {
+          apply in_seq.
+          split; try lia.
+          rewrite <- len_pks.
+          cbn; apply nth_error_Some.
+          congruence.
+        }
+        assert (i < length bs)%nat by (apply in_seq in isin; lia).
+        rewrite <- perm in isin.
+        apply in_map_iff in isin.
+        destruct isin as [b [indexb inbbs]].
+        subst i.
+        rewrite pks_sks in ntha' by auto.
+        rewrite map_nth_error with (d := index b) in ntha by (now rewrite nth_error_seq_in).
+        rewrite geti_i with (b := b) in ntha by auto.
+        congruence.
+      - auto.
+    }
+
+    rewrite <- H0.
+    unfold bruteforce_tally.
+    rewrite map_length, seq_length.
+    rewrite mul_public_votes.
+    rewrite <- (sumnat_map svs (fun sv => if sv then 1%nat else 0%nat)).
+    enough (Permutation (map svs bs) (map svsi (seq 0 (length sks_list)))).
+    {
+      rewrite H1.
+      rewrite sumnat_map.
+      rewrite sumZ_sumnat_votes.
+      unfold sks_list.
+      rewrite map_length, seq_length.
+      rewrite bruteforce_tally_aux_correct; auto.
+      rewrite <- Nat.mul_1_l.
+      rewrite <- (seq_length (length bs) 0) at 2.
+      apply sumnat_max.
+      intros i iin.
+      destruct (svsi i); lia.
+    }
+    unfold sks_list.
+    rewrite map_length, !seq_length.
+    rewrite <- perm.
+    pose proof (seq_NoDup (length bs) 0).
+    rewrite <- perm in H1.
+    clear -H1.
+    induction bs as [|b bs IH]; auto.
+    subst geti svsi; cbn in *.
+    rewrite Nat.eqb_refl.
+    inversion H1; subst.
+    rewrite (map_ext_in _ (fun i => match find (fun b => (index b =? i)%nat) bs with
+                                    | Some x => svs x
+                                    | None => false
+                                    end)); cycle 1.
+    {
+      intros a ain.
+      destruct (Nat.eqb_spec (index b) a); auto.
+      subst a; contradiction.
+    }
+    apply Permutation_cons; auto.
+  Qed.
+
+End WithBoardroomAxioms.
+
+Module Zp.
+  Local Open Scope Z.
+
+  Fixpoint mod_pow_pos_aux (a : Z) (x : positive) (m : Z) (r : Z) : Z :=
+    match x with
+    | x~0%positive => mod_pow_pos_aux (a * a mod m) x m r
+    | x~1%positive => mod_pow_pos_aux (a * a mod m) x m (r * a mod m)
+    | _ => r * a mod m
+    end.
+
+  Definition mod_pow_pos (a : Z) (x : positive) (m : Z) : Z :=
+    mod_pow_pos_aux a x m 1.
+
+  Definition mod_inv (a : Z) (p : Z) : Z :=
+    fst (egcd a p) mod p.
+
+  Definition mod_pow (a x p : Z) : Z :=
+    match x with
+    | Z0 => a ^ 0 mod p
+    | Zpos x => mod_pow_pos a x p
+    | Zneg x => mod_inv (mod_pow_pos a x p) p
+    end.
+
+  Lemma Z_pow_pos_mod_idemp a x m :
+    Z.pow_pos (a mod m) x mod m = Z.pow_pos a x mod m.
+  Proof.
+    destruct (m =? 0) eqn:mzero.
+    {
+      apply Z.eqb_eq in mzero.
+      rewrite mzero.
+      now rewrite 2!Zmod_0_r.
+    }
+
+    apply Z.eqb_neq in mzero.
+
+    unfold Z.pow_pos.
+    assert (H: forall start l x, Pos.iter (Z.mul l) start x = start * Pos.iter (Z.mul l) 1 x).
+    {
+      clear.
+      intros start l x.
+      revert start.
+      induction x; intros start.
+      - cbn.
+        rewrite 2!IHx.
+        rewrite (IHx (Pos.iter (Z.mul l) 1 x)).
+        lia.
+      - cbn.
+        rewrite 2!IHx.
+        rewrite (IHx (Pos.iter (Z.mul l) 1 x)).
+        lia.
+      - cbn.
+        lia.
+    }
+
+    induction x.
+    - cbn.
+      rewrite (H _ (a mod m)).
+      rewrite (H _ a).
+      rewrite Z.mul_assoc.
+      assert (H2: forall a b c,
+                 ((a mod m) * b * c) mod m = ((a mod m) * (b mod m) * (c mod m)) mod m).
+      {
+        clear.
+        intros.
+        rewrite <- Z.mul_assoc.
+        rewrite Zmult_mod_idemp_l.
+
+        rewrite <- Z.mul_assoc.
+        rewrite Zmult_mod_idemp_l.
+
+        rewrite 2!Z.mul_assoc.
+        rewrite (Z.mul_comm _ (c mod m)).
+        rewrite Zmult_mod_idemp_l.
+        rewrite Z.mul_assoc.
+        rewrite (Z.mul_comm _ (b mod m)).
+        rewrite Zmult_mod_idemp_l.
+        replace (b * (c * a)) with (a * b * c) by lia; auto.
+      }
+
+      rewrite H2.
+      rewrite IHx.
+      rewrite <- H2.
+
+      rewrite <- Z.mul_assoc.
+      now rewrite Zmult_mod_idemp_l.
+    - cbn.
+      rewrite H.
+      rewrite Z.mul_mod by auto.
+      rewrite IHx.
+      rewrite <- Z.mul_mod by auto.
+      now rewrite <- H.
+    - cbn.
+      rewrite 2!Z.mul_1_r.
+      now apply Z.mod_mod.
+  Qed.
+
+  Lemma mod_pow_pos_aux_0_r a x r :
+    mod_pow_pos_aux a x 0 r = 0.
+  Proof.
+    revert a r.
+    induction x; intros a r; cbn.
+    + now (repeat rewrite ?IHx, ?Zmod_0_r).
+    + now (repeat rewrite ?IHx, ?Zmod_0_r).
+    + now rewrite !Zmod_0_r.
+  Qed.
+  Lemma mod_pow_pos_0_r a x :
+    mod_pow_pos a x 0 = 0.
+  Proof. apply mod_pow_pos_aux_0_r. Qed.
+  Lemma mod_pow_0_r a x :
+    mod_pow a x 0 = 0.
+  Proof.
+    destruct x; auto; cbn.
+    - apply mod_pow_pos_0_r.
+    - now rewrite mod_pow_pos_0_r.
+  Qed.
+
+  Lemma mod_pow_pos_aux_spec a x p r :
+    mod_pow_pos_aux a x p r = r * Z.pow_pos a x mod p.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|nonzero].
+    - now rewrite mod_pow_pos_aux_0_r, Zmod_0_r.
+    - revert a r.
+      induction x; intros a r.
+      + cbn -[Z.pow_pos].
+        specialize (IHx ((a * a) mod p) ((r * a) mod p)).
+        rewrite IHx.
+        rewrite <- Z.mul_mod_idemp_r by auto.
+        rewrite Z_pow_pos_mod_idemp.
+        rewrite <- Z.mul_mod by auto.
+        replace (x~1)%positive with (x*2+1)%positive by lia.
+        rewrite Zpower_pos_is_exp.
+        cbn.
+        rewrite 2!Z.pow_pos_fold.
+        rewrite Z.pow_mul_l.
+        rewrite <- Z.pow_add_r by (auto with zarith).
+        rewrite Zred_factor1.
+        f_equal.
+        lia.
+      + cbn -[Z.pow_pos].
+        rewrite IHx.
+        rewrite <- Zmult_mod_idemp_r.
+        rewrite Z_pow_pos_mod_idemp.
+        rewrite Zmult_mod_idemp_r.
+        replace (x~0)%positive with (x*2)%positive by lia.
+        rewrite 2!Z.pow_pos_fold.
+        rewrite Z.pow_mul_l.
+        rewrite <- Z.pow_add_r by (auto with zarith).
+        now rewrite Zred_factor1.
+      + cbn.
+        f_equal; lia.
+  Qed.
+
+  Lemma mod_pow_pos_spec a x p :
+    mod_pow_pos a x p = Z.pow_pos a x mod p.
+  Proof.
+    pose proof (mod_pow_pos_aux_spec a x p 1).
+    now rewrite Z.mul_1_l in H.
+  Qed.
+
+  Lemma Z_pow_mod_idemp a x p :
+    (a mod p)^x mod p = a^x mod p.
+  Proof.
+    destruct x; auto.
+    cbn.
+    apply Z_pow_pos_mod_idemp.
+  Qed.
+
+  Lemma mod_pow_pos_aux_mod_idemp a x p r :
+    mod_pow_pos_aux (a mod p) x p r = mod_pow_pos_aux a x p r.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - now rewrite !mod_pow_pos_aux_0_r.
+    - revert a r.
+      induction x; intros a r; cbn in *.
+      + rewrite <- Z.mul_mod by auto.
+        now rewrite Z.mul_mod_idemp_r by auto.
+      + now rewrite <- Z.mul_mod by auto.
+      + now rewrite Z.mul_mod_idemp_r by auto.
+  Qed.
+
+  Lemma mod_pow_pos_mod_idemp a x p :
+    mod_pow_pos (a mod p) x p = mod_pow_pos a x p.
+  Proof. apply mod_pow_pos_aux_mod_idemp. Qed.
+
+  Lemma mod_pow_pos_aux_mod a x p r :
+    mod_pow_pos_aux a x p r mod p = mod_pow_pos_aux a x p r.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - now rewrite mod_pow_pos_aux_0_r.
+    - rewrite mod_pow_pos_aux_spec.
+      now rewrite Z.mod_mod by auto.
+  Qed.
+  Lemma mod_pow_pos_mod a x p :
+    mod_pow_pos a x p mod p = mod_pow_pos a x p.
+  Proof. apply mod_pow_pos_aux_mod. Qed.
+  Lemma mod_inv_mod a p :
+    mod_inv a p mod p = mod_inv a p.
+  Proof.
+    unfold mod_inv.
+    now rewrite Zmod_mod.
+  Qed.
+
+  Lemma mod_pow_mod a x p :
+    mod_pow a x p mod p = mod_pow a x p.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - now rewrite mod_pow_0_r.
+    - destruct x; cbn.
+      + now rewrite Z.mod_mod by auto.
+      + now rewrite mod_pow_pos_mod.
+      + now rewrite mod_inv_mod.
+  Qed.
+
+
+  Lemma mul_mod_inv a p :
+    prime p ->
+    a mod p <> 0 ->
+    a * mod_inv a p mod p = 1.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    unfold mod_inv.
+    rewrite Z.mul_mod_idemp_r by lia.
+    rewrite <- (Z.mod_1_l p) by lia.
+    apply mul_fst_egcd.
+    apply rel_prime_sym, prime_rel_prime; [easy|].
+    intros eq; contradiction ap0.
+    apply Z.mod_divide; [lia|easy].
+  Qed.
+
+  Lemma mod_mul_both_l a b c p :
+    prime p ->
+    c mod p <> 0 ->
+    (c * a mod p = c * b mod p <-> a mod p = b mod p).
+  Proof.
+    intros isprime cp0.
+    pose proof (prime_ge_2 _ isprime).
+    split.
+    - intros eq.
+      rewrite <- (Z.mul_1_l a).
+      rewrite <- (Z.mul_1_l b).
+      rewrite <- (mul_mod_inv c _ isprime cp0).
+      rewrite !Z.mul_mod_idemp_l by lia.
+      rewrite (Z.mul_comm c).
+      rewrite <- 2!Z.mul_assoc.
+      rewrite <- (Z.mul_mod_idemp_r _ (c * a)) by lia.
+      rewrite <- (Z.mul_mod_idemp_r _ (c * b)) by lia.
+      now rewrite eq.
+    - intros eq.
+      now rewrite <- Z.mul_mod_idemp_r, eq, Z.mul_mod_idemp_r by lia.
+  Qed.
+
+  Lemma mul_mod_nonzero a b p :
+    prime p ->
+    a mod p <> 0 ->
+    b mod p <> 0 ->
+    a * b mod p <> 0.
+  Proof.
+    intros isprime ap0 bp0.
+    intros abp0.
+    pose proof (prime_ge_2 _ isprime).
+    pose proof (proj1 (Z.mod_divide _ p ltac:(lia)) abp0) as pdiv.
+    pose proof (prime_mult _ isprime _ _ pdiv) as onediv.
+    destruct onediv as [div|div]; apply Z.mod_divide in div; lia.
+  Qed.
+  Hint Resolve mul_mod_nonzero : core.
+
+  Lemma mod_mod_nonzero a p :
+    a mod p <> 0 ->
+    (a mod p) mod p <> 0.
+  Proof.
+    intros ap0.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - cbn in ap0.
+      rewrite Zmod_0_r in ap0.
+      congruence.
+    - rewrite Z.mod_mod by auto.
+      auto.
+  Qed.
+  Hint Resolve mod_mod_nonzero : core.
+
+  Lemma mod_pow_pos_aux_nonzero a x p r :
+    prime p ->
+    a mod p <> 0 ->
+    r mod p <> 0 ->
+    mod_pow_pos_aux a x p r <> 0.
+  Proof.
+    intros prime.
+    pose proof (prime_ge_2 _ prime).
+    revert a r.
+    induction x; intros a r ap0 rp0; cbn; auto.
+  Qed.
+  Hint Resolve mod_pow_pos_aux_nonzero : core.
+
+  Lemma mod_pow_pos_nonzero a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow_pos a x p <> 0.
+  Proof.
+    intros isprime ap0.
+    apply mod_pow_pos_aux_nonzero; auto.
+    pose proof (prime_ge_2 _ isprime).
+    now rewrite Z.mod_1_l by lia.
+  Qed.
+  Hint Resolve mod_pow_pos_nonzero : core.
+  Lemma mod_inv_nonzero a p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_inv a p <> 0.
+  Proof.
+    intros isprime ap0 iszero.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite <- (Z.mod_0_l p) in iszero by lia.
+    rewrite <- mod_inv_mod in iszero.
+    apply (mod_mul_both_l _ _ a p isprime ap0) in iszero.
+    rewrite mul_mod_inv in iszero by auto.
+    rewrite Z.mul_0_r, Z.mod_0_l in iszero; easy.
+  Qed.
+  Hint Resolve mod_inv_nonzero : core.
+  Lemma mod_pow_nonzero a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a x p <> 0.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    destruct x; cbn; auto.
+    - rewrite Z.mod_1_l by lia; discriminate.
+    - apply mod_inv_nonzero; auto.
+      rewrite mod_pow_pos_mod; auto.
+  Qed.
+  Hint Resolve mod_pow_nonzero : core.
+  Lemma mod_pow_pos_mod_nonzero a x p :
+    mod_pow_pos a x p <> 0 ->
+    mod_pow_pos a x p mod p <> 0.
+  Proof. rewrite mod_pow_pos_mod; auto. Qed.
+  Lemma mod_inv_mod_nonzero a p :
+    mod_inv a p <> 0 ->
+    mod_inv a p mod p <> 0.
+  Proof. rewrite mod_inv_mod; auto. Qed.
+  Lemma mod_pow_mod_nonzero a x p :
+    mod_pow a x p <> 0 ->
+    mod_pow a x p mod p <> 0.
+  Proof. rewrite mod_pow_mod; auto. Qed.
+  Lemma one_nonzero p :
+    prime p ->
+    1 mod p <> 0.
+  Proof.
+    intros isprime.
+    pose proof (prime_ge_2 _ isprime).
+    now rewrite Z.mod_1_l by lia.
+  Qed.
+  Hint Resolve mod_pow_pos_mod_nonzero mod_inv_mod_nonzero mod_pow_mod_nonzero one_nonzero : core.
+
+  Lemma mod_inv_mod_idemp a p :
+    prime p ->
+    mod_inv (a mod p) p = mod_inv a p.
+  Proof.
+    intros isprime.
+    pose proof (prime_ge_2 _ isprime).
+    destruct (Z.eqb_spec (a mod p) 0) as [ap0|ap0].
+    {
+      rewrite ap0.
+      apply Zmod_divide in ap0; [|lia].
+      unfold mod_inv.
+      now rewrite (egcd_divides a p) by (auto; lia).
+    }
+    rewrite <- mod_inv_mod, <- (mod_inv_mod a).
+    apply mod_mul_both_l with a; auto.
+    rewrite <- Z.mul_mod_idemp_l by lia.
+    now rewrite !mul_mod_inv by auto.
+  Qed.
+
+  Lemma mod_pow_pos_fermat a p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow_pos a (Z.to_pos (p - 1)) p = 1.
+  Proof.
+    intros isprime ap.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite mod_pow_pos_spec.
+    rewrite Z.pow_pos_fold.
+    rewrite Z2Pos.id by lia.
+    now apply fermat.
+  Qed.
+
+  Lemma mod_pow_fermat a p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (p - 1) p = 1.
+  Proof.
+    intros isprime ap.
+    pose proof (prime_ge_2 _ isprime).
+    pose proof (mod_pow_pos_fermat _ _ isprime ap).
+    destruct p; try lia.
+    destruct (Z.pos p - 1) eqn:?; try lia.
+    assumption.
+  Qed.
+
+  Lemma mod_pow_pos_exp_mul a x x' p :
+    mod_pow_pos a (x * x') p = mod_pow_pos (mod_pow_pos a x p) x' p.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - now rewrite !mod_pow_pos_0_r.
+    - rewrite !mod_pow_pos_spec by auto.
+      rewrite !Z.pow_pos_fold.
+      rewrite Pos2Z.inj_mul.
+      rewrite Z_pow_mod_idemp.
+      now rewrite <- Z.pow_mul_r by lia.
+  Qed.
+
+  Lemma mod_pow_pos_aux_1_l x p r :
+    mod_pow_pos_aux 1 x p r = r mod p.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - now rewrite mod_pow_pos_aux_0_r, Zmod_0_r.
+    - revert r.
+      induction x; intros r; cbn.
+      + rewrite mod_pow_pos_aux_mod_idemp.
+        rewrite Z.mul_1_r.
+        rewrite IHx.
+        apply Z.mod_mod; auto.
+      + rewrite mod_pow_pos_aux_mod_idemp.
+        apply IHx.
+      + now rewrite Z.mul_1_r.
+  Qed.
+  Lemma mod_pow_pos_1_l x p :
+    mod_pow_pos 1 x p = 1 mod p.
+  Proof. apply mod_pow_pos_aux_1_l. Qed.
+  Lemma mod_inv_1_l p :
+    prime p ->
+    mod_inv 1 p = 1 mod p.
+  Proof.
+    intros isprime.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite <- mod_inv_mod.
+    apply mod_mul_both_l with 1; auto.
+    rewrite mul_mod_inv by auto.
+    cbn.
+    now rewrite Z.mod_1_l by lia.
+  Qed.
+  Lemma mod_pow_1_l x p :
+    prime p ->
+    mod_pow 1 x p = 1 mod p.
+  Proof.
+    intros isprime.
+    destruct x; auto; cbn.
+    - apply mod_pow_pos_1_l.
+    - rewrite mod_pow_pos_1_l, mod_inv_mod_idemp by auto.
+      now apply mod_inv_1_l.
+  Qed.
+
+  Lemma mod_pow_1_r a p :
+    mod_pow a 1 p = a mod p.
+  Proof.
+    cbn -[Z.mul].
+    now rewrite Z.mul_1_l.
+  Qed.
+
+  Lemma mod_inv_mul a b p :
+    prime p ->
+    a mod p <> 0 ->
+    b mod p <> 0 ->
+    mod_inv (a * b) p = mod_inv b p * mod_inv a p mod p.
+  Proof.
+    intros isprime ap0 bp0.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite <- mod_inv_mod.
+    apply mod_mul_both_l with (a * b); auto.
+    rewrite mul_mod_inv by auto.
+    rewrite <- Z.mul_assoc, (Z.mul_assoc b).
+    rewrite <- Z.mul_mod_idemp_r by lia.
+    rewrite <- (Z.mul_mod_idemp_l (b * _)) by lia.
+    rewrite Z.mul_mod_idemp_r by lia.
+    rewrite mul_mod_inv by auto.
+    rewrite Z.mul_1_l.
+    now rewrite mul_mod_inv by auto.
+  Qed.
+
+  Lemma mod_pow_pos_succ_r a x p :
+    a * mod_pow_pos a x p mod p = mod_pow_pos a (Pos.succ x) p.
+  Proof.
+    destruct (Z.eq_dec p 0) as [->|?].
+    - rewrite !mod_pow_pos_0_r.
+      now rewrite Zmod_0_r.
+    - rewrite !mod_pow_pos_spec, !Z.pow_pos_fold.
+      cbn.
+      rewrite Z.mul_mod_idemp_r by lia.
+      rewrite Z.pow_pos_fold.
+      rewrite <- Z.pow_succ_r by lia.
+      cbn.
+      now rewrite <- Pos.add_1_r.
+  Qed.
+
+  Lemma mod_pow_succ a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (Z.succ x) p = a * mod_pow a x p mod p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    destruct x.
+    - cbn.
+      rewrite Z.mod_1_l by lia.
+      rewrite Z.mul_1_r.
+      destruct a; auto.
+    - cbn -[Pos.add].
+      rewrite mod_pow_pos_succ_r.
+      now replace (p0 + 1)%positive with (Pos.succ p0) by lia.
+    - cbn.
+      destruct (Pos.eq_dec p0 1) as [->|?].
+      + cbn -[Z.mul].
+        rewrite Z.mul_1_l.
+        rewrite mod_inv_mod_idemp by auto.
+        rewrite mul_mod_inv by auto.
+        now rewrite Z.mod_1_l by lia.
+      + rewrite Z.pos_sub_lt by lia.
+        cbn.
+        rewrite <- mod_inv_mod.
+        apply mod_mul_both_l with (mod_inv a p); auto.
+        rewrite Z.mul_assoc.
+        rewrite <- (Z.mul_mod_idemp_l (mod_inv a p * a)) by lia.
+        rewrite (Z.mul_comm _ a).
+        rewrite mul_mod_inv by auto.
+        rewrite <- mod_inv_mul by auto.
+        rewrite Z.mul_comm.
+        rewrite <- mod_inv_mod_idemp by auto.
+        rewrite mod_pow_pos_succ_r.
+        replace (Pos.succ (p0 - 1)) with p0 by lia.
+        now rewrite Z.mul_1_l, mod_inv_mod.
+  Qed.
+
+  Lemma mod_pow_pred a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (Z.pred x) p = mod_inv a p * mod_pow a x p mod p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite <- mod_pow_mod.
+    apply mod_mul_both_l with a; auto.
+    rewrite <- mod_pow_succ by auto.
+    replace (Z.succ (Z.pred x)) with x by lia.
+    rewrite Z.mul_assoc.
+    rewrite <- Z.mul_mod_idemp_l by lia.
+    rewrite mul_mod_inv by auto.
+    now rewrite Z.mul_1_l, mod_pow_mod.
+  Qed.
+
+  Lemma mod_pow_exp_plus a x x' p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (x + x') p = mod_pow a x p * mod_pow a x' p mod p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    revert x'.
+    induction x using Z.peano_ind; intros x'.
+    - cbn.
+      rewrite Z.mod_1_l by lia.
+      rewrite Z.mul_1_l.
+      now rewrite mod_pow_mod by lia.
+    - replace (Z.succ x + x') with (Z.succ (x + x')) by lia.
+      rewrite mod_pow_succ by auto.
+      rewrite IHx.
+      rewrite Z.mul_mod_idemp_r by lia.
+      rewrite Z.mul_assoc.
+      rewrite <- Z.mul_mod_idemp_l by lia.
+      now rewrite <- mod_pow_succ by auto.
+    - replace (Z.pred x + x') with (x + Z.pred x') by lia.
+      rewrite IHx.
+      rewrite !mod_pow_pred by auto.
+      rewrite Z.mul_mod_idemp_l, Z.mul_mod_idemp_r by lia.
+      apply f_equal2; lia.
+  Qed.
+
+  Lemma mod_inv_involutive a p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_inv (mod_inv a p) p = a mod p.
+  Proof.
+    intros isprime ap0.
+    rewrite <- mod_inv_mod.
+    apply mod_mul_both_l with (mod_inv a p); auto.
+    rewrite mul_mod_inv by auto.
+    now rewrite Z.mul_comm, mul_mod_inv by auto.
+  Qed.
+
+  Lemma mod_pow_pos_distr_exp a a' x p :
+    p <> 0 ->
+    mod_pow_pos (a * a') x p =
+    (mod_pow_pos a x p * mod_pow_pos a' x p) mod p.
+  Proof.
+    intros p0.
+    rewrite !mod_pow_pos_spec, !Z.pow_pos_fold.
+    rewrite Z.pow_mul_l.
+    now rewrite Z.mul_mod by auto.
+  Qed.
+
+  Lemma mod_inv_mod_pow_pos_comm a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_inv (mod_pow_pos a x p) p = mod_pow_pos (mod_inv a p) x p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    destruct (Z.eqb_spec p 2) as [->|?].
+    {
+      rewrite <- mod_pow_pos_mod_idemp, <- (mod_inv_mod_idemp a) by auto.
+      pose proof (Z.mod_pos_bound a 2 ltac:(lia)).
+      replace (a mod 2) with 1 by lia.
+      now rewrite !mod_pow_pos_1_l, mod_inv_1_l by auto.
+    }
+    rewrite <- mod_inv_mod, <- (mod_pow_pos_mod (mod_inv a p)).
+    apply mod_mul_both_l with (mod_pow_pos a x p); auto.
+    rewrite mul_mod_inv by auto.
+    rewrite <- mod_pow_pos_distr_exp by lia.
+    rewrite <- mod_pow_pos_mod_idemp.
+    rewrite mul_mod_inv by auto.
+    rewrite mod_pow_pos_1_l.
+    now rewrite Z.mod_1_l by lia.
+  Qed.
+
+  Lemma mod_pow_exp_mul a x x' p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (x * x') p = mod_pow (mod_pow a x p) x' p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    destruct x, x'; cbn;
+      repeat (
+          try rewrite Z.mod_1_l by lia;
+          try rewrite mod_pow_pos_1_l;
+          try rewrite mod_inv_1_l);
+      auto.
+    - apply mod_pow_pos_exp_mul.
+    - now rewrite mod_pow_pos_exp_mul.
+    - rewrite !mod_inv_mod_pow_pos_comm by auto.
+      now rewrite mod_pow_pos_exp_mul.
+    - rewrite mod_inv_mod_pow_pos_comm by auto.
+      rewrite mod_inv_involutive by auto.
+      rewrite mod_pow_pos_mod_idemp.
+      now rewrite <- mod_pow_pos_exp_mul.
+  Qed.
+
+  Lemma mod_pow_exp_opp a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (-x) p = mod_inv (mod_pow a x p) p.
+  Proof.
+    intros isprime ap0.
+    pose proof (prime_ge_2 _ isprime).
+    destruct x; auto.
+    - cbn.
+      rewrite mod_inv_mod_idemp by auto.
+      now rewrite mod_inv_1_l.
+    - cbn.
+      rewrite mod_inv_involutive by auto.
+      now rewrite mod_pow_pos_mod.
+  Qed.
+
+  Lemma mod_pow_exp_mod a x p :
+    prime p ->
+    a mod p <> 0 ->
+    mod_pow a (x mod (p - 1)) p = mod_pow a x p.
+  Proof.
+    intros isprime ap.
+    pose proof (prime_ge_2 _ isprime).
+    rewrite (Z.div_mod x (p - 1)) at 2 by lia.
+    rewrite mod_pow_exp_plus by auto.
+    rewrite mod_pow_exp_mul by auto.
+    rewrite mod_pow_fermat by auto.
+    rewrite mod_pow_1_l by auto.
+    rewrite !Z.mod_1_l by lia.
+    now rewrite Z.mul_1_l, mod_pow_mod.
+  Qed.
+
+  Definition boardroom_axioms (p : Z) :
+    prime p -> BoardroomAxioms Z.
+  Proof.
+    intros isprime.
+    pose proof (prime_ge_2 _ isprime).
+    refine
+      {|
+        elmeq a b := a mod p = b mod p;
+        elmeqb a b := a mod p =? b mod p;
+        zero := 0;
+        one := 1;
+        add a a' := (a + a') mod p;
+        mul a a' := (a * a') mod p;
+        opp a := p - a;
+        inv a := mod_inv a p;
+        pow a e := mod_pow a e p;
+        order := p;
+      |}.
+    - intros x y; apply Z.eqb_spec.
+    - lia.
+    - constructor; auto.
+      now intros a a' a'' -> ->.
+    - intros a a' aeq b b' beq.
+      now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
+    - intros a a' aeq b b' beq.
+      now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
+    - intros a a' aeq.
+      now rewrite Zminus_mod, aeq, <- Zminus_mod.
+    - intros a a' aeq.
+      cbn.
+      now rewrite <- mod_inv_mod_idemp, aeq, mod_inv_mod_idemp by auto.
+    - intros a anp e e' eeq.
+      rewrite <- (mod_pow_exp_mod _ e), <- (mod_pow_exp_mod _ e') by auto.
+      now rewrite eeq.
+    - now rewrite Z.mod_1_l, Z.mod_0_l by lia.
+    - intros a b.
+      now rewrite Z.add_comm.
+    - intros a b c.
+      rewrite !Z.mod_mod by lia.
+      rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
+      apply f_equal2; lia.
+    - intros a b.
+      now rewrite Z.mul_comm.
+    - intros a b c.
+      repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
+      now rewrite Z.mul_assoc.
+    - intros a.
+      now rewrite Z.mod_mod by lia.
+    - intros a.
+      now rewrite Z.mod_mod by lia.
+    - intros a.
+      rewrite Z.mod_mod by lia.
+      now rewrite Z.mul_1_l.
+    - intros a.
+      rewrite Z.mod_mod by lia.
+      replace (p - a + a) with p by lia.
+      rewrite Z.mod_same, Z.mod_0_l; lia.
+    - intros a anp.
+      now rewrite Z.mul_comm, mul_mod_inv by auto.
+    - intros a b c.
+      repeat (try rewrite Z.mul_mod_idemp_l;
+              try rewrite Z.mul_mod_idemp_r;
+              try rewrite Z.add_mod_idemp_l;
+              try rewrite Z.add_mod_idemp_r;
+              try rewrite Z.mod_mod); try lia.
+      apply f_equal2; lia.
+    - intros a anp.
+      cbn.
+      now rewrite Z.mod_1_l at 1 by lia.
+    - intros a.
+      now rewrite mod_pow_mod, mod_pow_1_r.
+    - intros a ap0.
+      rewrite (mod_pow_exp_opp _ 1) by auto.
+      rewrite mod_pow_1_r.
+      now rewrite mod_inv_mod_idemp.
+    - intros a e e' ap0.
+      now rewrite mod_pow_exp_plus by auto.
+    - auto.
+    - auto.
+  Defined.
+End Zp.
+
+Module BigZp.
+  Local Open Scope bigZ.
+  Fixpoint mod_pow_pos_aux (a : bigZ) (x : positive) (m : bigZ) (r : bigZ) : bigZ :=
+    match x with
+    | x~0%positive => mod_pow_pos_aux (BigZ.square a mod m) x m r
+    | x~1%positive => mod_pow_pos_aux (BigZ.square a mod m) x m (r * a mod m)
+    | _ => r * a mod m
+    end.
+
+  Definition mod_pow_pos (a : bigZ) (x : positive) (m : bigZ) : bigZ :=
+    mod_pow_pos_aux a x m 1.
+
+  Fixpoint egcd_aux
+           (n : nat)
+           (r0 a0 b0 r1 a1 b1 : bigZ) {struct n} : bigZ * bigZ :=
+    match n with
+    | 0%nat => (0, 0)
+    | S n => let (q, r) := BigZ.div_eucl r0 r1 in
+             if r =? 0 then
+               (a1, b1)
+             else
+               egcd_aux n r1 a1 b1 r (a0 - q*a1) (b0 - q*b1)
+    end.
+
+  Definition egcd (m n : bigZ) : bigZ * bigZ :=
+    if m =? 0 then
+      (0, BigZ.sgn n)
+    else
+      if n =? 0 then
+        (BigZ.sgn m, 0)
+      else
+        let num_steps :=
+            S (Z.to_nat (BigZ.to_Z (BigZ.log2 (BigZ.abs m) + BigZ.log2 (BigZ.abs n)))) in
+        if BigZ.abs m <? BigZ.abs n then
+          let (x, y) := egcd_aux num_steps (BigZ.abs n) 1 0 (BigZ.abs m) 0 1 in
+          (BigZ.sgn m * y, BigZ.sgn n * x)
+        else
+          let (x, y) := egcd_aux num_steps (BigZ.abs m) 1 0 (BigZ.abs n) 0 1 in
+          (BigZ.sgn m * x, BigZ.sgn n * y).
+
+  Definition mod_inv (a : bigZ) (p : bigZ) : bigZ :=
+    fst (egcd a p) mod p.
+
+  Definition mod_pow (a : bigZ) (x : Z) (p : bigZ) : bigZ :=
+    match x with
+    | Z0 => a ^ 0 mod p
+    | Zpos x => mod_pow_pos a x p
+    | Zneg x => mod_inv (mod_pow_pos a x p) p
+    end.
+
+  Hint Rewrite BigZ.square_spec BigZ.spec_pow_pos : zsimpl.
+  Hint Rewrite BigN.spec_of_pos : nsimpl.
+
+  Lemma spec_mod_pow_pos_aux a x p r :
+    [mod_pow_pos_aux a x p r] = Zp.mod_pow_pos_aux [a] x [p] [r].
+  Proof.
+    revert a p r.
+    induction x; intros a p r; cbn in *.
+    - rewrite IHx.
+      now autorewrite with zsimpl.
+    - rewrite IHx.
+      now autorewrite with zsimpl.
+    - now autorewrite with zsimpl.
+  Qed.
+  Hint Rewrite spec_mod_pow_pos_aux : zsimpl.
+
+  Lemma spec_mod_pow_pos a x p :
+    [mod_pow_pos a x p] = Zp.mod_pow_pos [a] x [p].
+  Proof. apply spec_mod_pow_pos_aux. Qed.
+  Hint Rewrite spec_mod_pow_pos : zsimpl.
+
+  Lemma spec_egcd_aux n r0 a0 b0 r1 a1 b1 :
+    let (x, y) := egcd_aux n r0 a0 b0 r1 a1 b1 in
+    ([x], [y]) = Egcd.egcd_aux n [r0] [a0] [b0] [r1] [a1] [b1].
+  Proof.
+    revert r0 a0 b0 r1 a1 b1.
+    induction n as [|n IH]; [easy|]; intros r0 a0 b0 r1 a1 b1.
+    cbn.
+    pose proof (BigZ.spec_div_eucl r0 r1) as H.
+    destruct (BigZ.div_eucl r0 r1) as [q r].
+    destruct (Z.div_eucl [r0] [r1]) as [q' r'].
+    inversion H; subst.
+    rewrite BigZ.spec_eqb.
+    cbn.
+    destruct ([r] =? 0)%Z; [easy|].
+    rewrite <- !BigZ.spec_mul, <- !BigZ.spec_sub.
+    apply IH.
+  Qed.
+
+  Hint Rewrite BigZ.spec_abs : zsimpl.
+  Lemma spec_egcd a b :
+    let (x, y) := egcd a b in
+    ([x], [y]) = Egcd.egcd [a] [b].
+  Proof.
+    unfold egcd, Egcd.egcd.
+    autorewrite with zsimpl.
+    change [0] with 0%Z.
+    destruct (_ =? _)%Z; [now autorewrite with zsimpl|].
+    destruct (_ =? _)%Z; [now autorewrite with zsimpl|].
+    destruct (_ <? _)%Z.
+    all: rewrite <- !BigZ.spec_abs.
+    all: change 1%Z with [1].
+    all: change 0%Z with [0].
+    all:
+      repeat
+        match goal with
+        | [|- context[egcd_aux ?n ?r0 ?a0 ?b0 ?r1 ?a1 ?b1]] =>
+          pose proof (spec_egcd_aux n r0 a0 b0 r1 a1 b1);
+            destruct (egcd_aux n r0 a0 b0 r1 a1 b1),
+                     (Egcd.egcd_aux n [r0] [a0] [b0] [r1] [a1] [b1])
+        end.
+    all: inversion H.
+    all: now autorewrite with zsimpl.
+  Qed.
+
+  Lemma spec_mod_inv a p :
+    [mod_inv a p] = Zp.mod_inv [a] [p].
+  Proof.
+    unfold mod_inv, Zp.mod_inv.
+    pose proof (spec_egcd a p).
+    destruct (egcd _ _), (Egcd.egcd _ _).
+    inversion H.
+    now autorewrite with zsimpl.
+  Qed.
+  Hint Rewrite spec_mod_inv : zsimpl.
+
+  Lemma spec_mod_pow a x p :
+    [mod_pow a x p] = Zp.mod_pow [a] x [p].
+  Proof.
+    unfold mod_pow, Zp.mod_pow.
+    now destruct x; autorewrite with zsimpl.
+  Qed.
+  Hint Rewrite spec_mod_pow : zsimpl.
+
+  Hint Rewrite BigZ.spec_modulo : zsimpl.
+
+  Definition boardroom_axioms (p : bigZ) :
+    prime [p] -> BoardroomAxioms bigZ.
+  Proof.
+    intros isprime.
+    pose proof (prime_ge_2 _ isprime).
+    refine
+      {| elmeq a b := a mod p == b mod p;
+         elmeqb a b := a mod p =? b mod p;
+         zero := 0;
+         one := 1;
+         add a a' := (a + a') mod p;
+         mul a a' := (a * a') mod p;
+         opp a := p - a;
+         inv a := mod_inv a p;
+         pow a e := mod_pow a e p;
+         order := BigZ.to_Z p;
+      |}; unfold "==".
+    - intros x y; apply BigZ.eqb_spec.
+    - lia.
+    - constructor; auto.
+      now intros a a' a'' -> ->.
+    - intros a a' aeq b b' beq.
+      autorewrite with zsimpl in *.
+      now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
+    - intros a a' aeq b b' beq.
+      autorewrite with zsimpl in *.
+      now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
+    - intros a a' aeq.
+      autorewrite with zsimpl in *.
+      now rewrite Zminus_mod, aeq, <- Zminus_mod.
+    - intros a a' aeq.
+      autorewrite with zsimpl in *.
+      now rewrite <- Zp.mod_inv_mod_idemp, aeq, Zp.mod_inv_mod_idemp.
+    - intros a anp e e' eeq.
+      autorewrite with zsimpl in *.
+      rewrite <- (Zp.mod_pow_exp_mod _ e), <- (Zp.mod_pow_exp_mod _ e') by auto.
+      now rewrite eeq.
+    - autorewrite with zsimpl in *.
+      now rewrite Z.mod_1_l, Z.mod_0_l by lia.
+    - intros a b.
+      autorewrite with zsimpl in *.
+      now rewrite Z.add_comm.
+    - intros a b c.
+      autorewrite with zsimpl in *.
+      rewrite !Z.mod_mod by lia.
+      rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
+      apply f_equal2; lia.
+    - intros a b.
+      autorewrite with zsimpl in *.
+      now rewrite Z.mul_comm.
+    - intros a b c.
+      autorewrite with zsimpl in *.
+      repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
+      now rewrite Z.mul_assoc.
+    - intros a.
+      autorewrite with zsimpl in *.
+      now rewrite Z.mod_mod by lia.
+    - intros a.
+      autorewrite with zsimpl in *.
+      now rewrite Z.mod_mod by lia.
+    - intros a.
+      autorewrite with zsimpl in *.
+      rewrite Z.mod_mod by lia.
+      now rewrite Z.mul_1_l.
+    - intros a.
+      autorewrite with zsimpl in *.
+      rewrite Z.mod_mod by lia.
+      replace ([p] - [a] + [a])%Z with [p] by lia.
+      rewrite Z.mod_same, Z.mod_0_l; lia.
+    - intros a anp.
+      autorewrite with zsimpl in *.
+      now rewrite Z.mul_comm, Zp.mul_mod_inv by auto.
+    - intros a b c.
+      autorewrite with zsimpl in *.
+      repeat (try rewrite Z.mul_mod_idemp_l;
+              try rewrite Z.mul_mod_idemp_r;
+              try rewrite Z.add_mod_idemp_l;
+              try rewrite Z.add_mod_idemp_r;
+              try rewrite Z.mod_mod); try lia.
+      apply f_equal2; lia.
+    - intros a anp.
+      autorewrite with zsimpl in *.
+      cbn.
+      now rewrite Z.mod_1_l at 1 by lia.
+    - intros a.
+      autorewrite with zsimpl in *.
+      now rewrite Zp.mod_pow_mod, Zp.mod_pow_1_r.
+    - intros a ap0.
+      autorewrite with zsimpl in *.
+      rewrite (Zp.mod_pow_exp_opp _ 1) by auto.
+      rewrite Zp.mod_pow_1_r.
+      now rewrite Zp.mod_inv_mod_idemp.
+    - intros a e e' ap0.
+      autorewrite with zsimpl in *.
+      now rewrite Zp.mod_pow_exp_plus by auto.
+    - intros a e ap0.
+      autorewrite with zsimpl in *.
+      auto.
+    - intros a ap0.
+      autorewrite with zsimpl in *.
+      auto.
+  Defined.
+End BigZp.

--- a/execution/theories/BoardroomVoting.v
+++ b/execution/theories/BoardroomVoting.v
@@ -1,0 +1,709 @@
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+From Coq Require Import Orders.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+From Coq Require Import Permutation.
+From Coq Require Import Psatz.
+From Coq Require Import Mergesort.
+From Coq Require Program.
+From RecordUpdate Require Import RecordUpdate.
+Require Import Automation.
+Require Import Blockchain.
+Require Import BoundedN.
+Require Import Containers.
+From stdpp Require countable.
+Require ContractMonads.
+Require Import Extras.
+Require Import BoardroomMath.
+Require Import Monads.
+Require Import Serializable.
+
+Import ListNotations.
+Import RecordSetNotations.
+
+Section BoardroomVoting.
+Context `{Base : ChainBase}.
+
+Context {A : Type}.
+Context `(H : A -> Z).
+Context {ser : Serializable A}.
+Context {axioms : BoardroomAxioms A}.
+Context {generator : Generator axioms}.
+Context {discr_log : DiscreteLog axioms generator}.
+
+Local Open Scope ffield.
+
+(* Allow us to automatically derive Serializable instances *)
+Set Nonrecursive Elimination Schemes.
+
+Record Setup :=
+  build_setup {
+    eligible_voters : FMap Address unit;
+    finish_registration_by : nat;
+    finish_commit_by : option nat;
+    finish_vote_by : nat;
+    registration_deposit : Amount;
+  }.
+
+
+Record VoterInfo :=
+  build_voter_info {
+    voter_index : nat;
+    vote_hash : Z;
+    public_vote : A;
+}.
+
+Record State :=
+  build_state {
+    owner : Address;
+    registered_voters : FMap Address VoterInfo;
+    public_keys : list A;
+    setup : Setup;
+    result : option nat;
+  }.
+
+Inductive Msg :=
+| signup (pk : A)
+| commit_to_vote (hash : Z)
+| submit_vote (v : A) (proof : Z)
+| tally_votes.
+
+Global Instance VoterInfo_settable : Settable _ :=
+  settable! build_voter_info <voter_index; vote_hash; public_vote>.
+
+Global Instance State_settable : Settable _ :=
+  settable! build_state <owner; registered_voters; public_keys; setup; result>.
+
+Global Instance Setup_serializable : Serializable Setup :=
+  Derive Serializable Setup_rect<build_setup>.
+
+Global Instance VoterInfo_serializable : Serializable VoterInfo :=
+  Derive Serializable VoterInfo_rect<build_voter_info>.
+
+Global Instance State_serializable : Serializable State :=
+  Derive Serializable State_rect<build_state>.
+
+Global Instance Msg_serializable : Serializable Msg :=
+  Derive Serializable Msg_rect<signup, commit_to_vote, submit_vote, tally_votes>.
+
+Class VoteProofScheme :=
+  build_vote_proof_scheme {
+    make_vote_proof (pks : list A) (index : nat)
+                    (secret_key : Z) (secret_vote : bool) : Z;
+    verify_vote (pks : list A) (index : nat) (public_vote : A) (proof : Z) : bool;
+
+    (*
+    verify_vote_spec pks index pv proof :
+      verify_vote pks index pv proof = true ->
+      exists sk sv, proof = make_vote_proof pks index sk sv;
+*)
+  }.
+
+Context `{VoteProofScheme}.
+
+Local Open Scope Z.
+
+Import ContractMonads.
+
+Definition init : ContractIniter Setup State :=
+  do owner <- lift caller_addr;
+  do setup <- deployment_setup;
+  do lift (if finish_registration_by setup <? finish_vote_by setup then Some tt else None)%nat;
+  accept_deployment
+    {| owner := owner;
+       registered_voters := FMap.empty;
+       public_keys := [];
+       setup := setup;
+       result := None; |}.
+
+Definition receive : ContractReceiver State Msg State :=
+  do state <- my_state;
+  do caller <- lift caller_addr;
+  do cur_slot <- lift current_slot;
+  do msg <- call_msg >>= lift;
+  match msg with
+  | signup pk =>
+    do lift (if finish_registration_by (setup state) <? cur_slot then None else Some tt)%nat;
+    do lift (if FMap.find caller (eligible_voters (setup state)) then Some tt else None);
+    do lift (if FMap.find caller (registered_voters state) then None else Some tt);
+    do amt <- lift call_amount;
+    do lift (if amt =? (registration_deposit (setup state)) then Some tt else None);
+    do lift (if Z.of_nat (length (public_keys state)) <? order - 2 then Some tt else None);
+    let index := length (public_keys state) in
+    let inf := {| voter_index := index;
+                  vote_hash := 0;
+                  public_vote := zero; |} in
+    let new_state := state<|registered_voters ::= FMap.add caller inf|>
+                          <|public_keys ::= fun l => l ++ [pk]|> in
+    accept_call new_state
+
+  | commit_to_vote hash =>
+    do commit_by <- lift (finish_commit_by (setup state));
+    do lift (if commit_by <? cur_slot then None else Some tt)%nat;
+    do inf <- lift (FMap.find caller (registered_voters state));
+    let inf := inf<|vote_hash := hash|> in
+    accept_call (state<|registered_voters ::= FMap.add caller inf|>)
+
+  | submit_vote v proof =>
+    do lift (if finish_vote_by (setup state) <? cur_slot then None else Some tt)%nat;
+    do inf <- lift (FMap.find caller (registered_voters state));
+    do lift (if finish_commit_by (setup state) then
+               if H v =? vote_hash inf then Some tt else None
+             else
+               Some tt);
+    do lift (if verify_vote (public_keys state) (voter_index inf) v proof then Some tt else None);
+    let inf := inf<|public_vote := v|> in
+    accept_call (state<|registered_voters ::= FMap.add caller inf|>)
+
+  | tally_votes =>
+    do lift (if cur_slot <? finish_vote_by (setup state) then None else Some tt)%nat;
+    do lift (match result state with | Some _ => None | None => Some tt end);
+    let voters := FMap.values (registered_voters state) in
+    do lift (if existsb
+                  (fun vi => if elmeqb (public_vote vi) zero then true else false)
+                  voters then None else Some tt);
+    let votes := map public_vote voters in
+    do res <- lift (bruteforce_tally votes);
+    accept_call (state<|result := Some res|>)
+  end.
+
+Definition boardroom_voting : Contract Setup Msg State.
+Proof with cbn -[Nat.ltb].
+  refine (build_contract init receive _ _).
+  - repeat intro; subst.
+    cbn -[Nat.ltb].
+    destruct (_ <? _)%nat; auto.
+  - intros c1 c2 ceq ctx ? <- state ? <- msg ? <-.
+    unfold run_contract_receiver...
+    destruct msg as [msg|]; [|congruence]...
+    destruct msg.
+    + rewrite <- ceq.
+      destruct (_ <? _)%nat; auto.
+      destruct (FMap.find _ _); auto.
+      destruct (FMap.find _ _); auto.
+      destruct (_ =? _)%Z; auto.
+      destruct (_ <? _); auto.
+    + destruct (finish_commit_by _); auto.
+      rewrite <- ceq.
+      destruct (_ <? _)%nat; auto.
+      destruct (FMap.find _ _); auto.
+    + rewrite <- ceq.
+      destruct (_ <? _)%nat; auto.
+      destruct (FMap.find _ _); auto.
+      destruct (finish_commit_by _); [destruct (_ =? _); auto|].
+      all: destruct (verify_vote _ _ _ _); auto.
+    + rewrite <- ceq.
+      destruct (_ <? _)%nat; auto.
+      destruct (result _); auto.
+      destruct (existsb _ _); auto.
+      destruct (bruteforce_tally _); auto.
+Defined.
+
+Definition make_signup_msg (sk : Z) : Msg :=
+  signup (compute_public_key sk).
+
+Definition make_commit_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) : Msg :=
+  commit_to_vote (H (compute_public_vote (reconstructed_key pks my_index) sk sv)).
+
+Definition make_vote_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) : Msg :=
+  submit_vote (compute_public_vote (reconstructed_key pks my_index) sk sv)
+              (make_vote_proof pks my_index sk sv).
+
+Section Theories.
+
+(* For correctness we assume that all signups and vote messages were
+   created using the make_signup_msg and make_vote_msg functions from
+   the contract *)
+Fixpoint MsgAssumption
+         (pks : list A)
+         (index : Address -> nat)
+         (sks : Address -> Z)
+         (svs : Address -> bool)
+         (calls : list (ContractCallInfo Msg)) : Prop :=
+  match calls with
+  | call :: calls =>
+    let caller := Blockchain.call_from call in
+    match Blockchain.call_msg call with
+    | Some (signup pk as m) => m = make_signup_msg (sks caller)
+    | Some (submit_vote _ _ as m) =>
+      m = make_vote_msg pks (index caller) (sks caller) (svs caller)
+    | _ => True
+    end /\ MsgAssumption pks index sks svs calls
+  | [] => True
+  end.
+
+Definition signups (calls : list (ContractCallInfo Msg)) : list (Address * A) :=
+  (* reverse the signups since the calls will have the last one at the head *)
+  rev (map_option (fun call => match Blockchain.call_msg call with
+                               | Some (signup pk) => Some (Blockchain.call_from call, pk)
+                               | _ => None
+                               end) calls).
+
+(* The index map and public keys list provided also needs to match the
+   order in which parties signed up in the contract. *)
+Definition SignupOrderAssumption
+           (pks : list A)
+           (index : Address -> nat)
+           (calls : list (ContractCallInfo Msg)) : Prop :=
+  All (fun '((addr, pk), i) => index addr = i /\ nth_error pks i = Some pk)
+      (zip (signups calls) (seq 0 (length (signups calls)))).
+
+(*
+Lemma voter_info_update (voters : FMap Address VoterInfo) index addr vi_before vi_after :
+  IndexAssumptions (FMap.add addr vi_after voters) index ->
+  FMap.find addr voters = Some vi_before ->
+  voter_index vi_before = voter_index vi_after ->
+  IndexAssumptions voters index.
+Proof.
+  unfold IndexAssumptions in *.
+  intros index_assum inf index_same addr' inf' find_addr.
+  destruct (address_eqb_spec addr addr') as [->|].
+  - specialize (index_assum addr' vi_after).
+    replace inf' with vi_before in * by congruence.
+    rewrite index_same.
+    apply index_assum.
+    now rewrite FMap.find_add.
+  - apply index_assum.
+    rewrite FMap.find_add_ne by auto; congruence.
+Qed.
+*)
+
+Local Open Scope nat.
+
+Lemma no_outgoing bstate caddr :
+  reachable bstate ->
+  env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+  outgoing_acts bstate caddr = [].
+Proof.
+  contract_induction; intros; cbn -[Nat.ltb] in *; auto.
+  - now inversion IH.
+  - destruct msg as [msg|]; cbn -[Nat.ltb] in *; try congruence.
+    destruct msg.
+    + destruct (_ <? _); cbn in *; try congruence.
+      destruct (FMap.find _ _); cbn in *; try congruence.
+      destruct (FMap.find _ _); cbn in *; try congruence.
+      destruct (_ =? _)%Z; cbn in *; try congruence.
+      destruct (_ <? _)%Z; cbn in *; try congruence.
+      now inversion_clear receive_some.
+    + destruct (finish_commit_by _); cbn -[Nat.ltb] in *; try congruence.
+      destruct (_ <? _); cbn in *; try congruence.
+      destruct (FMap.find _ _); cbn in *; try congruence.
+      now inversion_clear receive_some.
+    + destruct (_ <? _); cbn in *; try congruence.
+      destruct (FMap.find _ _); cbn in *; try congruence.
+      destruct (if finish_commit_by (setup prev_state)
+                      then if (H v =? vote_hash v0)%Z then Some tt else None
+                      else Some tt); cbn in *; try congruence.
+      destruct (verify_vote _ _ _ _); cbn in *; try congruence.
+      now inversion_clear receive_some.
+    + destruct (_ <? _); cbn in *; try congruence.
+      destruct (result _); cbn in *; try congruence.
+      destruct (existsb _ _); cbn in *; try congruence.
+      destruct (bruteforce_tally _); cbn in *; try congruence.
+      now inversion_clear receive_some.
+  - inversion IH.
+  - subst out_queue.
+    now apply Permutation_nil in perm.
+  - [AddBlockFacts]: exact (fun _ _ _ _ _ _ => True).
+    [DeployFacts]: exact (fun _ _ => True).
+    [CallFacts]: exact (fun _ _ _ => True).
+    unset_all; subst.
+    destruct_chain_step; auto.
+    destruct_action_eval; auto.
+Qed.
+
+Lemma Permutation_modify k vold vnew (m : FMap Address VoterInfo) :
+  FMap.find k m = Some vold ->
+  voter_index vold = voter_index vnew ->
+  Permutation (map (fun '(_, v) => voter_index v)
+                   (FMap.elements m))
+              (seq 0 (FMap.size m)) ->
+  Permutation
+    (map (fun '(_, v0) => voter_index v0)
+         (FMap.elements (FMap.add k vnew m)))
+    (seq 0 (FMap.size m)).
+Proof.
+  intros find_some index old_perm.
+  rewrite <- old_perm.
+  rewrite <- (FMap.add_id _ _ _ find_some) at 2.
+  rewrite <- (FMap.add_remove k vold).
+  rewrite (FMap.elements_add_existing k vold vnew) by auto.
+  rewrite FMap.elements_add by auto.
+  cbn.
+  now rewrite index.
+Qed.
+
+Lemma all_signups pks index calls :
+  SignupOrderAssumption pks index calls ->
+  length (signups calls) = length pks ->
+  map snd (signups calls) = pks.
+Proof.
+  intros order len_signups.
+  unfold SignupOrderAssumption in order.
+  revert index pks len_signups order.
+  induction (signups calls) as [|[addr pk] xs IH]; intros index pks len_signups order.
+  - destruct pks; cbn in *; congruence.
+  - cbn in *.
+    destruct pks as [|pk' pks]; cbn in *; try lia.
+    destruct order as [[index_eq nth_eq] all].
+    f_equal; try congruence.
+    apply (IH (fun addr => index addr - 1)); try lia.
+    clear -all.
+    rewrite <- (map_id xs) in all at 1.
+    rewrite <- seq_shift in all.
+    rewrite zip_map in all.
+    apply All_map in all.
+    apply (All_ext_in _ _ _ all).
+    intros.
+    destruct a, p.
+    cbn in *.
+    split; [|tauto].
+    destruct H0; lia.
+Qed.
+
+Definition has_tallied (calls : list (ContractCallInfo Msg)) : bool :=
+  existsb (fun c => match Blockchain.call_msg c with
+                    | Some tally_votes => true
+                    | _ => false
+                    end) calls.
+
+Theorem boardroom_voting_correct_strong
+        bstate caddr (trace : ChainTrace empty_state bstate)
+        pks index sks svs :
+    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+    exists (cstate : State)
+           (depinfo : DeploymentInfo Setup)
+           (inc_calls : list (ContractCallInfo Msg)),
+      deployment_info Setup trace caddr = Some depinfo /\
+      contract_state bstate caddr = Some cstate /\
+      incoming_calls Msg trace caddr = Some inc_calls /\
+
+      finish_registration_by (setup cstate) < finish_vote_by (setup cstate) /\
+
+      (Blockchain.current_slot bstate < finish_vote_by (setup cstate) ->
+       has_tallied inc_calls = false) /\
+
+      length (public_keys cstate) = FMap.size (registered_voters cstate) /\
+      public_keys cstate = map snd (signups inc_calls) /\
+
+      (Z.of_nat (length (public_keys cstate)) < order - 1)%Z /\
+
+      (MsgAssumption pks index sks svs inc_calls ->
+       SignupOrderAssumption pks index inc_calls ->
+       (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
+        length pks = length (signups inc_calls)) ->
+
+       Permutation (map (fun '(_, v) => voter_index v)
+                        (FMap.elements (registered_voters cstate)))
+                   (seq 0 (length (public_keys cstate))) /\
+
+       (forall addr inf,
+           FMap.find addr (registered_voters cstate) = Some inf ->
+           voter_index inf < length (public_keys cstate) /\
+           voter_index inf = index addr /\
+           nth_error (public_keys cstate) (voter_index inf) =
+           Some (compute_public_key (sks addr)) /\
+           (public_vote inf == zero \/
+            public_vote inf = compute_public_vote
+                                (reconstructed_key pks (voter_index inf))
+                                (sks addr)
+                                (svs addr))) /\
+       ((has_tallied inc_calls = false ->
+         result cstate = None) /\
+        (has_tallied inc_calls = true ->
+         result cstate = Some (sumnat (fun party => if svs party then 1 else 0)%nat
+                                     (FMap.keys (registered_voters cstate)))))).
+Proof.
+  contract_induction; intros.
+  - [AddBlockFacts]: exact (fun _ old_slot _ _ new_slot _ => old_slot < new_slot).
+    subst AddBlockFacts.
+    cbn in facts.
+    destruct_and_split; try tauto.
+    + eauto with lia.
+    + intros; eauto with lia.
+  - cbn -[Nat.ltb] in *.
+    destruct (_ <? _) eqn:ltb; [|congruence].
+    apply Nat.ltb_lt in ltb.
+    inversion_clear init_some.
+    cbn.
+    split; auto.
+    split; auto.
+    split; [symmetry; apply FMap.size_empty|].
+    pose proof order_ge_2.
+    split; [auto|].
+    split; [lia|].
+    intros _ index_assum pks_assum.
+    rewrite FMap.elements_empty.
+    split; [auto|].
+    split; [|easy].
+    intros ? ? find.
+    now rewrite FMap.find_empty in find.
+  - auto.
+  - cbn -[Nat.ltb] in receive_some.
+    destruct msg as [msg|]; cbn -[Nat.ltb] in *; [|congruence].
+    destruct msg.
+    + (* signup *)
+      destruct (_ <? _)%nat eqn:intime in receive_some; cbn -[Nat.ltb] in *; [congruence|].
+      apply Nat.ltb_ge in intime.
+      destruct (FMap.find _ _) in receive_some; cbn in *; [|congruence].
+      destruct (FMap.find _ _) eqn:new in receive_some; cbn in *; [congruence|].
+      destruct (_ =? _)%Z in receive_some; cbn in *; [|congruence].
+      destruct (_ <? _)%Z eqn:lt in receive_some; cbn in *; [|congruence].
+      inversion_clear receive_some.
+      cbn.
+      split; [lia|].
+      split; [tauto|].
+      split.
+      { rewrite app_length, FMap.size_add_new by auto; cbn; lia. }
+      apply Z.ltb_lt in lt.
+      rewrite app_length in *.
+      cbn.
+      fold (has_tallied prev_inc_calls).
+      fold (signups prev_inc_calls).
+      rewrite app_length, map_app; cbn.
+      split; [destruct_and_split; congruence|].
+      split; [lia|].
+      intros [signup_assum msg_assum] order_assum num_signups_assum.
+      destruct IH as [reg_lt [cur_lt [_ [pks_signups [_ IH]]]]].
+      unshelve epose proof (IH _ _ _) as IH.
+      * auto.
+      * rewrite seq_app in order_assum.
+        rewrite zip_app in order_assum by (now rewrite seq_length).
+        apply All_app in order_assum.
+        tauto.
+      * intros.
+        lia.
+      * split.
+        {
+          destruct IH as [perm _].
+          cbn.
+          rewrite FMap.elements_add by auto.
+          cbn.
+          rewrite seq_app.
+          cbn.
+          perm_simplify.
+        }
+        split; cycle 1.
+        {
+          split; [easy|].
+          intros tallied.
+          specialize (cur_lt ltac:(lia)).
+          congruence.
+        }
+        intros addr inf find_add.
+        destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+        -- rewrite (FMap.find_add (ctx_from ctx)) in find_add.
+           inversion_clear find_add.
+           cbn.
+           unfold make_signup_msg in signup_assum.
+           rewrite nth_error_snoc.
+           rewrite seq_app, zip_app in order_assum by (now rewrite seq_length).
+           apply All_app in order_assum.
+           cbn in order_assum.
+           destruct order_assum as [_ []].
+           split; [lia|].
+           rewrite pks_signups, map_length.
+           split; [symmetry; tauto|].
+           split; [congruence|].
+           left; easy.
+        -- rewrite FMap.find_add_ne in find_add by auto.
+           destruct IH as [_ [IH _]].
+           specialize (IH _ _ find_add).
+           split; [lia|].
+           now rewrite nth_error_app1 by lia.
+    + (* commit_to_vote *)
+      destruct (finish_commit_by _); cbn -[Nat.ltb] in *; [|congruence].
+      destruct (_ <? _); cbn in *; [congruence|].
+      destruct (FMap.find _ _) eqn:found; cbn in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      split; [lia|].
+      split; [tauto|].
+      split.
+      { rewrite FMap.size_add_existing by congruence; tauto. }
+      split; [tauto|].
+      split; [tauto|].
+      intros [_ msg_assum] order_assum num_signups_assum.
+      destruct IH as [_ [_ [len_pks [_ [_ IH]]]]].
+      specialize (IH msg_assum order_assum num_signups_assum).
+      setoid_rewrite (FMap.keys_already _ _ _ _ found).
+      split.
+      {
+        destruct IH as [perm _].
+        rewrite len_pks in *.
+        apply Permutation_modify with (vold := v); auto.
+      }
+
+      split; try tauto.
+      intros addr inf find_add.
+      destruct IH as [_ [IH _]].
+      destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+      * rewrite FMap.find_add in find_add.
+        inversion_clear find_add; cbn.
+        auto.
+      * rewrite FMap.find_add_ne in find_add by auto.
+        auto.
+    + (* submit_vote *)
+      destruct (_ <? _); cbn -[Nat.ltb] in *; [congruence|].
+      destruct (FMap.find _ _) eqn:found; cbn in *; [|congruence].
+      destruct (if finish_commit_by _ then _ else _); cbn in *; [|congruence].
+      destruct (verify_vote _ _ _ _); cbn in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      split; [lia|].
+      split; [tauto|].
+      rewrite FMap.size_add_existing by congruence.
+      split; [tauto|].
+      split; [tauto|].
+      split; [tauto|].
+      intros [vote_assum msg_assum] order_assum num_signups_assum.
+      destruct IH as [_ [_ [len_pks [_ [_ IH]]]]].
+      specialize (IH msg_assum order_assum num_signups_assum).
+      setoid_rewrite (FMap.keys_already _ _ _ _ found).
+      split.
+      {
+        destruct IH as [perm _].
+        rewrite len_pks in *.
+        apply Permutation_modify with (vold := v0); auto.
+      }
+      split; [|tauto].
+      intros addr inf find_add.
+      destruct IH as [_ [IH _]].
+      destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+      * rewrite FMap.find_add in find_add.
+        inversion_clear find_add; cbn.
+        specialize (IH _ _ found).
+        repeat split; try tauto.
+        right.
+        unfold make_vote_msg in *.
+        inversion vote_assum.
+        destruct_hyps.
+        replace (index (ctx_from ctx)) with (voter_index v0) by congruence.
+        easy.
+      * rewrite FMap.find_add_ne in find_add by auto.
+        auto.
+    + (* tally_votes *)
+      destruct (_ <? _) eqn:intime; cbn in *; [congruence|].
+      destruct (result prev_state); cbn in *; [congruence|].
+      destruct (existsb _ _) eqn:all_voted; cbn in *; [congruence|].
+      destruct (bruteforce_tally _) eqn:bruteforce; cbn -[Nat.ltb] in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      apply Nat.ltb_ge in intime.
+      split; [lia|].
+      split; [intros; lia|].
+      split; [tauto|].
+      split; [tauto|].
+      split; [tauto|].
+      intros [_ msg_assum] order_assum num_signups_assum.
+      split; [tauto|].
+      split; [tauto|].
+      split; [easy|].
+      intros _.
+      apply f_equal.
+      destruct IH as [finish_before_vote [_ [len_pks [pks_signups [party_count IH]]]]].
+      specialize (IH msg_assum order_assum num_signups_assum).
+      destruct IH as [perm [addrs _]].
+      unfold FMap.values in bruteforce.
+      rewrite map_map in bruteforce.
+      rewrite (map_ext_in _ (fun '(_, v) => public_vote v)) in bruteforce
+        by (now intros []).
+      rewrite (bruteforce_tally_correct
+                    (FMap.elements (registered_voters prev_state))
+                    (fun '(_, v) => voter_index v)
+                    (fun '(addr, _) => sks addr)
+                    (public_keys prev_state)
+                    (fun kvp => svs (fst kvp))
+                    (fun '(_, v) => public_vote v)) in bruteforce.
+      * inversion bruteforce.
+        unfold FMap.keys.
+        now rewrite sumnat_map.
+      * now rewrite FMap.length_elements, <- len_pks.
+      * now rewrite FMap.length_elements, <- len_pks.
+      * auto.
+      * intros [k v] kvpin.
+        apply FMap.In_elements in kvpin.
+        specialize (addrs _ _ kvpin).
+        tauto.
+      * intros [k v] kvpin.
+        rewrite existsb_forallb in all_voted.
+        apply Bool.negb_false_iff in all_voted.
+        rewrite forallb_forall in all_voted.
+        unshelve epose proof (all_voted v _) as all_voted.
+        {
+          apply in_map_iff.
+          exists (k, v).
+          tauto.
+        }
+        apply Bool.negb_true_iff in all_voted.
+        destruct (elmeqb_spec (public_vote v) zero); [congruence|].
+        apply FMap.In_elements in kvpin.
+        specialize (addrs _ _ kvpin).
+        cbn.
+        destruct addrs as [_ [_ [_ []]]]; [easy|].
+        fold (signups prev_inc_calls) (SignupOrderAssumption pks index prev_inc_calls) in *.
+        rewrite pks_signups.
+        specialize (num_signups_assum ltac:(lia)).
+        now rewrite (all_signups pks index) by auto.
+  - [CallFacts]: exact (fun _ ctx _ => ctx_from ctx <> ctx_contract_address ctx).
+    subst CallFacts; cbn in *; congruence.
+  - auto.
+  - [DeployFacts]: exact (fun _ _ => True).
+    unset_all; subst; cbn in *.
+    destruct_chain_step; auto.
+    + destruct valid_header; auto.
+    + destruct_action_eval; auto.
+      intros.
+      pose proof (no_outgoing _ _ from_reachable H1).
+      unfold outgoing_acts in H3.
+      rewrite queue_prev in H3.
+      cbn in H3.
+      destruct (address_eqb_spec (act_from act) to_addr); cbn in *; try congruence.
+      subst act; cbn in *; congruence.
+Qed.
+
+Theorem boardroom_voting_correct
+        bstate caddr (trace : ChainTrace empty_state bstate)
+        (* list of all public keys, in the order of signups *)
+        (pks : list A)
+        (* function mapping a party to his signup index *)
+        (index : Address -> nat)
+        (* function mapping a party to his secret key *)
+        (sks : Address -> Z)
+        (* function mapping a party to his vote *)
+        (svs : Address -> bool) :
+    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+    exists (cstate : State)
+           (depinfo : DeploymentInfo Setup)
+           (inc_calls : list (ContractCallInfo Msg)),
+      deployment_info Setup trace caddr = Some depinfo /\
+      contract_state bstate caddr = Some cstate /\
+      incoming_calls Msg trace caddr = Some inc_calls /\
+
+      (* assuming that the message sent were created with the
+          functions provided by this smart contract *)
+      MsgAssumption pks index sks svs inc_calls ->
+
+      (* ..and that people signed up in the order given by 'index'
+          and 'pks' *)
+      SignupOrderAssumption pks index inc_calls ->
+
+      (* ..and that the correct number of people register *)
+      (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
+       length pks = length (signups inc_calls)) ->
+
+      (* then if we have not tallied yet, the result is none *)
+      ((has_tallied inc_calls = false -> result cstate = None) /\
+       (* or if we have tallied yet, the result is correct *)
+       (has_tallied inc_calls = true ->
+        result cstate = Some (sumnat (fun party => if svs party then 1 else 0)%nat
+                                     (FMap.keys (registered_voters cstate))))).
+Proof.
+  intros deployed.
+  destruct (boardroom_voting_correct_strong bstate caddr trace pks index sks svs deployed)
+    as [cstate [depinfo [inc_calls P]]].
+  exists cstate, depinfo, inc_calls.
+  tauto.
+Qed.
+
+End Theories.
+
+End BoardroomVoting.

--- a/execution/theories/BoardroomVotingTest.v
+++ b/execution/theories/BoardroomVotingTest.v
@@ -1,0 +1,134 @@
+From Bignums Require Import BigZ.
+From Coq Require Import Cyclic31.
+From Coq Require Import List.
+From Coq Require Import Znumtheory.
+Require Import BignumsSerializable.
+Require Import Blockchain.
+Require Import BoardroomMath.
+Require Import BoardroomVoting.
+Require Import BoundedN.
+Require Import Containers.
+Require Import Extras.
+Require Import LocalBlockchain.
+Require Import Monads.
+Require Import Serializable.
+
+Import ListNotations.
+
+Local Open Scope bigZ.
+Local Open Scope ffield.
+(*
+Definition modulus : bigZ := 1552518092300708935130918131258481755631334049434514313202351194902966239949102107258669453876591642442910007680288864229150803718918046342632727613031282983744380820890196288509170691316593175367469551763119843371637221007210577919.
+Definition generator : bigZ := 2.
+*)
+Definition modulus : bigZ := 201697267445741585806196628073.
+Definition generator : bigZ := 3.
+
+Axiom modulus_prime : prime [modulus].
+Instance axioms : BoardroomAxioms bigZ := BigZp.boardroom_axioms modulus modulus_prime.
+
+Lemma generator_nonzero : generator !== 0.
+Proof. discriminate. Qed.
+
+Axiom generator_is_generator :
+  forall z,
+    z !== 0 ->
+    exists! (e : Z), (0 <= e < order - 1)%Z /\ pow generator e == z.
+
+Instance generator_instance : Generator axioms :=
+  {| BoardroomMath.generator := generator;
+     BoardroomMath.generator_nonzero := generator_nonzero;
+     generator_generates := generator_is_generator; |}.
+
+Instance id_scheme : @VoteProofScheme bigZ :=
+  {| make_vote_proof l n z b := 0%Z;
+     verify_vote l n a z := true; |}.
+
+Definition num_parties : nat := 7.
+Definition votes_for : nat := 4.
+
+(* a pseudo-random generator for secret keys *)
+Definition sk n := [pow ((BigZ.of_Z (Z.of_nat n) + 1234583932) * (modulus - 23241)) 159338231].
+
+(* Make a list of secret keys, here starting at i=7 *)
+Definition sks : list Z :=
+  Eval native_compute in map sk (seq 7 num_parties).
+
+(* Make a list of votes for each party *)
+Definition svs : list bool :=
+  Eval compute in map (fun _ => true)
+                      (seq 0 votes_for)
+                  ++ map (fun _ => false)
+                         (seq 0 (num_parties - votes_for)).
+
+(* Compute the public keys for each party *)
+Definition pks : list bigZ :=
+  Eval native_compute in map compute_public_key sks.
+
+(* Compute the signup messages that would be sent by each party *)
+Definition signups : list Msg :=
+  Eval native_compute in map make_signup_msg sks.
+
+(* Compute the submit_vote messages that would be sent by each party *)
+(* Our functional correctness proof assumes that the votes were computed
+   using the make_vote_msg function provided by the contract *)
+Definition votes : list Msg :=
+  Eval native_compute in map (fun '(i, sk, sv) => make_vote_msg pks i sk sv)
+                             (zip (zip (seq 0 (length pks)) sks) svs).
+
+Definition AddrSize := (2^128)%N.
+Instance Base : ChainBase := LocalChainBase AddrSize.
+Instance ChainBuilder : ChainBuilderType := LocalChainBuilderDepthFirst AddrSize.
+
+Definition A a :=
+  BoundedN.of_Z_const AddrSize a.
+
+Local Open Scope nat.
+Definition addrs : list Address.
+Proof.
+  let rec add_addr z n :=
+    match n with
+    | O => constr:(@nil Address)
+    | S ?n => let tail := add_addr (z + 1)%Z n in
+              constr:(cons (A z) tail)
+    end in
+  let num := eval compute in num_parties in
+  let tm := add_addr 11%Z num in
+  let tm := eval vm_compute in tm in
+  exact tm.
+Defined.
+
+Definition deploy_setup :=
+  {| eligible_voters := FMap.of_list (map (fun a => (a, tt)) addrs);
+     finish_registration_by := 3;
+     finish_commit_by := None;
+     finish_vote_by := 5;
+     registration_deposit := 0; |}.
+
+Local Open Scope list.
+Definition boardroom_example :=
+  let chain : ChainBuilder := builder_initial in
+  let creator : Address := A 10 in
+  let add_block (chain : ChainBuilder) (acts : list Action) :=
+      let next_header :=
+          {| block_height := S (chain_height chain);
+             block_slot := S (current_slot chain);
+             block_finalized_height := finalized_height chain;
+             block_creator := creator;
+             block_reward := 50; |} in
+      builder_add_block chain next_header acts in
+  do chain <- add_block chain [];
+  let dep := build_act creator (create_deployment 0 (boardroom_voting BigZ.to_Z) deploy_setup) in
+  do chain <- add_block chain [dep];
+  do caddr <- hd None (map Some (FMap.keys (lc_contracts (lcb_lc chain))));
+  let send addr m := build_act addr (act_call caddr 0 (serialize m)) in
+  let calls := map (fun '(addr, m) => send addr m) (zip addrs signups) in
+  do chain <- add_block chain calls;
+  let votes := map (fun '(addr, m) => send addr m) (zip addrs votes) in
+  do chain <- add_block chain votes;
+  let tally := build_act creator (act_call caddr 0 (serialize tally_votes)) in
+  do chain <- add_block chain [tally];
+  do state <- @contract_state _ (@State _ bigZ) _ (lcb_lc chain) caddr;
+  result state.
+
+Check (@eq_refl (option nat) (Some votes_for)) <: boardroom_example = Some votes_for.

--- a/execution/theories/Congress.v
+++ b/execution/theories/Congress.v
@@ -255,6 +255,7 @@ Definition receive
 Ltac solve_contract_proper :=
   repeat
     match goal with
+    | [|- @bind _ ?m _ _ _ _ = @bind _ ?m _ _ _ _] => unfold bind, m
     | [|- ?x _  = ?x _] => unfold x
     | [|- ?x _ _ = ?x _ _] => unfold x
     | [|- ?x _ _ _ = ?x _ _ _] => unfold x
@@ -316,10 +317,6 @@ Proof.
       unfold do_retract_vote in receive.
       destruct (FMap.find _ _); cbn in *; try congruence.
       destruct (FMap.find _ _); cbn in *; try congruence.
-      now inversion_clear receive.
-    + unfold do_finish_proposal in receive.
-      destruct (FMap.find _ _); cbn in *; try congruence.
-      destruct_match in receive; cbn in *; try congruence.
       now inversion_clear receive.
     + now inversion receive; subst.
   }
@@ -451,8 +448,8 @@ Lemma receive_state_well_behaved
   end.
 Proof.
   intros receive.
-  destruct msg as [msg|]; cbn in *; try congruence.
-  destruct msg; cbn in *; try congruence.
+  destruct msg as [[]|];
+    cbn -[vote_on_proposal do_retract_vote do_finish_proposal] in *.
   - (* transfer_ownership *)
     destruct_address_eq; try congruence.
     inversion receive; auto.
@@ -469,17 +466,17 @@ Proof.
     apply add_proposal_cacts.
   - (* vote_for_proposal *)
     destruct (FMap.mem _ _); try congruence.
-    destruct (vote_on_proposal _ _ _ _) eqn:vote; cbn in *; try congruence.
+    destruct (vote_on_proposal _ _ _ _) eqn:vote; cbn -[vote_on_proposal] in *; try congruence.
     inversion receive; subst.
     erewrite vote_on_proposal_cacts_preserved; eauto.
   - (* vote_against_proposal *)
     destruct (FMap.mem _ _); try congruence.
-    destruct (vote_on_proposal _ _ _ _) eqn:vote; cbn in *; try congruence.
+    destruct (vote_on_proposal _ _ _ _) eqn:vote; cbn -[vote_on_proposal] in *; try congruence.
     inversion receive; subst.
     erewrite vote_on_proposal_cacts_preserved; eauto.
   - (* retract_vote *)
     destruct (FMap.mem _ _); try congruence.
-    destruct (do_retract_vote _ _ _) eqn:retract; cbn in *; try congruence.
+    destruct (do_retract_vote _ _ _) eqn:retract; cbn -[do_retract_vote] in *; try congruence.
     inversion receive; subst.
     erewrite do_retract_vote_cacts_preserved; eauto.
   - (* finish_proposal *)

--- a/execution/theories/Congress_Buggy.v
+++ b/execution/theories/Congress_Buggy.v
@@ -260,9 +260,9 @@ Definition receive
   end.
 
 Ltac solve_contract_proper :=
+  repeat
     match goal with
-    | _ => progress subst
-    | _ => solve [auto]
+    | [|- @bind _ ?m _ _ _ _ = @bind _ ?m _ _ _ _] => unfold bind, m
     | [|- ?x _  = ?x _] => unfold x
     | [|- ?x _ _ = ?x _ _] => unfold x
     | [|- ?x _ _ _ = ?x _ _ _] => unfold x
@@ -274,15 +274,16 @@ Ltac solve_contract_proper :=
     | [|- (if ?x then _ else _) = (if ?x then _ else _)] => destruct x
     | [|- match ?x with | _ => _ end = match ?x with | _ => _ end ] => destruct x
     | [H: ChainEquiv _ _ |- _] => rewrite H in *
+    | _ => subst; auto
     end.
 
 Lemma init_proper :
   Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; repeat solve_contract_proper. Qed.
+Proof. repeat intro; solve_contract_proper. Qed.
 
 Lemma receive_proper :
   Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof. repeat intro; repeat solve_contract_proper. Qed.
+Proof. repeat intro; solve_contract_proper. Qed.
 
 Definition contract : Contract Setup Msg State :=
   build_contract init init_proper receive receive_proper.

--- a/execution/theories/Containers.v
+++ b/execution/theories/Containers.v
@@ -13,6 +13,7 @@ Notation FMap := gmap.gmap.
 
 Module FMap.
   Generalizable All Variables.
+
   Notation empty := stdpp.base.empty.
   Notation add := stdpp.base.insert.
   Notation find := stdpp.base.lookup.
@@ -30,6 +31,9 @@ Module FMap.
   Notation alter := stdpp.base.alter.
   Notation partial_alter := stdpp.base.partial_alter.
 
+  Definition keys {K V : Type} `{countable.Countable K} (m : FMap K V) : list K :=
+    map fst (elements m).
+
   Definition values {K V : Type} `{countable.Countable K} (m : FMap K V) : list V :=
     map snd (elements m).
 
@@ -40,20 +44,6 @@ Module FMap.
       of_list (elements m) = m.
     Proof. apply fin_maps.list_to_map_to_list. Qed.
 
-    Lemma find_union_None k (m1 m2 : FMap K V) :
-      find k m1 = None ->
-      find k m2 = None ->
-      find k (union m1 m2) = None.
-    Proof.
-      intros find1 find2.
-      apply fin_maps.lookup_union_None; auto.
-    Qed.
-
-    Lemma find_union_Some_l k v (m1 m2 : FMap K V) :
-      find k m1 = Some v ->
-      find k (union m1 m2) = Some v.
-    Proof. apply fin_maps.lookup_union_Some_l. Qed.
-
     Lemma find_add (k : K) (v : V) (m : FMap K V) :
       find k (add k v m) = Some v.
     Proof. apply fin_maps.lookup_insert. Qed.
@@ -62,11 +52,11 @@ Module FMap.
       k <> k' -> find k' (add k v m) = find k' m.
     Proof. apply fin_maps.lookup_insert_ne. Qed.
 
-    Lemma find_partial_alter f k (m : FMap K V) :
+    Lemma find_partial_alter k f (m : FMap K V) :
       find k (partial_alter f k m) = f (find k m).
     Proof. apply fin_maps.lookup_partial_alter. Qed.
 
-    Lemma find_partial_alter_ne f k k' (m : FMap K V) :
+    Lemma find_partial_alter_ne k k' f (m : FMap K V) :
       k <> k' ->
       find k' (partial_alter f k m) = find k' m.
     Proof. apply fin_maps.lookup_partial_alter_ne. Qed.
@@ -83,13 +73,13 @@ Module FMap.
     Lemma elements_empty : (elements empty : list (K * V)) = [].
     Proof. now rewrite fin_maps.map_to_list_empty. Qed.
 
-    Lemma elements_add_empty (k : K) (v : V) :
-      FMap.elements (FMap.add k v FMap.empty) = [(k, v)].
-    Proof. now rewrite fin_maps.insert_empty, fin_maps.map_to_list_singleton. Qed.
-
     Lemma add_remove k v (m : FMap K V) :
       add k v (remove k m) = add k v m.
     Proof. apply fin_maps.insert_delete. Qed.
+
+    Lemma add_add k v v' (m : FMap K V) :
+      add k v (add k v' m) = add k v m.
+    Proof. apply fin_maps.insert_insert. Qed.
 
     Lemma remove_add k v (m : FMap K V) :
       find k m = None ->
@@ -100,6 +90,11 @@ Module FMap.
       find k (remove k m) = None.
     Proof. apply fin_maps.lookup_delete. Qed.
 
+    Lemma find_remove_ne k k' (m : FMap K V) :
+      k <> k' ->
+      find k' (remove k m) = find k' m.
+    Proof. apply fin_maps.lookup_delete_ne. Qed.
+
     Lemma add_commute (k k' : K) (v v' : V) (m : FMap K V) :
       k <> k' ->
       FMap.add k v (FMap.add k' v' m) = FMap.add k' v' (FMap.add k v m).
@@ -109,17 +104,111 @@ Module FMap.
       find k m = Some v ->
       add k v m = m.
     Proof. apply fin_maps.insert_id. Qed.
+
+    Lemma remove_empty k :
+      remove k (@FMap.empty (FMap K V) _) = (@FMap.empty (FMap K V) _).
+    Proof. apply fin_maps.delete_empty. Qed.
+
+    Lemma keys_already k v v' (m : FMap K V) :
+      find k m = Some v ->
+      Permutation (keys (add k v' m)) (keys m).
+    Proof.
+      revert k.
+      induction m using fin_maps.map_ind; intros k find_some.
+      + rewrite find_empty in find_some.
+        congruence.
+      + destruct (stdpp.base.decide (k = i)) as [->|].
+        * rewrite fin_maps.insert_insert.
+          unfold keys.
+          rewrite 2!fin_maps.map_to_list_insert by auto.
+          cbn.
+          reflexivity.
+        * rewrite find_add_ne in find_some by auto.
+          specialize (IHm _ find_some).
+          rewrite add_commute by auto.
+          unfold keys.
+          rewrite elements_add by (now rewrite find_add_ne by auto).
+          setoid_rewrite elements_add at 2; auto.
+          cbn.
+          now rewrite IHm.
+    Qed.
+
+    Lemma ind (P : FMap K V -> Prop) :
+      P empty ->
+      (forall k v m, find k m = None -> P m -> P (add k v m)) ->
+      forall m, P m.
+    Proof. apply fin_maps.map_ind. Qed.
+
+    Lemma size_empty : size (@FMap.empty (FMap K V) _) = 0.
+    Proof. apply fin_maps.map_size_empty. Qed.
+
+    Lemma size_add_new k v (m : FMap K V) :
+      FMap.find k m = None ->
+      size (FMap.add k v m) = S (size m).
+    Proof. apply fin_maps.map_size_insert. Qed.
+
+    Lemma size_add_existing k v (m : FMap K V) :
+      FMap.find k m <> None ->
+      size (FMap.add k v m) = size m.
+    Proof.
+      revert k v.
+      induction m using ind; intros kadd vadd find_some.
+      - rewrite find_empty in find_some.
+        congruence.
+      - destruct (stdpp.base.decide (k = kadd)) as [->|?].
+        + rewrite add_add.
+          now rewrite !size_add_new by auto.
+        + rewrite add_commute by auto.
+          rewrite find_add_ne in find_some by auto.
+          rewrite size_add_new.
+          * rewrite (IHm _ _ find_some).
+            now rewrite size_add_new by auto.
+          * now rewrite find_add_ne by auto.
+    Qed.
+
+    Lemma length_elements (m : FMap K V) : length (FMap.elements m) = size m.
+    Proof.
+      induction m using ind.
+      - now rewrite size_empty, elements_empty.
+      - rewrite elements_add, size_add_new by auto.
+        cbn.
+        now rewrite IHm.
+    Qed.
+
+    Lemma In_elements k v (m : FMap K V) :
+      In (k, v) (elements m) <-> find k m = Some v.
+    Proof.
+      cbn in *.
+      induction m using ind.
+      - rewrite elements_empty, find_empty.
+        split; easy.
+      - rewrite elements_add by auto.
+        destruct (stdpp.base.decide (k = k0)) as [->|?].
+        + rewrite find_add.
+          cbn.
+          split; intros.
+          * destruct H1; try congruence.
+            apply IHm in H1.
+            congruence.
+          * left; congruence.
+        + cbn.
+          rewrite find_add_ne by auto.
+          split; intros.
+          * apply IHm.
+            destruct H1; auto; congruence.
+          * tauto.
+    Qed.
+
+    Lemma elements_add_existing k vold vnew (m : FMap K V) :
+      find k m = Some vold ->
+      Permutation (elements (add k vnew m)) ((k, vnew) :: elements (remove k m)).
+    Proof.
+      intros find.
+      rewrite <- add_remove.
+      rewrite elements_add; auto.
+      apply find_remove.
+    Qed.
   End Theories.
 End FMap.
 
-Hint Resolve
-     FMap.find_union_None
-     FMap.find_union_Some_l
-     FMap.find_add
-     FMap.find_add_ne : core.
-
-Instance empty_set_eq_dec : stdpp.base.EqDecision Empty_set.
-Proof. decidable.solve_decision. Defined.
-Program Instance empty_set_countable : countable.Countable Empty_set :=
-  {| countable.encode e := 1%positive; countable.decode d := None; |}.
-Solve Obligations with contradiction.
+Hint Resolve FMap.find_add FMap.find_add_ne FMap.find_remove : core.

--- a/execution/theories/ContractMonads.v
+++ b/execution/theories/ContractMonads.v
@@ -1,0 +1,197 @@
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+Require Import Blockchain.
+Require Import Monads.
+Require Import Serializable.
+Import ListNotations.
+
+Section ContractMonads.
+Context `{ChainBase}.
+
+Definition ContractReader (T : Type) : Type :=
+  Chain -> ContractCallContext -> (Chain * ContractCallContext * T).
+
+Definition run_contract_reader
+           {T : Type}
+           (chain : Chain) (ctx : ContractCallContext)
+           (m : ContractReader T) : T :=
+  let '(_, _, result) := m chain ctx in result.
+
+Global Instance contract_reader_monad : Monad ContractReader :=
+  {| ret _ x chain ctx := (chain, ctx, x);
+     bind _ _ prev f chain ctx :=
+       let '(chain, ctx, res) := prev chain ctx in
+       f res chain ctx; |}.
+
+Global Instance contract_reader_laws : MonadLaws contract_reader_monad.
+Proof.
+  constructor.
+  - reflexivity.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _) as [[? ?] ?]; auto.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _) as [[? ?] ?]; auto.
+Qed.
+
+Definition ContractIniter (Setup T : Type) : Type :=
+  Chain -> ContractCallContext -> Setup ->
+  (Chain * ContractCallContext * Setup * option T).
+
+Definition run_contract_initer
+           {Setup T : Type}
+           (m : ContractIniter Setup T)
+           (chain : Chain) (ctx : ContractCallContext) (setup : Setup) : option T :=
+  let '(_, _, _, result) := m chain ctx setup in result.
+
+Global Arguments run_contract_initer {_ _} _ /.
+
+Global Instance contract_initer_monad (Setup : Type) : Monad (ContractIniter Setup) :=
+  {| ret _ x chain ctx setup := (chain, ctx, setup, Some x);
+     bind _ _ prev f chain ctx setup :=
+       let '(chain, ctx, setup, res) := prev chain ctx setup in
+       match res with
+       | Some res => f res chain ctx setup
+       | None => (chain, ctx, setup, None)
+       end; |}.
+
+Global Instance contract_initer_laws
+       (Setup : Type) : MonadLaws (contract_initer_monad Setup).
+Proof.
+  constructor.
+  - reflexivity.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _ _) as [[[[? ?] ?] ?] []]; auto.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _ _) as [[[[? ?] ?] ?] []]; auto.
+Qed.
+
+Global Instance contract_reader_to_contract_initer
+       {Setup : Type} : MonadTrans (ContractIniter Setup) ContractReader :=
+  {| lift _ (reader : ContractReader _) chain ctx setup :=
+       let '(chain, ctx, res) := reader chain ctx in
+       (chain, ctx, setup, Some res) |}.
+
+Global Instance option_to_contract_initer
+       {Setup : Type} : MonadTrans (ContractIniter Setup) option :=
+  {| lift _ (opt : option _) chain ctx setup := (chain, ctx, setup, opt) |}.
+
+Definition ContractReceiver (State Msg T : Type) : Type :=
+  Chain -> ContractCallContext -> State -> option Msg -> list ActionBody ->
+  (Chain * ContractCallContext * State * option Msg * list ActionBody * option T).
+
+Global Instance contract_receiver_monad (State Msg : Type) : Monad (ContractReceiver State Msg) :=
+  {| ret _ x chain ctx state msg acts := (chain, ctx, state, msg, acts, Some x);
+     bind _ _ prev f chain ctx state msg acts :=
+       let '(chain, ctx, state, msg, acts, res) := prev chain ctx state msg acts in
+       match res with
+       | Some res => f res chain ctx state msg acts
+       | None => (chain, ctx, state, msg, acts, None)
+       end |}.
+
+Definition run_contract_receiver
+           {State Msg T : Type}
+           (m : ContractReceiver State Msg T)
+           (chain : Chain) (ctx : ContractCallContext) (state : State) (msg : option Msg)
+           : option (T * list ActionBody) :=
+  let '(_, _, _, _, acts, result) := m chain ctx state msg [] in
+  option_map (fun result => (result, acts)) result.
+
+Global Arguments run_contract_receiver {_ _ _} _ /.
+
+Global Instance contract_receiver_laws
+       (State Msg : Type) : MonadLaws (contract_receiver_monad State State).
+Proof.
+  constructor.
+  - reflexivity.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _ _ _ _) as [[[[[? ?] ?] ?] ?] []]; auto.
+  - intros; cbn.
+    repeat (apply functional_extensionality; intros).
+    destruct (t _ _ _ _ _) as [[[[[? ?] ?] ?] ?] []]; auto.
+Qed.
+
+Global Instance contract_reader_to_receiver
+       {State Msg : Type} : MonadTrans (ContractReceiver State Msg) ContractReader :=
+  {| lift _ (reader : ContractReader _) chain ctx state msg acts :=
+       let '(chain, ctx, res) := reader chain ctx in
+       (chain, ctx, state, msg, acts, Some res) |}.
+
+Global Instance option_to_contract_receiver
+       {State Msg : Type} : MonadTrans (ContractReceiver State Msg) option :=
+  {| lift _ (opt : option _) chain ctx state msg acts := (chain, ctx, state, msg, acts, opt) |}.
+
+Definition chain_height : ContractReader nat :=
+  fun chain ctx => (chain, ctx, chain_height chain).
+
+Definition current_slot : ContractReader nat :=
+  fun chain ctx => (chain, ctx, current_slot chain).
+
+Definition finalized_height : ContractReader nat :=
+  fun chain ctx => (chain, ctx, finalized_height chain).
+
+Definition account_balance (addr : Address) : ContractReader Amount :=
+  fun chain ctx => (chain, ctx, account_balance chain addr).
+
+Definition caller_addr : ContractReader Address :=
+  fun chain ctx => (chain, ctx, ctx_from ctx).
+
+Definition my_addr : ContractReader Address :=
+  fun chain ctx => (chain, ctx, ctx_contract_address ctx).
+
+Definition call_amount : ContractReader Amount :=
+  fun chain ctx => (chain, ctx, ctx_amount ctx).
+
+Definition deployment_setup {Setup : Type}
+  : ContractIniter Setup Setup :=
+  fun chain ctx setup => (chain, ctx, setup, Some setup).
+
+Definition reject_deployment {Setup State : Type}
+  : ContractIniter Setup State :=
+  fun chain ctx setup => (chain, ctx, setup, None).
+
+Definition accept_deployment
+           {Setup State : Type} (state : State) : ContractIniter Setup State :=
+  ret state.
+
+Definition call_msg
+           {State Msg : Type} : ContractReceiver State Msg (option Msg) :=
+  fun chain ctx state msg acts => (chain, ctx, state, msg, acts, Some msg).
+
+Definition my_state
+           {State Msg : Type} : ContractReceiver State Msg State :=
+  fun chain ctx state msg acts => (chain, ctx, state, msg, acts, Some state).
+
+Definition queue
+           {State Msg : Type} (act : ActionBody) : ContractReceiver State Msg unit :=
+  fun chain ctx state msg acts => (chain, ctx, state, msg, acts ++ [act], Some tt).
+
+Definition reject_call
+           {State Msg : Type} : ContractReceiver State Msg State :=
+  fun chain ctx state msg acts => (chain, ctx, state, msg, [], None).
+
+Definition accept_call
+           {State Msg : Type} (new_state : State) : ContractReceiver State Msg State :=
+  fun chain ctx state msg acts => (chain, ctx, state, msg, acts, Some new_state).
+
+Definition build_contract
+           {Setup Msg State : Type}
+           `{Serializable Setup} `{Serializable Msg} `{Serializable State}
+           (init : ContractIniter Setup State)
+           (receive : ContractReceiver State Msg State)
+           (init_proper :
+              Proper (ChainEquiv ==> eq ==> eq ==> eq) (run_contract_initer init))
+           (receive_proper :
+              Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) (run_contract_receiver receive))
+  : Contract Setup Msg State :=
+  {| init := (run_contract_initer init);
+     receive := (run_contract_receiver receive);
+     init_proper := init_proper;
+     receive_proper := receive_proper; |}.
+
+End ContractMonads.

--- a/execution/theories/Egcd.v
+++ b/execution/theories/Egcd.v
@@ -1,0 +1,179 @@
+From Coq Require Import List.
+From Coq Require Import Psatz.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+Import ListNotations.
+
+Local Open Scope Z.
+
+Fixpoint egcd_aux
+        (n : nat)
+        (r0 a0 b0 r1 a1 b1 : Z) {struct n} : Z * Z :=
+  match n with
+  | 0%nat => (0, 0)
+  | S n => let (q, r) := Z.div_eucl r0 r1 in
+           if r =? 0 then
+             (a1, b1)
+           else
+             egcd_aux n r1 a1 b1 r (a0 - q*a1) (b0 - q*b1)
+  end.
+
+(* returns (x, y) such that x*m + y*n = Z.gcd(x, y) *)
+Definition egcd (m n : Z) : Z * Z :=
+  if m =? 0 then
+    (0, Z.sgn n)
+  else if n =? 0 then
+    (Z.sgn m, 0)
+  else
+    let num_steps := S (Z.to_nat (Z.log2 (Z.abs m) + Z.log2 (Z.abs n))) in
+    if Z.abs m <? Z.abs n then
+      let (x, y) := egcd_aux num_steps (Z.abs n) 1 0 (Z.abs m) 0 1 in
+      (Z.sgn m * y, Z.sgn n * x)
+    else
+      let (x, y) := egcd_aux num_steps (Z.abs m) 1 0 (Z.abs n) 0 1 in
+      (Z.sgn m * x, Z.sgn n * y).
+
+Lemma egcd_aux_spec m n steps r0 a0 b0 r1 a1 b1 :
+  Z.log2 r0 + Z.log2 r1 < Z.of_nat steps ->
+  0 < r1 ->
+  r1 <= r0 ->
+  r0 = a0*m + b0*n ->
+  r1 = a1*m + b1*n ->
+  Z.gcd r0 r1 = Z.gcd m n ->
+  let (x, y) := egcd_aux steps r0 a0 b0 r1 a1 b1 in
+  x*m + y*n = Z.gcd m n.
+Proof.
+  revert r0 a0 b0 r1 a1 b1.
+  induction steps as [|steps IH];
+    intros r0 a0 b0 r1 a1 b1 enough_steps r1pos r1gt r0eq r1eq is_gcd.
+  {
+    cbn -[Z.add] in enough_steps.
+    pose proof (Z.log2_nonneg r0).
+    pose proof (Z.log2_nonneg r1).
+    lia.
+  }
+  cbn.
+  pose proof (Z_div_mod r0 r1 ltac:(lia)).
+  destruct (Z.div_eucl r0 r1) as [q r].
+  destruct (Z.eqb_spec r 0) as [->|?].
+  - destruct H.
+    rewrite Z.add_0_r in *.
+    rewrite <- r1eq.
+    rewrite <- is_gcd.
+    rewrite H.
+    rewrite Z.gcd_comm.
+    now rewrite Z.gcd_mul_diag_l by lia.
+  - apply IH; auto.
+    + destruct H.
+      destruct q; try lia; cycle 1.
+      {
+        pose proof (Z.mul_pos_neg r1 (Z.neg p) ltac:(lia) ltac:(lia)).
+        lia.
+      }
+      assert (r + r1 <= r0).
+      {
+        enough (r1 <= r1 * Z.pos p) by lia.
+        apply Z.le_mul_diag_r; lia.
+      }
+      assert (Z.log2 r1 + Z.log2 r < Z.log2 r0 + Z.log2 r1).
+      {
+        enough (Z.log2 r < Z.log2 r0) by lia.
+        pose proof (Z.log2_le_mono (r*2^1) r0 ltac:(lia)).
+        rewrite <- Z.shiftl_mul_pow2 in H2 by lia.
+        rewrite Z.log2_shiftl in H2 by lia.
+        lia.
+      }
+      lia.
+    + lia.
+    + lia.
+    + rewrite !Z.mul_sub_distr_r.
+      replace (a0 * m - q * a1 * m + (b0 * n - q * b1 * n))
+        with (a0 * m + b0*n + (-1) * (q*(a1*m + b1*n)))
+        by lia.
+      rewrite <- r0eq, <-r1eq.
+      lia.
+    + rewrite <- is_gcd.
+      rewrite (proj1 H).
+      rewrite (Z.gcd_comm (r1 * q + r)).
+      rewrite Z.add_comm, Z.mul_comm.
+      now rewrite Z.gcd_add_mult_diag_r.
+Qed.
+
+Lemma egcd_spec m n :
+  let (x, y) := egcd m n in
+  m*x + n*y = Z.gcd m n.
+Proof.
+  unfold egcd.
+  destruct (Z.eqb_spec m 0) as [->|?].
+  { apply Z.sgn_abs. }
+  destruct (Z.eqb_spec n 0) as [->|?].
+  { rewrite Z.gcd_0_r, Z.add_0_r; apply Z.sgn_abs. }
+  pose proof (Z.log2_nonneg (Z.abs m)).
+  pose proof (Z.log2_nonneg (Z.abs n)).
+  destruct (Z.ltb_spec (Z.abs m) (Z.abs n)).
+  - unshelve epose proof (egcd_aux_spec
+                            (Z.abs n) (Z.abs m)
+                            (S (Z.to_nat (Z.log2 (Z.abs m) + Z.log2 (Z.abs n))))
+                            (Z.abs n) 1 0
+                            (Z.abs m) 0 1
+                            _ _ _ _ _ _); try lia.
+    + rewrite Nat2Z.inj_succ.
+      rewrite Z2Nat.id by lia.
+      lia.
+    + destruct (egcd_aux _ _ _ _ _ _ _).
+      rewrite !Z.mul_assoc.
+      rewrite Z.gcd_abs_l, Z.gcd_comm, Z.gcd_abs_l in H2.
+      rewrite !Z.sgn_abs.
+      lia.
+  - unshelve epose proof (egcd_aux_spec
+                            (Z.abs m) (Z.abs n)
+                            (S (Z.to_nat (Z.log2 (Z.abs m) + Z.log2 (Z.abs n))))
+                            (Z.abs m) 1 0
+                            (Z.abs n) 0 1
+                            _ _ _ _ _ _); try lia.
+    + rewrite Nat2Z.inj_succ.
+      rewrite Z2Nat.id by lia.
+      lia.
+    + destruct (egcd_aux _ _ _ _ _ _ _).
+      rewrite !Z.mul_assoc.
+      rewrite Z.gcd_abs_l, Z.gcd_comm, Z.gcd_abs_l, Z.gcd_comm in H2.
+      rewrite !Z.sgn_abs.
+      lia.
+Qed.
+
+Lemma mul_fst_egcd a n :
+  rel_prime a n ->
+  a * fst (egcd a n) mod n = 1 mod n.
+Proof.
+  destruct (Z.eqb_spec n 0) as [->|?].
+  { intros; now rewrite !Zmod_0_r. }
+  intros relprime.
+  pose proof (egcd_spec a n).
+  destruct (egcd a n) as [x y]; cbn.
+  rewrite (proj2 (Zgcd_1_rel_prime _ _) relprime) in H.
+  replace (a * x) with (1  + (-y)*n) by lia.
+  rewrite <- Z.add_mod_idemp_r by lia.
+  now rewrite Z.mod_mul, Z.add_0_r by lia.
+Qed.
+
+Lemma egcd_divides a b :
+  b <> 0 ->
+  (b | a) ->
+  egcd a b = (0, Z.sgn b).
+Proof.
+  intros b0 divides.
+  unfold egcd.
+  destruct (Z.eqb_spec a 0) as [->|a0]; [easy|].
+  rewrite (proj2 (Z.eqb_neq _ _) b0).
+  assert (Z.abs b <= Z.abs a) by (apply Zdivide_bounds; auto).
+  replace (Z.abs a <? Z.abs b) with false; cycle 1.
+  { now symmetry; apply Z.ltb_ge. }
+  cbn.
+  pose proof (Z_div_mod_full (Z.abs a) (Z.abs b) ltac:(lia)).
+  destruct (Z.div_eucl (Z.abs a) (Z.abs b)) as [q r].
+  rewrite (Zmod_unique_full _ _ _ _ (proj2 H0) (proj1 H0)).
+  apply Z.divide_abs_l, Z.divide_abs_r in divides.
+  rewrite (Zdivide_mod _ _ divides).
+  cbn.
+  now rewrite Z.mul_0_r, Z.mul_1_r.
+Qed.

--- a/execution/theories/Euler.v
+++ b/execution/theories/Euler.v
@@ -1,0 +1,251 @@
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+From Coq Require Import Permutation.
+From Coq Require Import Psatz.
+From Coq Require Import Sorted.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+Require Import Extras.
+Import ListNotations.
+
+Definition rel_primes (n : nat) : list Z :=
+  filter (fun z => Z.gcd z (Z.of_nat n) =? 1) (map Z.of_nat (seq 0 n)).
+
+Definition totient (n : nat) : nat :=
+  length (rel_primes n).
+
+Lemma In_rel_primes z n :
+  In z (rel_primes n) <->
+  rel_prime z (Z.of_nat n) /\
+  0 <= z < Z.of_nat n.
+Proof.
+  split.
+  - intros isin.
+    unfold rel_primes in isin.
+    apply filter_In in isin.
+    destruct isin as [inseq isin].
+    apply Z.eqb_eq in isin.
+    split.
+    + apply Zgcd_1_rel_prime; auto.
+    + apply in_map_iff in inseq.
+      destruct inseq as [i [ieq inseq]].
+      apply in_seq in inseq.
+      lia.
+  - intros [isrelprime bound].
+    unfold rel_primes.
+    apply filter_In.
+    split; cycle 1.
+    + apply Z.eqb_eq.
+      apply Zgcd_1_rel_prime; auto.
+    + apply in_map_iff.
+      exists (Z.to_nat z).
+      rewrite Z2Nat.id by lia.
+      split; auto.
+      apply in_seq.
+      split; [lia|].
+      apply Nat2Z.inj_lt.
+      rewrite Z2Nat.id by lia.
+      lia.
+Qed.
+
+Lemma NoDup_rel_primes n :
+  NoDup (rel_primes n).
+Proof.
+  unfold rel_primes.
+  apply NoDup_filter.
+  apply NoDup_map.
+  - apply seq_NoDup.
+  - intros a a' _ _.
+    apply Nat2Z.inj.
+Qed.
+
+Lemma mul_both_r_mod r a a' n :
+  rel_prime r n ->
+  a * r mod n = a' * r mod n ->
+  a mod n = a' mod n.
+Proof.
+  destruct (Z.eqb_spec n 0) as [->|?].
+  { now rewrite !Zmod_0_r. }
+  intros rel eq.
+  rewrite <- (Z.mul_1_r a), <- (Z.mul_1_r a').
+  rewrite <- (Z.mul_mod_idemp_r a), <- (Z.mul_mod_idemp_r a') by lia.
+  destruct (rel_prime_bezout _ _ rel).
+  rewrite <- H.
+  rewrite !Z.mul_mod_idemp_r by auto.
+  rewrite !Z.mul_add_distr_l, !Z.mul_assoc.
+  rewrite !Z_mod_plus_full.
+  replace (a * u * r) with (a * r * u) by lia.
+  replace (a' * u * r) with (a' * r * u) by lia.
+  rewrite <- Z.mul_mod_idemp_l, <- (Z.mul_mod_idemp_l (a' * r)) by auto.
+  now rewrite eq.
+Qed.
+
+Fixpoint prod (l : list Z) : Z :=
+  match l with
+  | [] => 1
+  | x :: xs => x * prod xs
+  end.
+
+Instance prod_perm_proper : Proper (@Permutation Z ==> eq) prod.
+Proof.
+  intros l l' perm.
+  induction perm; cbn; try lia.
+  now rewrite IHperm.
+Qed.
+
+Lemma rel_prime_prod l n :
+  Forall (fun x => rel_prime x n) l ->
+  rel_prime (prod l) n.
+Proof.
+  intros all.
+  induction l as [|x xs IH].
+  - cbn.
+    apply rel_prime_1.
+  - cbn.
+    inversion all; subst.
+    apply rel_prime_sym.
+    apply rel_prime_mult;
+      apply rel_prime_sym; auto.
+Qed.
+
+Lemma euler a n :
+  n >= 0 ->
+  rel_prime a n ->
+  a^(Z.of_nat (totient (Z.to_nat n))) mod n = 1 mod n.
+Proof.
+  destruct (Z.eqb_spec n 0) as [->|?].
+  { now rewrite !Zmod_0_r. }
+
+  intros ge0 relan.
+  set (rprimes := rel_primes (Z.to_nat n)).
+  assert (Permutation (map (fun ai => ai * a mod n) rprimes) rprimes).
+  {
+    symmetry.
+    apply NoDup_Permutation.
+    - apply NoDup_rel_primes.
+    - apply NoDup_map; [apply NoDup_rel_primes|].
+      intros.
+      apply In_rel_primes in H.
+      apply In_rel_primes in H0.
+      destruct H as [_ H], H0 as [_ H0].
+      rewrite !Z2Nat.id in * by lia.
+      rewrite <- (Z.mod_small a0 n), <- (Z.mod_small a' n) by lia.
+      now apply (mul_both_r_mod a).
+    - intros x.
+      split; intros isin.
+      + apply in_map_iff.
+        destruct (proj1 (In_rel_primes _ _) isin) as [isrelprime bound].
+        rewrite Z2Nat.id in * by lia.
+        destruct (rel_prime_bezout _ _ relan).
+        exists (x * u mod n).
+        split.
+        * rewrite Z.mul_mod_idemp_l by lia.
+          rewrite <- Z.mul_assoc.
+          replace (u * a) with (1 + n*(-v)) by lia.
+          replace (x * (1 + n * (-v))) with (x + (x * (-v)) * n) by lia.
+          rewrite Z_mod_plus_full.
+          apply Z.mod_small; lia.
+        * apply In_rel_primes.
+          rewrite Z2Nat.id by lia.
+          split; [|pose proof (Z.mod_pos_bound (x * u) n); lia].
+          apply rel_prime_mod; [lia|].
+          apply rel_prime_sym.
+          apply rel_prime_mult; [now apply rel_prime_sym|].
+          apply rel_prime_sym.
+          apply bezout_rel_prime.
+          apply (Bezout_intro u n 1 a v).
+          lia.
+      + apply in_map_iff in isin.
+        destruct isin as [x' [<- inx']].
+        apply In_rel_primes.
+        apply In_rel_primes in inx'.
+        rewrite Z2Nat.id in * by lia.
+        split; [|pose proof (Z.mod_pos_bound (x' * a) n); lia].
+        apply rel_prime_mod; [lia|].
+        now
+          apply rel_prime_sym, rel_prime_mult;
+          apply rel_prime_sym.
+  }
+
+  unfold totient.
+  apply (mul_both_r_mod (prod rprimes)).
+  {
+    apply rel_prime_prod.
+    apply Forall_forall.
+    intros x xin.
+    apply In_rel_primes in xin.
+    now rewrite Z2Nat.id in xin by lia.
+  }
+
+  rewrite Z.mul_1_l.
+  subst rprimes; cbn.
+  rewrite <- H at 3.
+  clear -n0.
+  induction (rel_primes (Z.to_nat n)) as [|x xs IH]; [easy|].
+  cbn.
+  rewrite Z.pow_pos_fold.
+  rewrite Zpos_P_of_succ_nat.
+  rewrite <- Z.add_1_r.
+  rewrite Z.pow_add_r by lia.
+  replace (a ^ Z.of_nat (length xs) * a^1 * (x * prod xs))
+    with (x * a * (a ^ Z.of_nat (length xs) * prod xs))
+    by lia.
+  rewrite Z.mul_mod by auto.
+  rewrite IH.
+  now rewrite Z.mul_mod_idemp_r by auto.
+Qed.
+
+Lemma prime_rel_primes p :
+  prime p ->
+  rel_primes (Z.to_nat p) = map Z.of_nat (seq 1 (Z.to_nat p - 1)).
+Proof.
+  intros isprime.
+  pose proof (prime_ge_2 _ isprime).
+  assert (0 < Z.to_nat p)%nat.
+  { apply Nat2Z.inj_lt; cbn; rewrite Z2Nat.id; lia. }
+  unfold rel_primes.
+  replace (Z.to_nat p) with (1 + (Z.to_nat p - 1))%nat at 1 by lia.
+  rewrite seq_app.
+  cbn.
+  rewrite Z2Nat.id by lia.
+  destruct (Z.eqb_spec (Z.abs p) 1); [lia|].
+  rewrite filter_map.
+  rewrite filter_all; [easy|].
+  intros a ain.
+  apply Z.eqb_eq, Zgcd_1_rel_prime, rel_prime_le_prime; auto.
+  apply in_seq in ain.
+  split; [lia|].
+  apply Z2Nat.inj_lt; try lia.
+  rewrite Nat2Z.id.
+  lia.
+Qed.
+
+Lemma prime_totient p :
+  prime p -> Z.of_nat (totient (Z.to_nat p)) = p - 1.
+Proof.
+  intros isprime.
+  pose proof (prime_ge_2 _ isprime).
+  unfold totient.
+  rewrite prime_rel_primes by auto.
+  rewrite map_length, seq_length.
+  rewrite Nat2Z.inj_sub; cycle 1.
+  { apply Nat2Z.inj_le; rewrite Z2Nat.id; lia. }
+  rewrite Z2Nat.id by lia.
+  lia.
+Qed.
+
+Corollary fermat a p :
+  prime p ->
+  a mod p <> 0 ->
+  a^(p - 1) mod p = 1.
+Proof.
+  intros isprime ap0.
+  pose proof (prime_ge_2 _ isprime).
+  rewrite <- (Z.mod_1_l p) at 2 by lia.
+  rewrite <- prime_totient by auto.
+  apply euler; [lia|].
+  apply rel_prime_sym, prime_rel_prime; auto.
+  intros pdividea.
+  contradiction ap0.
+  now apply Zdivide_mod.
+Qed.

--- a/execution/theories/Extras.v
+++ b/execution/theories/Extras.v
@@ -9,16 +9,6 @@ From Coq Require Import Eqdep_dec.
 Require Import Automation.
 Import ListNotations.
 
-Fixpoint find_first {A B : Type} (f : A -> option B) (l : list A)
-  : option B :=
-  match l with
-  | hd :: tl => match f hd with
-                | Some b => Some b
-                | None => find_first f tl
-                end
-  | [] => None
-  end.
-
 Fixpoint map_option {A B : Type} (f : A -> option B) (l : list A)
   : list B :=
   match l with
@@ -56,17 +46,6 @@ Fixpoint sumnat {A : Type} (f : A -> nat) (xs : list A) : nat :=
   | x :: xs' => f x + sumnat f xs'
   end.
 
-Lemma sumnat_app
-      {A : Type} {f : A -> nat} {xs ys : list A} :
-  sumnat f (xs ++ ys) = sumnat f xs + sumnat f ys.
-Proof.
-  revert ys.
-  induction xs as [| x xs IH]; intros ys; auto.
-  cbn.
-  rewrite IH.
-  lia.
-Qed.
-
 Lemma sumnat_permutation
       {A : Type} {f : A -> nat} {xs ys : list A}
       (perm_eq : Permutation xs ys) :
@@ -76,6 +55,15 @@ Proof. induction perm_eq; perm_simplify; lia. Qed.
 Instance sumnat_perm_proper {A : Type} :
   Proper (eq ==> Permutation (A:=A) ==> eq) sumnat.
 Proof. repeat intro. subst. now apply sumnat_permutation. Qed.
+
+Lemma sumnat_map {A B : Type} (f : A -> B) (g : B -> nat) (xs : list A) :
+  sumnat g (map f xs) =
+  sumnat (fun a => g (f a)) xs.
+Proof.
+  induction xs as [|hd tl IH]; auto.
+  cbn.
+  now rewrite IH.
+Qed.
 
 Lemma sumZ_permutation
       {A : Type} {f : A -> Z} {xs ys : list A}
@@ -119,16 +107,10 @@ Proof.
   now rewrite IH.
 Qed.
 
-Lemma in_app_cons_or {A : Type} (x y : A) (xs ys : list A) :
-  x <> y ->
-  In x (xs ++ y :: ys) ->
-  In x (xs ++ ys).
+Lemma sumZ_mul (f : Z -> Z) (l : list Z) (z : Z) :
+  z * sumZ f l = sumZ (fun z' => z * f z') l.
 Proof.
-  intros x_neq_y x_in.
-  apply in_or_app.
-  apply in_app_or in x_in.
-  destruct x_in as [?|x_in]; auto.
-  destruct x_in; auto; congruence.
+  induction l; auto; cbn in *; lia.
 Qed.
 
 Lemma incl_split {A : Type} (l m n : list A) :
@@ -193,16 +175,6 @@ Proof.
     rewrite IH.
     f_equal; f_equal; f_equal.
     lia.
-Qed.
-
-Lemma sumZ_seq_S f start len :
-  sumZ f (seq start (S len)) = sumZ f (seq start len) + f (start + len)%nat.
-Proof.
-  replace (S len) with (len + 1)%nat by lia.
-  rewrite (seq_app start len 1).
-  rewrite sumZ_app.
-  cbn.
-  lia.
 Qed.
 
 Lemma forall_respects_permutation {A} (xs ys : list A) P :
@@ -288,16 +260,6 @@ Proof.
   destruct (pred hd); auto.
 Qed.
 
-Lemma filter_filter {A : Type} (f g : A -> bool) (l : list A) :
-  filter f (filter g l) = filter (fun a => (f a && g a)%bool) l.
-Proof.
-  induction l as [|? ? IH]; auto.
-  cbn.
-  destruct (f a) eqn:fa, (g a); auto.
-  - cbn. now rewrite IH, fa.
-  - cbn. now rewrite IH, fa.
-Qed.
-
 Lemma filter_map {A B : Type} (f : A -> B) (pred : B -> bool) (l : list A) :
   filter pred (map f l) =
   map f (filter (fun a => pred (f a)) l).
@@ -332,4 +294,385 @@ Proof.
     destruct (pred x), (pred y); auto.
     constructor.
   - rewrite IHperm1; auto.
+Qed.
+
+Fixpoint zip {X Y} (xs : list X) (ys : list Y) : list (X * Y) :=
+  match xs, ys with
+  | x :: xs, y :: ys => (x, y) :: zip xs ys
+  | _, _ => []
+  end.
+
+Lemma zip_app {X Y} (xs xs' : list X) (ys ys' : list Y) :
+  length xs = length ys ->
+  zip (xs ++ xs') (ys ++ ys') = zip xs ys ++ zip xs' ys'.
+Proof.
+  intros len_xs.
+  revert xs' ys ys' len_xs.
+  induction xs as [|x xs IH]; intros xs' ys ys' len_xs; cbn.
+  - destruct ys; cbn in *; congruence.
+  - destruct ys as [|y ys]; cbn in *; try lia.
+    apply f_equal.
+    apply IH; lia.
+Qed.
+
+Lemma zip_map {A B C D} (f : A -> B) (g : C -> D) (xs : list A) (ys : list C) :
+  zip (map f xs) (map g ys) =
+  map (fun '(x, y) => (f x, g y)) (zip xs ys).
+Proof.
+  revert f g ys.
+  induction xs as [|x xs IH]; intros f g ys; cbn; auto.
+  destruct ys as [|y ys]; cbn; auto.
+  f_equal.
+  auto.
+Qed.
+
+Lemma existsb_forallb {A} f (l : list A) :
+  existsb f l = negb (forallb (fun x => negb (f x)) l).
+Proof.
+  induction l as [|x xs IH]; auto.
+  cbn.
+  now rewrite IH, Bool.negb_andb, Bool.negb_involutive.
+Qed.
+
+Fixpoint All {A} (f : A -> Prop) (l : list A) : Prop :=
+  match l with
+  | [] => True
+  | x :: xs => f x /\ All f xs
+  end.
+
+Lemma All_app {A} f (l l' : list A) :
+  All f (l ++ l') <-> All f l /\ All f l'.
+Proof.
+  revert l'.
+  induction l as [|x xs IH]; intros l'; cbn; firstorder.
+Qed.
+
+Lemma All_map {A B} (g : B -> Prop) (f : A -> B) (l : list A) :
+  All g (map f l) <-> All (fun a => g (f a)) l.
+Proof.
+  induction l as [|x xs IH]; cbn; [tauto|].
+  tauto.
+Qed.
+
+Lemma All_ext_in {A} (f g : A -> Prop) (l : list A) :
+  All f l ->
+  (forall a, In a l -> f a -> g a) ->
+  All g l.
+Proof.
+  induction l as [|x xs IH]; intros all fall; cbn in *; intuition.
+Qed.
+
+Local Open Scope nat.
+Lemma sumZ_seq_n (f : nat -> Z) n len :
+  sumZ f (seq n len) =
+  sumZ (fun i => f (i + n)) (seq 0 len).
+Proof.
+  revert n f.
+  induction len as [|len IH]; intros n f; auto.
+  cbn.
+  apply f_equal.
+  rewrite (IH 1), (IH (S n)).
+  clear.
+  induction (seq 0 len); auto.
+  cbn.
+  rewrite IHl.
+  now replace (a + 1 + n) with (a + S n) by lia.
+Qed.
+
+Lemma sumZ_zero {A} (l : list A) :
+  sumZ (fun _ => 0%Z) l = 0%Z.
+Proof. induction l; auto. Qed.
+
+Lemma sumZ_seq_feq (f g : nat -> Z) len :
+  (forall i, i < len -> f i = g i)%nat ->
+  sumZ g (seq 0 len) = sumZ f (seq 0 len).
+Proof.
+  revert f g.
+  induction len as [|len IH]; intros f g all_same; auto.
+  cbn.
+  rewrite 2!(sumZ_seq_n _ 1).
+  rewrite (all_same 0%nat ltac:(lia)).
+  apply f_equal.
+  apply IH.
+  intros i lt.
+  now specialize (all_same (i + 1)%nat ltac:(lia)).
+Qed.
+
+Lemma sumZ_firstn {A} default (f : A -> Z) n l :
+  (n <= length l \/ f default = 0%Z) ->
+  sumZ f (firstn n l) =
+  sumZ (fun i => f (nth i l default)) (seq 0 n).
+Proof.
+  revert l.
+  induction n as [|n IH]; intros l le; auto.
+  cbn.
+  rewrite sumZ_seq_n.
+  destruct l; cbn in *.
+  - destruct le; [lia|].
+    rewrite H.
+    clear -H.
+    rewrite (sumZ_seq_feq (fun i : nat => 0%Z)).
+    + now rewrite sumZ_zero.
+    + intros i ?; destruct (i + 1); now rewrite H.
+  - apply f_equal.
+    rewrite IH by lia.
+    apply sumZ_seq_feq.
+    intros i.
+    intros lt.
+    destruct (i + 1) eqn:i1; [lia|].
+    now replace n0 with i by lia.
+Qed.
+
+Lemma sumZ_skipn {A} default (f : A -> Z) n l :
+  sumZ f (skipn n l) =
+  sumZ (fun i => f (nth (n + i) l default)) (seq 0 (length l - n)).
+Proof.
+  revert l.
+  induction n as [|n IH]; intros l; cbn.
+  - rewrite Nat.sub_0_r.
+    rewrite <- (sumZ_firstn default).
+    + now rewrite firstn_all.
+    + left; lia.
+  - destruct l; auto.
+    cbn.
+    apply IH.
+Qed.
+
+Local Open Scope Z.
+Lemma sumZ_add {A} (f g : A -> Z) l :
+  sumZ (fun a => f a + g a) l = sumZ f l + sumZ g l.
+Proof.
+  induction l; auto; cbn in *; lia.
+Qed.
+Lemma sumZ_sub {A} (f g : A -> Z) l :
+  sumZ (fun a => f a - g a) l =
+  sumZ f l - sumZ g l.
+Proof.
+  induction l; auto; cbn; lia.
+Qed.
+
+Lemma sumZ_seq_split split_len (f : nat -> Z) start len :
+  (split_len <= len)%nat ->
+  sumZ f (seq start len) =
+  sumZ f (seq start split_len) + sumZ f (seq (start + split_len) (len - split_len)).
+Proof.
+  rewrite <- sumZ_app.
+  rewrite <- seq_app.
+  intros le.
+  now replace (split_len + (len - split_len))%nat with len by lia.
+Qed.
+
+Lemma sumZ_sumZ_swap {A B} (f : A -> B -> Z) (xs : list A) (ys : list B) :
+  sumZ (fun a => sumZ (f a) (ys)) xs =
+  sumZ (fun b => sumZ (fun a => f a b) xs) ys.
+Proof.
+  revert ys.
+  induction xs as [|x xs IH]; intros ys; cbn.
+  - now rewrite sumZ_zero.
+  - rewrite IH.
+    clear IH.
+    induction ys as [|y ys IH]; cbn; auto.
+    rewrite <- IH.
+    lia.
+Qed.
+
+Lemma All_Forall {A} (l : list A) f :
+  All f l <-> Forall f l.
+Proof.
+  induction l.
+  - split; cbn; auto.
+  - split; cbn.
+    + intros [fa all].
+      constructor; tauto.
+    + intros all.
+      inversion all; tauto.
+Qed.
+
+Lemma all_incl {A} (l l' : list A) f :
+  incl l l' -> All f l' -> All f l.
+Proof.
+  intros incl all.
+  apply All_Forall.
+  apply All_Forall in all.
+  apply Forall_forall.
+  pose proof (Forall_forall f l').
+  firstorder.
+Qed.
+
+Lemma firstn_incl {A} n (l : list A) : incl (firstn n l) l.
+Proof.
+  unfold incl.
+  intros a.
+  revert l.
+  induction n as [|n IH]; intros l isin; try contradiction.
+  cbn in *.
+  destruct l; try contradiction.
+  cbn in *.
+  destruct isin; try tauto.
+  right.
+  auto.
+Qed.
+
+Lemma skipn_incl {A} n (l : list A) : incl (skipn n l) l.
+Proof.
+  unfold incl.
+  intros a.
+  revert l.
+  induction n as [|n IH]; intros l isin; auto.
+  cbn in *.
+  destruct l; try contradiction.
+  cbn in *.
+  right; auto.
+Qed.
+
+Lemma sumZ_seq_feq_rel (f g : nat -> Z) len (R : Z -> Z -> Prop) :
+  Reflexive R ->
+  Proper (R ==> R ==> R) Z.add ->
+  (forall i, i < len -> R (f i) (g i))%nat ->
+  R (sumZ f (seq 0 len)) (sumZ g (seq 0 len)).
+Proof.
+  intros refl proper all_same.
+  revert f g all_same.
+  induction len as [|len IH]; intros f g all_same; auto.
+  cbn.
+  rewrite 2!(sumZ_seq_n _ 1).
+  apply proper.
+  - apply all_same; lia.
+  - apply IH.
+    intros i ilt.
+    now specialize (all_same (i + 1)%nat ltac:(lia)).
+Qed.
+
+Lemma sumZ_map_id {A} (f : A -> Z) l :
+  sumZ f l = sumZ id (map f l).
+Proof.
+  induction l; cbn; auto.
+  unfold id.
+  now rewrite IHl.
+Qed.
+
+Lemma firstn_map {A B} (f : A -> B) n l :
+  firstn n (map f l) = map f (firstn n l).
+Proof.
+  revert l.
+  induction n; intros l; cbn; auto.
+  destruct l; cbn; auto.
+  apply f_equal.
+  auto.
+Qed.
+
+Lemma skipn_map {A B} (f : A -> B) n l :
+  skipn n (map f l) = map f (skipn n l).
+Proof.
+  revert l.
+  induction n; intros l; cbn; auto.
+  destruct l; cbn; auto.
+Qed.
+
+Lemma map_nth_alt {A B} n (l : list A) (f : A -> B) d1 d2 :
+  (n < length l)%nat ->
+  nth n (map f l) d1 = f (nth n l d2).
+Proof.
+  revert n.
+  induction l as [|x xs IH]; intros n nlt; cbn in *; try lia.
+  destruct n as [|n]; auto.
+  apply IH.
+  lia.
+Qed.
+
+Local Open Scope nat.
+Lemma sumnat_max {A} (f : A -> nat) l max :
+  (forall a, In a l -> f a <= max) ->
+  sumnat f l <= max * length l.
+Proof.
+  intros all.
+  induction l as [|x xs IH].
+  - cbn.
+    lia.
+  - cbn.
+    unshelve epose proof (IH _) as IH.
+    + intros a ain.
+      apply all; right; auto.
+    + specialize (all x (or_introl eq_refl)).
+      lia.
+Qed.
+
+Lemma list_eq_nth {A} (xs ys : list A) :
+  length xs = length ys ->
+  (forall i a a', nth_error xs i = Some a -> nth_error ys i = Some a' -> a = a') ->
+  xs = ys.
+Proof.
+  revert ys.
+  induction xs as [|x xs IH]; intros ys len_xs all_eq.
+  - destruct ys; cbn in *; auto; lia.
+  - cbn.
+    destruct ys as [|y ys]; cbn in *; try lia.
+    rewrite (all_eq 0 x y); cbn; auto.
+    apply f_equal.
+    apply IH.
+    + lia.
+    + intros i a b ntha nthb.
+      apply all_eq with (S i); cbn; auto.
+Qed.
+
+Lemma nth_error_seq_in i start len :
+  i < len ->
+  nth_error (seq start len) i = Some (start + i).
+Proof.
+  revert i start.
+  induction len as [|len IH]; intros i start ilt; try lia.
+  cbn.
+  destruct i as [|i]; cbn.
+  - f_equal; lia.
+  - rewrite IH by lia.
+    f_equal; lia.
+Qed.
+
+Lemma nth_error_snoc {B} (l : list B) (x : B) :
+  nth_error (l ++ [x]) (length l) = Some x.
+Proof.
+  rewrite nth_error_app2 by lia.
+  now replace (length l - length l) with 0 by lia.
+Qed.
+
+Lemma NoDup_filter {A} (f : A -> bool) l :
+  NoDup l ->
+  NoDup (filter f l).
+Proof.
+  intros nodup.
+  induction nodup; cbn.
+  - constructor.
+  - destruct (f x) eqn:fx; auto.
+    constructor; auto.
+    rewrite filter_In.
+    tauto.
+Qed.
+
+Lemma NoDup_map {A B} (f : A -> B) l :
+  NoDup l ->
+  (forall a a', In a l -> In a' l -> f a = f a' -> a = a') ->
+  NoDup (map f l).
+Proof.
+  intros nodup.
+  induction nodup; cbn; intros inj.
+  - constructor.
+  - constructor; auto.
+    rewrite in_map_iff.
+    intros ex.
+    destruct ex as [x' [fxeq inxl]].
+    contradiction H.
+    replace x with x'; [assumption|].
+    apply inj; auto.
+Qed.
+
+Lemma filter_all {A} (f : A -> bool) (l : list A) :
+  (forall a, In a l -> f a = true) ->
+  filter f l = l.
+Proof.
+  induction l as [|x xs IH]; [easy|]; intros all.
+  cbn.
+  rewrite all by (now left).
+  apply f_equal; apply IH.
+  intros a ain.
+  apply all; right; auto.
 Qed.

--- a/execution/theories/Monads.v
+++ b/execution/theories/Monads.v
@@ -1,21 +1,54 @@
-(* This file defines some helpful notations for the option monad. *)
+(* This file defines some helpful notations for monads. *)
 
-Definition option_bind {A B : Type} (v : option A) (f : A -> option B) : option B :=
-  match v with
-  | Some val => f val
-  | None => None
-  end.
+Class Monad (m : Type -> Type) : Type :=
+build_monad {
+  ret : forall {t}, t -> m t;
+  bind : forall {t u}, m t -> (t -> m u) -> m u
+}.
 
-Notation "c >>= f" := (option_bind c f) (at level 50, left associativity).
-Notation "f =<< c" := (option_bind c f) (at level 51, right associativity).
+Notation "c >>= f" := (bind c f) (at level 50, left associativity).
+Notation "f =<< c" := (bind c f) (at level 51, right associativity).
 
 Notation "'do' x <- c1 ; c2" :=
-  (option_bind c1 (fun x => c2))
+  (bind c1 (fun x => c2))
     (at level 60, c1 at next level, right associativity).
 
 Notation "'do' ' pat <- c1 ; c2" :=
-  (option_bind c1 (fun x => match x with pat => c2 end))
+  (bind c1 (fun x => match x with pat => c2 end))
     (at level 60, pat pattern, c1 at next level, right associativity).
 
 Notation "'do' e1 ; e2" := (do _ <- e1 ; e2)
   (at level 60, right associativity).
+
+Class MonadLaws {m : Type -> Type} (mon : Monad m) :=
+build_monad_laws {
+  bind_of_return :
+    forall (T : Type) (t : T) (U : Type) (f : T -> m U),
+      (ret t >>= f) = f t;
+  return_of_bind :
+    forall (T : Type) (t : m T),
+      (t >>= @ret m mon T) = t;
+  bind_assoc :
+    forall (T U V : Type) (t : m T) (f : T -> m U) (g : U -> m V),
+      (t >>= f) >>= g = t >>= (fun t => f t >>= g);
+}.
+
+Class MonadTrans (m : Type -> Type) (mt : Type -> Type) : Type :=
+  { lift : forall {t}, mt t -> m t }.
+
+Global Instance option_monad : Monad option :=
+  {| ret _ t := Some t;
+     bind _ _ v f := match v with
+                 | Some val => f val
+                 | None => None
+                 end |}.
+
+Global Instance option_monad_laws : MonadLaws option_monad.
+Proof.
+  constructor.
+  - auto.
+  - intros; cbn.
+    destruct t; auto.
+  - intros; cbn.
+    destruct t; auto.
+Qed.


### PR DESCRIPTION
From the modified readme:
In BoardroomVoting.v we verify functional correctness of a private boardroom voting contract based on [1] under some simplifying assumptions. In particular we do not verify anything about the zero-knowledge proofs required to make sure that everyone participates correctly in the smart contract. Instead we assume that everyone participates correctly and then show that the smart contract in this case computes the correct result (i.e. a public tally of the private votes). The statement is the following:

```coq
Theorem boardroom_voting_correct
        bstate caddr (trace : ChainTrace empty_state bstate)
        (* list of all public keys, in the order of signups *)
        (pks : list A)
        (* function mapping a party to his signup index *)
        (index : Address -> nat)
        (* function mapping a party to his secret key *)
        (sks : Address -> Z)
        (* function mapping a party to his vote *)
        (svs : Address -> bool) :
    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
    exists (cstate : State)
           (depinfo : DeploymentInfo Setup)
           (inc_calls : list (ContractCallInfo Msg)),
      deployment_info Setup trace caddr = Some depinfo /\
      contract_state bstate caddr = Some cstate /\
      incoming_calls Msg trace caddr = Some inc_calls /\
      (* assuming that the message sent were created with the
          functions provided by this smart contract *)
      MsgAssumption pks index sks svs inc_calls ->
      (* ..and that people signed up in the order given by 'index'
          and 'pks' *)
      SignupOrderAssumption pks index inc_calls ->
      (* ..and that the correct number of people register *)
      (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
       length pks = length (signups inc_calls)) ->
      (* then if we have not tallied yet, the result is none *)
      ((has_tallied inc_calls = false -> result cstate = None) /\
       (* or if we have tallied yet, the result is correct *)
       (has_tallied inc_calls = true ->
        result cstate = Some (sumnat (fun party => if svs party then 1 else 0)%nat
                                     (FMap.keys (registered_voters cstate))))).
```
The simplifying assumptions are expressed over the messages seen in the blockchain state. For instance, `MsgAssumption` above captures that everyone participates correctly by saying that all messages sent to the contract were created using functions provided by the smart contract:

```coq
Fixpoint MsgAssumption
         (pks : list A)
         (index : Address -> nat)
         (sks : Address -> Z)
         (svs : Address -> bool)
         (calls : list (ContractCallInfo Msg)) : Prop :=
  match calls with
  | call :: calls =>
    let caller := Blockchain.call_from call in
    match Blockchain.call_msg call with
    | Some (signup pk as m) => m = make_signup_msg (sks caller)
    | Some (submit_vote _ _ as m) =>
      m = make_vote_msg pks (index caller) (sks caller) (svs caller)
    | _ => True
    end /\ MsgAssumption pks index sks svs calls
  | [] => True
  end.
```

Here `make_signup_msg` and `make_vote_msg` are the functions provided by the smart contract and could potentially be extracted with the rest of the smart contract to have functionally verified boardroom voting contract with privacy.

[1] McCorry, Patrick, Siamak F. Shahandashti, and Feng Hao. "A smart contract for
boardroom voting with maximum voter privacy." International Conference on
Financial Cryptography and Data Security. Springer, Cham, 2017.
