### PR TITLE
Do not introduce typevars for logical things

### DIFF
--- a/extraction/examples/ErasureTests.v
+++ b/extraction/examples/ErasureTests.v
@@ -189,11 +189,11 @@ Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex1) 
 
 MetaCoq Quote Recursively Definition ex2 := (forall (A : Type) (P : A -> Prop), @sig A P).
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex2) in exact x) =
-                Ok ("A P", "□ → □ → sig A □").
+                Ok ("A", "□ → □ → sig A □").
 
 MetaCoq Quote Recursively Definition ex3 := (forall (A : Type) (P : A -> Prop), { a : A | P a }).
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex3) in exact x) =
-                Ok ("A P", "□ → □ → sig A □").
+                Ok ("A", "□ → □ → sig A □").
 
 MetaCoq Quote Recursively Definition ex4 := (forall (A B : Type) (f : A -> B) (n : nat),
                                         Vector.t A n -> Vector.t B n).
@@ -245,7 +245,7 @@ Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex11)
 
 MetaCoq Quote Recursively Definition ex12 := (forall (A : Type) (P : A -> Prop), unit).
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex12) in exact x) =
-                Ok ("A P", "□ → □ → unit").
+                Ok ("A", "□ → □ → unit").
 
 MetaCoq Quote Recursively Definition ex13 := (let p := (nat, unit) in fst p × snd p).
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_type id ex13) in exact x) =
@@ -471,12 +471,10 @@ Inductive IndexedList : Type -> Type :=
 | icons : forall T, T -> IndexedList T -> IndexedList T.
 
 MetaCoq Quote Recursively Definition ex9 := IndexedList.
-Compute erase_and_print_ind_prog ex9.
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_ind_prog ex9) in exact x) =
                 Err (EraseIndBodyError "IndexedList" (CtorUnmappedTypeVariables "inil")).
 
 MetaCoq Quote Recursively Definition ex10 := Monad.
-Compute erase_and_print_ind_prog ex10.
 Check eq_refl : ltac:(let x := eval vm_compute in (erase_and_print_ind_prog ex10) in exact x) =
                 Err (EraseIndBodyError "Monad" (EraseCtorError "Build_Monad" NotPrenex)).
 
@@ -484,8 +482,6 @@ Inductive ManyParamsInd (A : Type) (P : Prop) (Q : Prop) (B : Type) :=
   MPIConstr : P -> A -> B -> ManyParamsInd A P Q B.
 
 MetaCoq Quote Recursively Definition ex11 := ManyParamsInd.
-
-Compute erase_and_print_ind_prog ex11.
 
 Example ManyParamsInd_test :
   erase_and_print_ind_prog ex11 =
@@ -518,6 +514,17 @@ Example ManyParamsIndNonArity_remove_log_params_test:
   Ok <$ "data ManyParamsIndNonArity A B";
         "| MPINAConstr1 □ □ □ □ □ A B";
         "| MPINAConstr2 □ □ □ □ □ (list □) (prod A B)" $>.
+Proof. vm_compute. reflexivity. Qed.
+
+Inductive PropTypeVarInCtor :=
+  ex13_ctor : Prop -> PropTypeVarInCtor.
+MetaCoq Quote Recursively Definition ex13 := PropTypeVarInCtor.
+Compute erase_and_print_ind_prog ex13.
+
+Example PropTypeVarInCtor_test :
+  erase_and_print_ind_prog ex13 =
+  Ok <$ "data PropTypeVarInCtor";
+        "| ex13_ctor □" $>.
 Proof. vm_compute. reflexivity. Qed.
 
 End erase_ind_tests.

--- a/extraction/examples/ErasureTests.v
+++ b/extraction/examples/ErasureTests.v
@@ -519,12 +519,20 @@ Proof. vm_compute. reflexivity. Qed.
 Inductive PropTypeVarInCtor :=
   ex13_ctor : Prop -> PropTypeVarInCtor.
 MetaCoq Quote Recursively Definition ex13 := PropTypeVarInCtor.
-Compute erase_and_print_ind_prog ex13.
 
 Example PropTypeVarInCtor_test :
   erase_and_print_ind_prog ex13 =
   Ok <$ "data PropTypeVarInCtor";
         "| ex13_ctor □" $>.
+Proof. vm_compute. reflexivity. Qed.
+
+Inductive IndWithIndex : nat -> Type :=
+| ex14_ctor (T : Type) : IndWithIndex 0.
+MetaCoq Quote Recursively Definition ex14 := IndWithIndex.
+
+Example IndWithIndex_test :
+  erase_and_print_ind_prog ex14 =
+  Err (EraseIndBodyError "IndWithIndex" (CtorUnmappedTypeVariables "ex14_ctor")).
 Proof. vm_compute. reflexivity. Qed.
 
 End erase_ind_tests.

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -507,10 +507,8 @@ erase_type Γ erΓ t wat tvars with inspect (reduce_term redβιζ Σ wfΣ Γ t 
 
       | et_view_prod na A B with flag_of_type Γ A _ := {
           (* For logical things, we add a type variable if it's an arity *)
-        | Checked {| is_logical := true ; is_arity := isar |} :=
-          let e := if isar then RelTypeVar (List.length tvars) else RelOther in
-          let tvars' := if isar then tvars ++ [na] else tvars in
-          '(tvars, bt) <- erase_type (Γ,, vass na A) (e :: erΓ)%vector B _ tvars';;
+        | Checked {| is_logical := true |} :=
+          '(tvars, bt) <- erase_type (Γ,, vass na A) (RelOther :: erΓ)%vector B _ tvars;;
           ret (tvars, TArr TBox bt);
 
           (* If the type isn't an arity now, then it's a "normal" type like nat. *)
@@ -883,7 +881,8 @@ Program Definition erase_ind_body
   let the_rest := skipn (P.ind_npars mib) oib_tvars in
   (* we filter out non-arities from the inductive parameters since non-arities
      will not be type variables *)
-  let ind_params_arities_only := filter tvar_is_arity ind_params in
+  let ind_params_arities_only :=
+      filter (fun t => tvar_is_sort t && negb (tvar_is_logical t)) ind_params in
   (* We map type vars in constructors to type vars in the inductive parameters.
      Thus, we only allow the constructor this many type vars *)
   let num_tvars_in_params :=

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -879,17 +879,17 @@ Program Definition erase_ind_body
 
   let ind_params := firstn (P.ind_npars mib) oib_tvars in
   (* Type erasure will only produce type vars for non-logical sorts *)
-  let ind_params_tvars :=
+  let ind_ctor_tvars :=
       filter (fun t => tvar_is_sort t && negb (tvar_is_logical t)) ind_params in
   (* We map type vars in constructors to type vars in the inductive parameters.
      Thus, we only allow the constructor this many type vars *)
-  let num_tvars_in_params := List.length ind_params_tvars in
+  let num_ctor_tvars := List.length ind_ctor_tvars in
   let erase_ind_ctor (p : (ident × P.term) × nat) (is_in : In p (P.ind_ctors oib)) :=
       let '((name, t), _) := p in
       '(ctor_tvars, bt) <- map_error (EraseCtorError name)
                                      (erase_type Γ erΓ t _ []);;
 
-      (if (#|ctor_tvars| <=? num_tvars_in_params)%nat then
+      (if (#|ctor_tvars| <=? num_ctor_tvars)%nat then
          ret tt
        else
          Err (CtorUnmappedTypeVariables name));;
@@ -901,7 +901,7 @@ Program Definition erase_ind_body
 
   ret {| ind_name := P.ind_name oib;
          ind_type_vars := oib_tvars;
-         ind_ctor_type_vars := ind_params_tvars;
+         ind_ctor_type_vars := ind_ctor_tvars;
          ind_ctors := ctors;
          ind_projs := [] (* todo *) |}.
 Next Obligation.

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -878,15 +878,12 @@ Program Definition erase_ind_body
   let '(Γ; erΓ) := arities_contexts mind (P.ind_bodies mib) in
 
   let ind_params := firstn (P.ind_npars mib) oib_tvars in
-  let the_rest := skipn (P.ind_npars mib) oib_tvars in
-  (* we filter out non-arities from the inductive parameters since non-arities
-     will not be type variables *)
-  let ind_params_arities_only :=
+  (* Type erasure will only produce type vars for non-logical sorts *)
+  let ind_params_tvars :=
       filter (fun t => tvar_is_sort t && negb (tvar_is_logical t)) ind_params in
   (* We map type vars in constructors to type vars in the inductive parameters.
      Thus, we only allow the constructor this many type vars *)
-  let num_tvars_in_params :=
-      List.length ind_params_arities_only in
+  let num_tvars_in_params := List.length ind_params_tvars in
   let erase_ind_ctor (p : (ident × P.term) × nat) (is_in : In p (P.ind_ctors oib)) :=
       let '((name, t), _) := p in
       '(ctor_tvars, bt) <- map_error (EraseCtorError name)
@@ -904,7 +901,7 @@ Program Definition erase_ind_body
 
   ret {| ind_name := P.ind_name oib;
          ind_type_vars := oib_tvars;
-         ind_ctor_type_vars := ind_params_arities_only ++ the_rest;
+         ind_ctor_type_vars := ind_params_tvars;
          ind_ctors := ctors;
          ind_projs := [] (* todo *) |}.
 Next Obligation.


### PR DESCRIPTION
This breaks erasure for some constructors because we use the count of
type vars to figure out whether the constructor is extractable.
Also, since constructors are not generalized over indices there is no need to include type variables from indices, only parameters.