### PR TITLE
Update for new MetaCoq

### DIFF
--- a/extraction/theories/OptimizeCorrectness.v
+++ b/extraction/theories/OptimizeCorrectness.v
@@ -3051,7 +3051,6 @@ Proof.
         apply filter_length.
 Qed.
 
-Axiom projections_first : forall n, n = 0.
 Lemma dearg_correct Σ t v :
   env_closed (trans Σ) ->
   closed t ->
@@ -3407,7 +3406,7 @@ Proof.
       apply is_expanded_aux_mkApps_inv in H4 as (exp_constr & exp_args).
       cbn in *; propify.
       unfold dearg_proj.
-      apply (eval_proj _ _ _ _ _ (pairwise_remove (get_ctor_mask i k) (map dearg args)) k).
+      apply (eval_proj _ _ _ _ _ (pairwise_remove (get_ctor_mask i 0) (map dearg args))).
       * unshelve epose proof (IH _ _ _ _ _ ev1 _); auto.
         1: lia.
         rewrite dearg_mkApps in *.
@@ -3442,7 +3441,6 @@ Proof.
         replace (count_zeros (param_mask m) + (arg - count_ones (firstn arg (get_branch_mask m i 0))) -
             count_zeros (param_mask m)) with (arg - count_ones (firstn arg (get_branch_mask m i 0)))
           by lia.
-        pose proof (projections_first k) as ->.
         rewrite nth_error_pairwise_remove by easy.
         rewrite nth_error_skipn, nth.
         cbn.

--- a/extraction/theories/WcbvEvalAux.v
+++ b/extraction/theories/WcbvEvalAux.v
@@ -331,7 +331,7 @@ Fixpoint deriv_length {Σ t v} (ev : Σ ⊢ t ▷ v) : nat :=
   | eval_iota _ _ _ _ _ _ _ ev1 ev2
   | eval_iota_sing _ _ _ _ _ _ _ ev1 _ ev2
   | eval_fix_value _ _ _ _ _ _ _ _ ev1 ev2 _ _
-  | eval_proj _ _ _ _ _ _ _ ev1 ev2
+  | eval_proj _ _ _ _ _ _ ev1 ev2
   | eval_app_cong _ _ _ _ ev1 _ ev2 => S (deriv_length ev1 + deriv_length ev2)
   | eval_beta _ _ _ _ _ _ ev1 ev2 ev3
   | eval_fix _ _ _ _ _ _ _ _ _ ev1 ev2 _ _ _ ev3 =>
@@ -572,10 +572,15 @@ Proof.
       noconf e.
       destruct o as [|(_ & ?)]; [easy|].
       now rewrite i in H.
-    + noconf H1.
-      assert (H = eq_refl) as -> by (apply uip).
+    + apply mkApps_eq_inj in e' as H'; try easy.
+      destruct H' as (H' & <-).
+      noconf H'.
+      assert (e' = eq_refl) as -> by (now apply uip).
       cbn in *.
       subst ev0.
+      rewrite e0 in e.
+      noconf e.
+      cbn in *.
       intuition.
   - depelim ev2; cbn in *; determ; cbn in *; try congruence; try solve_discr.
     + apply eval_mkApps_tCoFix in ev2_1 as H.
@@ -612,10 +617,8 @@ Proof.
     assert (body0 = body) as -> by congruence.
     intuition.
   - depelim ev2; cbn in *; determ; cbn in *; try congruence; try solve_discr.
-    + apply eval_mkApps_tCoFix in ev1_1 as H.
-      destruct H; solve_discr.
-    + noconf H.
-      intuition.
+    apply eval_mkApps_tCoFix in ev1_1 as H.
+    destruct H; solve_discr.
   - depelim ev2; cbn in *; determ; cbn in *; try congruence; try solve_discr.
     apply eval_mkApps_tCoFix in ev1 as H.
     destruct H; solve_discr.

--- a/extraction/theories/WcbvEvalType.v
+++ b/extraction/theories/WcbvEvalType.v
@@ -94,8 +94,8 @@ Section Wcbv.
       eval (tConst c) res
 
   (** Proj *)
-  | eval_proj i pars arg discr args k res :
-      eval discr (mkApps (tConstruct i k) args) ->
+  | eval_proj i pars arg discr args res :
+      eval discr (mkApps (tConstruct i 0) args) ->
       eval (List.nth (pars + arg) args tDummy) res ->
       eval (tProj (i, pars, arg) discr) res
 


### PR DESCRIPTION
Projections are only out of the first constructor now, which means we no
longer have any admissions in our dearg proof.