### PR TITLE
Remove unnecessary name environment

### DIFF
--- a/extraction/examples/ElmExtractTests.v
+++ b/extraction/examples/ElmExtractTests.v
@@ -40,7 +40,7 @@ Definition general_wrapped (p : program) (pre post : string)
            end;;
   Σ <- extract_template_env_within_coq p.1 [entry] (fun k => existsb (eq_kername k) ignore);;
   let TT_fun kn := option_map snd (List.find (fun '(kn',v) => eq_kername kn kn') TT) in
-  '(_, s) <- finish_print (print_env Σ p.1 TT_fun);;
+  '(_, s) <- finish_print (print_env Σ TT_fun);;
   ret (pre ++ nl ++ s ++ nl ++ post).
 
 Definition wrapped (p : program) (pre post : string) : result string string :=

--- a/extraction/examples/MidlangEscrow.v
+++ b/extraction/examples/MidlangEscrow.v
@@ -140,7 +140,7 @@ Definition midlang_prelude :=
 Definition escrow_result :=
   Eval vm_compute in
     (env <- escrow_extract ;;
-     '(_, s) <- finish_print (print_env env escrow_env midlang_escrow_translate);;
+     '(_, s) <- finish_print (print_env env midlang_escrow_translate);;
      ret s).
 
 MetaCoq Run (match escrow_result with
@@ -153,7 +153,5 @@ Definition midlang_escrow :=
   | Ok s => wrap_in_delimiters (midlang_prelude ++ nl ++ s)
   | Err s => s
   end.
-
-Compute midlang_escrow.
 
 Redirect "./extraction/examples/midlang-extract/MidlangEscrow.midlang" Compute midlang_escrow.

--- a/extraction/examples/MidlangExtractTests.v
+++ b/extraction/examples/MidlangExtractTests.v
@@ -43,7 +43,7 @@ Definition general_extract (p : program) (ignore: list kername) (TT : list (kern
            end;;
   Σ <- extract_template_env no_check_args p.1 [entry] (fun k => existsb (eq_kername k) ignore);;
   let TT_fun kn := option_map snd (List.find (fun '(kn',v) => eq_kername kn kn') TT) in
-  '(_, s) <- finish_print (print_env Σ p.1 TT_fun);;
+  '(_, s) <- finish_print (print_env Σ TT_fun);;
   ret s.
 
 Definition extract (p : program) : result string string :=


### PR DESCRIPTION
Since we are now including ignored inductives it is unnecessary to have
an extra environment for looking up names.

Also reduce spam a bit.