### PR TITLE
Totality improvements and prep for type scheme erasure

### DIFF
--- a/extraction/examples/ErasureTests.v
+++ b/extraction/examples/ErasureTests.v
@@ -34,10 +34,7 @@ Program Definition flag_of_type_program (p : Ast.program)
   : result type_flag_squashed string :=
   let p := fix_program_universes p in
   let Σ := trans_global_decls p.1 in
-  f <- match flag_of_type (empty_ext Σ) _ [] (trans p.2) _ with
-       | Checked a => ret a
-       | TypeError te => Err "Could not get flag"
-       end;;
+  let f := flag_of_type (empty_ext Σ) _ [] (trans p.2) _ in
   ret {| is_logical := Erasure.is_logical f;
          is_sort := if Erasure.is_sort f then true else false;
          is_arity := if Erasure.is_arity f then true else false |}.
@@ -308,6 +305,13 @@ MetaCoq Quote Recursively Definition ex19 := (Fin.t 0 -> False).
 Example ex19_test :
   erase_and_print_type id ex19 =
   Ok ("", "□").
+Proof. vm_compute. reflexivity. Qed.
+
+Axiom match_head : nat.
+MetaCoq Quote Recursively Definition ex20 := (match match_head with | 0 => nat | S n => bool end).
+Example ex20_test :
+  erase_and_print_type id ex20 =
+  Ok ("", "𝕋").
 Proof. vm_compute. reflexivity. Qed.
 End erase_type_tests.
 

--- a/extraction/theories/CertifyingEta.v
+++ b/extraction/theories/CertifyingEta.v
@@ -268,7 +268,7 @@ Definition eta_global_env
                        cst_universes := cb.(cst_universes) |}
         | None => cb
         end in
-    let Σ' := restrict_env Σ (map fst Σe) in
+    let Σ' := restrict_env Σ (map (fun '(kn, _, _) => kn) Σe) in
     ret (map_constants_global_env id f Σ')
   end.
 

--- a/extraction/theories/ErasureCorrectness.v
+++ b/extraction/theories/ErasureCorrectness.v
@@ -483,7 +483,7 @@ Proof.
   - now constructor.
 Qed.
 
-Opaque erase_type SafeErasureFunction.wf_reduction.
+Opaque erase_type flag_of_type SafeErasureFunction.wf_reduction.
 Lemma erase_global_decls_deps_recursive_correct Σ wfΣ include ignore Σex :
   (forall k, ignore k = false) ->
   erase_global_decls_deps_recursive Σ wfΣ include ignore = Ok Σex ->
@@ -539,10 +539,9 @@ Proof.
     cbn -[erase_constant_decl] in *.
     destruct erase_constant_decl eqn:erconst; cbn -[erase_constant_decl] in *; [|congruence].
     unfold erase_constant_decl in erconst.
-    destruct flag_of_type; cbn in *; [|congruence].
-    destruct a; cbn in *.
-    destruct is_sort.
-    + cbn in wfdecl.
+    destruct flag_of_type; cbn in *.
+    destruct is_arity; cbn in *.
+    + destruct is_sort; [|congruence].
       destruct c.
       destruct cst_body; cbn in *; [|congruence].
       destruct erase_type; cbn in *; [|congruence].
@@ -558,7 +557,7 @@ Proof.
       * cbn.
         destruct wfΣ as [wfΣ].
         destruct wfdecl as [wfdecl].
-        destruct i as (u & [redu]).
+        destruct i0 as (u & [redu]).
         eapply type_reduction in wfdecl; eauto.
         2: now inversion wfΣ.
         constructor.

--- a/extraction/theories/ExtractionCorrectness.v
+++ b/extraction/theories/ExtractionCorrectness.v
@@ -41,7 +41,7 @@ Proof.
   depelim ev.
   unfold valid_masks_env in valid.
   apply forallb_Forall in valid.
-  apply declared_constant_trans in isdecl as [(? & ? & nth)|(isbox & ? & ? & nth)]; cycle 1.
+  apply declared_constant_trans in isdecl as [(? & ? & ? & nth)|(isbox & ? & ? & ? & nth)]; cycle 1.
   { eapply nth_error_forall in nth; [|eassumption].
     cbn in *.
     now destruct get_const_mask. }
@@ -120,10 +120,12 @@ Print Assumptions extract_correct.
 (* There are some assumptions of which almost all are in MetaCoq.
    From this project are the following:
 
-   1. hnf_completion, which is used in flag_of_type. These cases require a completion
-      statement about the hnf function from MetaCoq, saying that this function actually
-      reduces to head normal from. MetaCoq does not yet include a completeness statement
-      about hnf (but it is planned), so for now we defer those proofs.
+   1. not_prod_or_sort_hnf, which is used in flag_of_type. This says that if the head normal
+      form of a term is not a product or sort then the term is not convertible to an arity.
+      The proof of this requires a statement about completeness of the hnf function from MetaCoq,
+      saying that this function actually reduces to head normal from. MetaCoq does not yet
+      include a completeness statement about hnf (but it is planned), so for now we defer
+      those proofs.
 
    2. assume_env_wellformed, which is used to assume that the environments we extract are
       wellformed. MetaCoq's safe checker does not run from within Coq, so we cannot type

--- a/extraction/theories/Optimize.v
+++ b/extraction/theories/Optimize.v
@@ -261,12 +261,12 @@ Definition dearg_mib (kn : kername) (mib : mutual_inductive_body) : mutual_induc
 Definition dearg_decl (kn : kername) (decl : global_decl) : global_decl :=
   match decl with
   | ConstantDecl cst => ConstantDecl (dearg_cst kn cst)
-  | InductiveDecl b mib => InductiveDecl b (dearg_mib kn mib)
+  | InductiveDecl mib => InductiveDecl (dearg_mib kn mib)
   | TypeAliasDecl _ => decl
   end.
 
 Definition dearg_env (Σ : global_env) : global_env :=
-  map (fun '(kn, decl) => (kn, dearg_decl kn decl)) Σ.
+  map (fun '(kn, has_deps, decl) => (kn, has_deps, dearg_decl kn decl)) Σ.
 
 End dearg.
 
@@ -327,7 +327,7 @@ Definition debox_type_mib (mib : mutual_inductive_body) : mutual_inductive_body 
 Definition debox_type_decl (decl : global_decl) : global_decl :=
   match decl with
   | ConstantDecl cst => ConstantDecl (debox_type_constant cst)
-  | InductiveDecl b mib => InductiveDecl b (debox_type_mib mib)
+  | InductiveDecl mib => InductiveDecl (debox_type_mib mib)
   | TypeAliasDecl _ => decl
   end.
 
@@ -498,14 +498,14 @@ Record dearg_set := {
 Fixpoint analyze_env (Σ : global_env) : dearg_set :=
   match Σ with
   | [] => {| const_masks := []; ind_masks := [] |}
-  | (kn, decl) :: Σ =>
+  | (kn, has_deps, decl) :: Σ =>
     let (consts, inds) := analyze_env Σ in
     let (consts, inds) :=
         match decl with
         | ConstantDecl cst =>
           let '(mask, inds) := analyze_constant cst inds in
           ((kn, mask) :: consts, inds)
-        | InductiveDecl _ mib =>
+        | InductiveDecl mib =>
           let ctor_masks :=
               List.concat
                 (mapi (fun ind oib =>


### PR DESCRIPTION
type_of is now total in MetaCoq so improve our erasure for this as well.
Also fix some things for upcoming type scheme erasure.

* Make flag_of_type total and improve admitted axiom to actually admit
  something true
* Switch flag_of_type to use our well-founded relation instead of
  MetaCoq's
* Change erase_type to require a proof of isType instead of
  isWfArity_or_Type in preparation for type scheme erasure
* Change erase_type to return TAny for things like stuck fixpoints and
  matches
* Change extended environments to include, for every global declaration,
  whether it includes its dependencies. This is now used to avoid
  printing inductives that are included only because they are matched
  on, and globals that are included purely for deboxing. The old
  ignore_on_print flag on InductiveDecl is now gone as a result.