### PR TITLE
Make erase_type and erase_ind_arity total

### DIFF
--- a/extraction/theories/Aux.v
+++ b/extraction/theories/Aux.v
@@ -128,3 +128,29 @@ Proof.
   cbn in *.
   now rewrite H, IHForall.
 Qed.
+
+Definition map_In {X Y} : forall (xs : list X) (f : forall x, In x xs -> Y), list Y.
+Proof.
+  fix map_In 1.
+  intros [|x xs] f.
+  - exact [].
+  - refine (f x (or_introl eq_refl) :: map_In xs _).
+    intros x' isin.
+    apply (f x').
+    right.
+    assumption.
+Defined.
+
+Definition monad_map_In {T : Type -> Type} {M : Monad T} {X Y : Type}
+  : forall (xs : list X) (f : forall (x : X), In x xs -> T Y), T (list Y).
+Proof.
+  fix monad_map_In 1.
+  intros [|x xs] f.
+  - exact (ret []).
+  - refine (y <- f x (or_introl eq_refl);;
+            tl <- monad_map_In xs _;; ret (y :: tl)).
+    intros x' isin.
+    apply (f x').
+    right.
+    assumption.
+Defined.

--- a/extraction/theories/CertifyingEta.v
+++ b/extraction/theories/CertifyingEta.v
@@ -223,7 +223,7 @@ Definition contains_global_env (Σ : global_env) (kn : kername) :=
 
 Definition restrict_env (Σ : global_env) (kns : list kername) : global_env :=
   filter (fun '(kn, _) => match find (eq_kername kn) kns with
-                       |Some _ => true
+                       | Some _ => true
                        | None => false
                        end) Σ.
 
@@ -300,7 +300,7 @@ Definition eta_global_env_template
 Definition eta_expand_def {A} (params : extract_template_env_params) (mpath : modpath) (cst_name_ignore : kername -> bool) (def : A) : TemplateMonad _ :=
   p <- tmQuoteRecTransp def false ;;
   kn <- extract_def_name def ;;
-  eta_global_env_template params mpath p.1 [kn] (fun _ => false) cst_name_ignore .
+  eta_global_env_template params mpath p.1 [kn] (fun _ => false) cst_name_ignore.
 
 Module Examples.
 

--- a/extraction/theories/ErasureCorrectness.v
+++ b/extraction/theories/ErasureCorrectness.v
@@ -544,7 +544,7 @@ Proof.
     + destruct is_sort; [|congruence].
       destruct c.
       destruct cst_body; cbn in *; [|congruence].
-      destruct erase_type; cbn in *; [|congruence].
+      destruct erase_type; cbn in *.
       inversion erconst; subst; clear erconst.
       inversion erdecl; subst; clear erdecl.
       cbn in *.
@@ -572,7 +572,7 @@ Proof.
         cbn in *.
         inversion H; subst; clear H.
         now constructor.
-    + destruct erase_type; cbn in *; [|congruence].
+    + destruct erase_type; cbn in *.
       destruct c; cbn in *.
       destruct cst_body; cycle 1.
       { inversion erconst; subst; clear erconst.

--- a/extraction/theories/ExAst.v
+++ b/extraction/theories/ExAst.v
@@ -21,6 +21,13 @@ Fixpoint decompose_arr (bt : box_type) : list box_type * box_type :=
   | _ => ([], bt)
   end.
 
+Definition can_have_args (bt : box_type) : bool :=
+  match bt with
+  | TInd _
+  | TConst _ => true
+  | _ => false
+  end.
+
 Fixpoint mkTApps (hd : box_type) (args : list box_type) : box_type :=
   match args with
   | [] => hd


### PR DESCRIPTION
erase_type now can no longer fail. That means it supports rank 2+ types
instead of failing on these.

We are still missing two things for erasure to be completely total:
- For constants we have to be able to erase type schemes
- For inductives we need to erase constructors in an environment
  corresponding to the parameters of the inductive and then avoid adding
  new type variables