### PR TITLE
Make inductive erasure total

### DIFF
--- a/extraction/examples/MidlangExtractTests.v
+++ b/extraction/examples/MidlangExtractTests.v
@@ -289,3 +289,12 @@ Module ex10.
 "  proj1_sig x" $>.
   Proof. vm_compute. reflexivity. Qed.
 End ex10.
+
+Module ex11.
+  MetaCoq Quote Recursively Definition ex11 := Monad.
+  Example Monad_test :
+    extract ex11 = Ok <$
+"type Monad m";
+"  = Build_Monad (□ -> 𝕋 -> m) (□ -> □ -> m -> (𝕋 -> m) -> m)" $>.
+  Proof. vm_compute. reflexivity. Qed.
+End ex11.

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -992,22 +992,13 @@ Proof.
   apply IH.
 Qed.
 
-Inductive erase_ind_body_error :=
-| CtorUnmappedTypeVariables (ctor : ident).
-
-Definition string_of_erase_ind_body_error (e : erase_ind_body_error) : string :=
-  match e with
-  | CtorUnmappedTypeVariables ctor => "Ctor " ++ ctor ++ " has unmapped type variables"
-  end.
-
 Inductive view_prod : term -> Type :=
 | view_prod_prod na A B : view_prod (tProd na A B)
 | view_prod_other t : negb (isProd t) -> view_prod t.
 
-Equations view_prodc (t : term) : view_prod t := {
-  | tProd na A B => view_prod_prod na A B;
-  | t => view_prod_other t _
-  }.
+Equations view_prodc (t : term) : view_prod t :=
+| tProd na A B => view_prod_prod na A B;
+| t => view_prod_other t _.
 
 (* Constructors are treated slightly differently to types as we always
    generate type variables for parameters *)
@@ -1075,16 +1066,6 @@ Next Obligation.
   now exists s.
 Qed.
 
-Inductive erase_ind_error :=
-| EraseIndBodyError (ind : ident) (err : erase_ind_body_error).
-
-Definition string_of_erase_ind_error (e : erase_ind_error) : string :=
-  match e with
-  | EraseIndBodyError ind e => "Error while erasing ind body "
-                                 ++ ind ++ ": "
-                                 ++ string_of_erase_ind_body_error e
-  end.
-
 Program Definition erase_ind
         (kn : kername)
         (mib : P.mutual_inductive_body)
@@ -1121,17 +1102,13 @@ Local Existing Instance extraction_checker_flags.
 Import ExAst.
 
 Inductive erase_global_decl_error :=
-| ErrConstant (kn : kername) (err : erase_constant_decl_error)
-| ErrInductive (kn : kername) (err : erase_ind_error).
+| ErrConstant (kn : kername) (err : erase_constant_decl_error).
 
 Definition string_of_erase_global_decl_error (e : erase_global_decl_error) : string :=
   match e with
   | ErrConstant kn err => "Error while erasing constant "
                               ++ string_of_kername kn ++ ": "
                               ++ string_of_erase_constant_decl_error err
-  | ErrInductive kn err => "Error while erasing inductive "
-                               ++ string_of_kername kn ++ ": "
-                               ++ string_of_erase_ind_error err
   end.
 
 Program Definition erase_global_decl

--- a/extraction/theories/ExAst.v
+++ b/extraction/theories/ExAst.v
@@ -70,7 +70,6 @@ Record oib_type_var :=
 Record one_inductive_body :=
   { ind_name : ident;
     ind_type_vars : list oib_type_var;
-    ind_ctor_type_vars : list oib_type_var;
     ind_ctors : list (ident * list box_type);
     ind_projs : list (ident * box_type); }.
 

--- a/extraction/theories/Extraction.v
+++ b/extraction/theories/Extraction.v
@@ -8,7 +8,6 @@ From ConCert.Extraction Require Import Erasure.
 From ConCert.Extraction Require Import Optimize.
 From ConCert.Extraction Require Import OptimizeCorrectness.
 From ConCert.Extraction Require Import ResultMonad.
-From ConCert.Extraction Require Import SpecializeChainBase.
 From Coq Require Import List.
 From Coq Require Import String.
 From MetaCoq.Erasure Require Import ELiftSubst SafeErasureFunction.

--- a/extraction/theories/MidlangExtract.v
+++ b/extraction/theories/MidlangExtract.v
@@ -529,20 +529,13 @@ Definition print_mutual_inductive_body
 
        push_indent (col + indent_size);;
 
-       (* Type variables for constructors *)
-       Γc <- monad_fold_left
-              (fun Γ name =>
-                 name <- fresh_ty_arg_name (tvar_name name) Γ;;
-                 ret (Γ ++ [name])%list) (ind_ctor_type_vars oib) [];;
-
-
        (fix print_ind_ctors (ctors : list (ident * list box_type)) prefix :=
           match ctors with
           | [] => ret tt
           | (name, data) :: ctors =>
             append_nl_and_indent;;
             append (prefix ++ " ");;
-            print_ind_ctor_definition Γc (kn.1, name) data;;
+            print_ind_ctor_definition Γ (kn.1, name) data;;
 
             print_ind_ctors ctors "|"
           end) (ind_ctors oib) "=";;

--- a/extraction/theories/MidlangExtract.v
+++ b/extraction/theories/MidlangExtract.v
@@ -4,7 +4,6 @@ From ConCert.Execution Require Import Containers.
 From ConCert.Extraction Require Import Common.
 From ConCert.Extraction Require Import Erasure.
 From ConCert.Extraction Require Import Extraction.
-From ConCert.Extraction Require Import SpecializeChainBase.
 From ConCert.Extraction Require Import ExAst.
 From ConCert.Extraction Require Import Optimize.
 From ConCert.Extraction Require Import PrettyPrinterMonad.

--- a/extraction/theories/Optimize.v
+++ b/extraction/theories/Optimize.v
@@ -272,21 +272,18 @@ End dearg.
 Section dearg_types.
 Context (Σ : global_env).
 
-Fixpoint mkAppsBt (t : box_type) (us : list box_type) : box_type :=
-  match us with
-  | [] => t
-  | a :: args => mkAppsBt (TApp t a) args
-  end.
+Definition keep_tvar tvar :=
+  tvar_is_arity tvar && negb (tvar_is_logical tvar).
 
 Fixpoint dearg_single_bt (tvars : list oib_type_var) (t : box_type) (args : list box_type)
   : box_type :=
   match tvars, args with
   | tvar :: tvars, arg :: args =>
-    if tvar_is_logical tvar || negb (tvar_is_sort tvar) then
-      dearg_single_bt tvars t args
-    else
+    if keep_tvar tvar then
       dearg_single_bt tvars (TApp t arg) args
-  | _, _ => mkAppsBt t args
+    else
+      dearg_single_bt tvars t args
+  | _, _ => mkTApps t args
   end.
 
 Definition get_inductive_tvars (ind : inductive) : list oib_type_var :=
@@ -311,9 +308,6 @@ Definition debox_box_type (bt : box_type) : box_type :=
 Definition debox_type_constant (cst : constant_body) : constant_body :=
   {| cst_type := on_snd debox_box_type (cst_type cst);
      cst_body := cst_body cst; |}.
-
-Definition keep_tvar tvar :=
-  tvar_is_sort tvar && negb (tvar_is_logical tvar).
 
 Definition reindex (tvars : list oib_type_var) :=
   fix f (bt : box_type) : box_type :=


### PR DESCRIPTION
Remove our hack for erasing constructors: now they get erased in a context with type variables for every parameter, meaning that we no longer need a special context when printing these. Because of this we have to change deboxing of constructors and projections slightly, as they now have to have type variables adjusted.

Additionally we now avoid adding type variables after the parameters so that the erasure is total (i.e. we no longer can have unmapped type variables).