### PR TITLE
Fix type annotations when removing applications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         env && \
         opam switch && \
         eval $(opam env --switch=${COMPILER_EDGE} --set-switch) && \
-        make -j && \
+        make && \
         make html
     - uses: actions/upload-artifact@v2
       with:

--- a/extraction/examples/TypeAnnotationTests.v
+++ b/extraction/examples/TypeAnnotationTests.v
@@ -113,12 +113,14 @@ Module ex2.
   Definition foo : { n : nat | n = 0 } := exist _ 0 eq_refl.
   Definition bar := proj1_sig foo.
   MetaCoq Quote Recursively Definition ex := bar.
-  Example test_opt :
-    extract_opt ex = "(proj1_sig : sig 𝕋 → 𝕋) (foo : sig nat) : nat".
-  Proof. vm_compute. reflexivity. Qed.
+
   Example test_no_opt :
     extract_no_opt ex =
     "(((proj1_sig : □ → □ → sig 𝕋 □ → 𝕋) (□ : □) : □ → sig nat □ → nat) (□ : □) : sig nat □ → nat) (foo : sig nat □) : nat".
+  Proof. vm_compute. reflexivity. Qed.
+
+  Example test_opt :
+    extract_opt ex = "(proj1_sig : sig nat → nat) (foo : sig nat) : nat".
   Proof. vm_compute. reflexivity. Qed.
 End ex2.
 
@@ -132,8 +134,35 @@ Module ex3.
   Example test_no_opt :
     extract_no_opt ex = "(foo : (□ → nat → nat) → nat) (bar : □ → nat → nat) : nat".
   Proof. vm_compute. reflexivity. Qed.
+
   Example test_opt :
     extract_opt ex =
     "(foo : (□ → nat → nat) → nat) ((_ -> (bar : nat → nat)) : □ → nat → nat) : nat".
   Proof. vm_compute. reflexivity. Qed.
 End ex3.
+
+Module ex4.
+  Definition foo : option nat := None.
+  MetaCoq Quote Recursively Definition ex := foo.
+
+  Example test_no_opt :
+    extract_no_opt ex = "(None : □ → option 𝕋) (□ : □) : option nat".
+  Proof. vm_compute. reflexivity. Qed.
+
+  Example test_opt :
+    extract_opt ex = "None : option nat".
+  Proof. vm_compute. reflexivity. Qed.
+End ex4.
+
+Module ex5.
+  Definition foo : list nat := [0].
+  MetaCoq Quote Recursively Definition ex := foo.
+
+  Example test_no_opt :
+    extract_no_opt ex = "(((cons : □ → 𝕋 → list 𝕋 → list 𝕋) (□ : □) : nat → list nat → list nat) (O : nat) : list nat → list nat) ((nil : □ → list 𝕋) (□ : □) : list nat) : list nat".
+  Proof. vm_compute. reflexivity. Qed.
+
+  Example test_opt :
+    extract_opt ex = "((cons : nat → list nat → list nat) (O : nat) : list nat → list nat) (nil : list nat) : list nat".
+  Proof. vm_compute. reflexivity. Qed.
+End ex5.

--- a/extraction/theories/TypeAnnotations.v
+++ b/extraction/theories/TypeAnnotations.v
@@ -307,14 +307,10 @@ Proof.
                     | TArr _ cod => cod
                     | _ => bt
                     end) hda).
-      * (* arg was removed, new type is codomain *)
+      * (* arg was removed. We take the new type to be the old type of the application
+         instead of the codomain as the old type of the application is more specialized. *)
         apply IHmask; [|exact argsa].
-        exact (map_annot
-                 (fun bt =>
-                    match bt with
-                    | TArr _ cod => cod
-                    | _ => bt
-                    end) hda).
+        exact (map_annot (fun _ => p.1) hda).
     + destruct argsa.
       * refine (annot hda, _).
         apply IHmask; [|exact All_nil].
@@ -324,10 +320,7 @@ Proof.
                 | t => (t, (annot_lift _ _ hda, t))
                 end).
       * apply IHmask; [|exact argsa].
-        exact (match annot hda with
-               | TArr dom cod => (cod, (hda, p.2))
-               | t => (t, (hda, p.2))
-               end).
+        exact (p.1, (hda, p.2)).
 Defined.
 
 Definition annot_dearg_case_branches


### PR DESCRIPTION
We should use the type of the application, not the codomain, since the
application type is more specialized.