### PR TITLE
Update metacoq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConCert
 
-A framework for smart contract verification in Coq. 
+A framework for smart contract verification in Coq.
 
 See the [Papers](#paper) for details on the development.
 
@@ -17,7 +17,7 @@ opam switch create . 4.07.1
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install -j 4 coq.8.11 coq-bignums coq-stdpp coq-quickchick
-opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#6f241fe5f0c39d1d33f9ae169c81e0db968b7117
+opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#bc323fd17aa25a242480770711c6b6685803dd9c
 ```
 
 After completing the procedures above, run `make` to build the development, and

--- a/embedding/theories/pcuic/PCUICCorrectnessAux.v
+++ b/embedding/theories/pcuic/PCUICCorrectnessAux.v
@@ -1130,7 +1130,7 @@ Proof.
   + intros. simpl. symmetry. rewrite <- subst_env_i_empty with (k:=n).
     f_equal. lia.
   + intros. simpl. destruct a.
-    inversion H0. subst. clear H0.
+    inversion X0. subst. clear X0.
     assert (All (fun x => iclosed_n 0 (snd x) = true) (ρ2++ρ1))
       by now apply All_app_inv.
     rewrite subst_env_compose_1 with (ρ := ρ2 ++ ρ1) by auto.
@@ -1244,9 +1244,9 @@ Proof.
     intuition;eauto with hints.
     eapply forallb_impl_inner;intros;eauto; now apply iclosed_ty_env_ok.
     now apply iclosed_ty_env_ok.
-    apply All_forallb. apply forallb_All in H1.
-    eapply All_impl_inner. apply H. simpl in *.
-    eapply All_impl. apply H1. intros.
+    apply All_forallb. apply forallb_All in H0.
+    eapply All_impl_inner. apply X. simpl in *.
+    eapply All_impl. apply H0. intros.
     simpl in *. easy.
   + simpl in *. unfold is_true in *. repeat rewrite Bool.andb_true_iff in *.
     intuition;now apply iclosed_ty_env_ok.
@@ -1312,11 +1312,11 @@ Proof.
     * eapply ty_env_ok_subst_env;eauto.
     * apply All_forallb. apply All_map.
       intros. unfold compose. simpl in *.
-      eapply forallb_All in H2.
-      eapply (All_impl_inner _ _ _ H2).
-      eapply All_impl. apply H. intros. simpl in *.
+      eapply forallb_All in H1.
+      eapply (All_impl_inner _ _ _ H1).
+      eapply All_impl. apply X. intros. simpl in *.
       replace (#|pVars x.1| + (k + #|ρ1|)) with (#|pVars x.1| + k + #|ρ1|) by lia.
-      eapply H0;eauto.
+      eapply H;eauto.
   + simpl in *.
     unfold is_true in *. repeat rewrite Bool.andb_true_iff in *.
     intuition;eapply ty_env_ok_subst_env;eauto.

--- a/embedding/theories/pcuic/PCUICFacts.v
+++ b/embedding/theories/pcuic/PCUICFacts.v
@@ -151,9 +151,9 @@ Section Values.
       apply forallb_All in Hforall.
       apply All_impl_inner with (P:= fun x => iclosed_n (#|pVars (fst x)|+n1) (snd x) = true).
       assumption.
-      eapply All_impl. apply H.
+      eapply All_impl. apply X.
       intros. simpl in *.
-      eapply H0 with (n:=#|pVars x.1| + n1). lia. easy.
+      eapply H with (n:=#|pVars x.1| + n1). lia. easy.
     + simpl in *. rewrite H1. repeat rewrite Bool.andb_true_iff in *. intuition.
       repeat split_andb;eauto with facts.
       eapply iclosed_ty_geq with (n:=n1);eauto.
@@ -254,12 +254,12 @@ Section Values.
           intros a H. unfold compose. change (iclosed_n (0+n1) (snd a) = true); now apply iclosed_m_n.
         * simpl in *. leb_ltb_to_prop. assumption.
       + inv_andb H1. inv_andb H. split_andb;auto with facts.
-      + repeat inv_andb H0. repeat inv_andb H2.
+      + repeat inv_andb H. repeat inv_andb H1.
         destruct p as [ind tys]. simpl in *.
-        apply forallb_All in H3 as Hall3.
-        apply forallb_All in H1 as Hall1.
-        apply forallb_All in H0 as Hall0.
-        apply forallb_All in H2 as Hall2.
+        apply forallb_All in H2 as Hall3.
+        apply forallb_All in H0 as Hall1.
+        apply forallb_All in H as Hall0.
+        apply forallb_All in H1 as Hall2.
         specialize (All_mix Hall0 Hall2) as Hall'. simpl in *.
         specialize (All_mix Hall3 Hall1) as Hall. simpl in *.
         repeat split_andb;eauto with facts.
@@ -270,9 +270,9 @@ Section Values.
           intros;eapply subst_env_i_ty_closed;intuition.
         apply All_forallb. apply All_map. unfold compose. simpl.
         eapply All_impl_inner. apply Hall. simpl in *.
-        eapply All_impl. apply H. intros. simpl in *.
+        eapply All_impl. apply X. intros. simpl in *.
         rewrite PeanoNat.Nat.add_assoc in *.
-        eapply H8;intuition;auto with facts.
+        eapply H7;intuition;auto with facts.
       + inv_andb H. inv_andb H1. split_andb.
         eapply subst_env_i_ty_closed;eauto with facts. intuition.
   Qed.
@@ -628,10 +628,10 @@ Section Validate.
       simpl in *;unfold is_true in *;repeat rewrite Bool.andb_true_iff in *;intuition;
         try eapply valid_ty_env_ty_env_ok;eauto.
     + destruct p as [ind tys]. simpl in *.
-      eapply forallb_impl_inner. eapply H1. intros.
+      eapply forallb_impl_inner. eapply H0. intros.
       now eapply valid_ty_env_ty_env_ok.
-    + apply All_forallb. apply forallb_All in H2.
-      eapply All_impl_inner. apply H2. simpl.
-      eapply (All_impl H);eauto.
+    + apply All_forallb. apply forallb_All in H1.
+      eapply All_impl_inner. apply H1. simpl.
+      eapply (All_impl X);eauto.
   Qed.
 End Validate.

--- a/extraction/examples/TypeAnnotationTests.v
+++ b/extraction/examples/TypeAnnotationTests.v
@@ -110,7 +110,7 @@ Module ex1.
 End ex1.
 
 Module ex2.
-  Definition foo : { n : nat | n = 0 } := exist _ 0 eq_refl.
+  Definition foo : { n : nat | n = 0 } := exist 0 eq_refl.
   Definition bar := proj1_sig foo.
   MetaCoq Quote Recursively Definition ex := bar.
 

--- a/extraction/theories/ClosedAux.v
+++ b/extraction/theories/ClosedAux.v
@@ -180,15 +180,6 @@ Proof.
         repeat (f_equal; try lia).
 Qed.
 
-Lemma lookup_env_find Σ kn :
-  ETyping.lookup_env Σ kn =
-  option_map snd (find (fun '(kn', _) => if kername_eq_dec kn kn' then true else false) Σ).
-Proof.
-  induction Σ as [|(kn' & decl) Σ IH]; [easy|].
-  cbn.
-  now destruct (kername_eq_dec kn kn').
-Qed.
-
 Lemma closedn_subst0 s k t :
   Forall (closedn k) s ->
   closedn (k + #|s|) t ->

--- a/extraction/theories/ClosedAux.v
+++ b/extraction/theories/ClosedAux.v
@@ -88,7 +88,7 @@ Proof.
     cbn in *; auto; propify.
   - destruct (Nat.leb_spec k' n);
       cbn; propify; lia.
-  - induction H; cbn in *; propify; easy.
+  - induction X; cbn in *; propify; easy.
   - erewrite <- IHt by eassumption.
     easy.
   - erewrite <- IHt1 at 1 by easy.
@@ -100,25 +100,25 @@ Proof.
     induction X; cbn in *; propify; easy.
   - rewrite map_length.
     revert n' k k' clos.
-    induction H; intros n' k k' clos; cbn in *; propify; [easy|].
+    induction X; intros n' k k' clos; cbn in *; propify; [easy|].
     destruct x; cbn in *.
     split.
     + erewrite <- (p _ (S (#|l| + k)) _) by easy.
       f_equal.
       lia.
-    + erewrite <- (IHAll n' (S k) (S k'));
+    + erewrite <- (IHX n' (S k) (S k'));
         repeat (f_equal; try lia).
       rewrite <- (proj2 clos);
         repeat (f_equal; try lia).
   - rewrite map_length.
     revert n' k k' clos.
-    induction H; intros n' k k' clos; cbn in *; propify; [easy|].
+    induction X; intros n' k k' clos; cbn in *; propify; [easy|].
     destruct x; cbn in *.
     split.
     + erewrite <- (p _ (S (#|l| + k)) _) by easy.
       f_equal.
       lia.
-    + erewrite <- (IHAll n' (S k) (S k'));
+    + erewrite <- (IHX n' (S k) (S k'));
         repeat (f_equal; try lia).
       rewrite <- (proj2 clos);
         repeat (f_equal; try lia).
@@ -142,7 +142,7 @@ Proof.
         apply nth_error_None in eq.
         lia.
     + lia.
-  - induction H; cbn in *; propify; easy.
+  - induction X; cbn in *; propify; easy.
   - erewrite <- (IHt _ (S k')); [|easy|rewrite <- clos; f_equal; lia].
     f_equal; lia.
   - split; [easy|].
@@ -154,27 +154,27 @@ Proof.
     induction X; cbn in *; propify; easy.
   - rewrite map_length.
     revert k k' all clos.
-    induction H; intros k k' all all'; cbn in *; propify; [easy|].
+    induction X; intros k k' all all'; cbn in *; propify; [easy|].
     destruct x; cbn in *.
     split.
     + erewrite <- (p _ (S (#|l| + k'))); [|easy|].
       * f_equal; lia.
       * rewrite <- (proj1 all').
         f_equal; lia.
-    + erewrite <- (IHAll _ (S k')); [|easy|].
+    + erewrite <- (IHX _ (S k')); [|easy|].
       * repeat (f_equal; try lia).
       * rewrite <- (proj2 all').
         repeat (f_equal; try lia).
   - rewrite map_length.
     revert k k' all clos.
-    induction H; intros k k' all all'; cbn in *; propify; [easy|].
+    induction X; intros k k' all all'; cbn in *; propify; [easy|].
     destruct x; cbn in *.
     split.
     + erewrite <- (p _ (S (#|l| + k'))); [|easy|].
       * f_equal; lia.
       * rewrite <- (proj1 all').
         f_equal; lia.
-    + erewrite <- (IHAll _ (S k')); [|easy|].
+    + erewrite <- (IHX _ (S k')); [|easy|].
       * repeat (f_equal; try lia).
       * rewrite <- (proj2 all').
         repeat (f_equal; try lia).

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -1325,7 +1325,7 @@ Next Obligation.
   destruct wt as [wt].
   constructor.
   exists i.
-  specialize (onInductives _ _ _ _ wt).
+  specialize (onInductives wt).
 
   change i with (0 + i).
   generalize 0 as n.

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -1256,46 +1256,62 @@ erase_ind_ctor Γ erΓ t isT next_par (tvar :: tvars)
 Proof. all: reduce_term_sound; eauto with erase. Qed.
 
 Import ExAst.
-Program Definition erase_ind_body
+Definition erase_ind_body
         (mind : kername)
         (mib : P.mutual_inductive_body)
         (oib : P.one_inductive_body)
-        (wt : ∥∑i, on_ind_body (lift_typing typing) Σ mind mib i oib∥) : one_inductive_body :=
+        (wt : ∥∑i, on_ind_body (lift_typing typing) Σ mind mib i oib∥) : one_inductive_body.
+Proof.
+  unshelve refine (
+  let is_propositional :=
+      match destArity [] (ind_type oib) with
+      | Some (_, u) => Universe.is_prop u
+      | None => false
+      end in
   let oib_tvars := erase_ind_arity [] (P.ind_type oib) _ in
 
-  let '(Γ; erΓ) := arities_contexts mind (P.ind_bodies mib) in
+  let ctx := inspect (arities_contexts mind (P.ind_bodies mib)) in
 
   let ind_params := firstn (P.ind_npars mib) oib_tvars in
   let erase_ind_ctor (p : (ident × P.term) × nat) (is_in : In p (P.ind_ctors oib)) :=
-      let '((name, t), _) := p in
-      let bt := erase_ind_ctor Γ erΓ t _ 0 ind_params in
+      let bt := erase_ind_ctor (proj1_sig ctx).π1 (proj1_sig ctx).π2 p.1.2 _ 0 ind_params in
       let '(ctor_args, _) := decompose_arr bt in
-      (name, ctor_args) in
+      (p.1.1, ctor_args) in
 
   let ctors := map_In (P.ind_ctors oib) erase_ind_ctor in
 
+  let erase_ind_proj (p : ident × P.term) (is_in : In p (P.ind_projs oib)) :=
+      (p.1, TBox) (* todo *) in
+
+  let projs := map_In (P.ind_projs oib) erase_ind_proj in
+
   {| ind_name := P.ind_name oib;
+     ind_propositional := is_propositional;
+     ind_kelim := P.ind_kelim oib;
      ind_type_vars := oib_tvars;
      ind_ctors := ctors;
-     ind_projs := [] (* todo *) |}.
-Next Obligation.
-  destruct wt as [wt].
-  sq.
-  right.
-  exact (onArity wt.π2).
-Qed.
-Next Obligation.
-  destruct wt as [[ind_index wt]].
-  pose proof (onConstructors wt) as on_ctors.
-  unfold on_constructors in *.
-  induction on_ctors; [easy|].
-  destruct is_in as [->|later]; [|easy].
-  constructor.
-  destruct (on_ctype r) as (s & typ).
-  rewrite <- (arities_contexts_1 mind) in typ.
-  rewrite <- Heq_anonymous in typ.
-  now exists s.
-Qed.
+     ind_ctor_original_arities := map snd (P.ind_ctors oib);
+     ind_projs := projs |}).
+
+  - abstract (
+        destruct wt as [wt];
+        sq;
+        right;
+        exact (onArity wt.π2)).
+  - abstract (
+        destruct p as ((?&?)&?);
+        cbn in *;
+        destruct wt as [[ind_index wt]];
+        pose proof (onConstructors wt) as on_ctors;
+        unfold on_constructors in *;
+        induction on_ctors; [easy|];
+        destruct is_in as [->|later]; [|easy];
+        constructor;
+        destruct (on_ctype r) as (s & typ);
+        rewrite <- (arities_contexts_1 mind) in typ;
+        cbn in *;
+        now exists s).
+Defined.
 
 Program Definition erase_ind
         (kn : kername)

--- a/extraction/theories/Extraction.v
+++ b/extraction/theories/Extraction.v
@@ -1,10 +1,9 @@
 (* This file provides the main function for invoking our extraction. *)
 
-From ConCert.Execution Require Import Blockchain.
-From ConCert.Execution Require Import Serializable.
 From ConCert.Extraction Require Import ClosedAux.
 From ConCert.Extraction Require Import Common.
 From ConCert.Extraction Require Import Erasure.
+From ConCert.Extraction Require Import ExAst.
 From ConCert.Extraction Require Import Optimize.
 From ConCert.Extraction Require Import OptimizeCorrectness.
 From ConCert.Extraction Require Import ResultMonad.

--- a/extraction/theories/Optimize.v
+++ b/extraction/theories/Optimize.v
@@ -236,6 +236,8 @@ Definition dearg_oib
            (oib_index : nat)
            (oib : one_inductive_body) : one_inductive_body :=
   {| ind_name := ind_name oib;
+     ind_propositional := ind_propositional oib;
+     ind_kelim := ind_kelim oib;
      ind_type_vars := ind_type_vars oib;
      ind_ctors :=
        mapi (fun c '(name, bts) =>
@@ -247,6 +249,7 @@ Definition dearg_oib
                    end in
                (name, masked (param_mask mib_masks ++ ctor_mask) bts))
             (ind_ctors oib);
+     ind_ctor_original_arities := ind_ctor_original_arities oib;
      ind_projs := ind_projs oib |}.
 
 Definition dearg_mib (kn : kername) (mib : mutual_inductive_body) : mutual_inductive_body :=
@@ -321,8 +324,11 @@ Definition reindex (tvars : list type_var_info) :=
 Definition debox_type_oib (oib : one_inductive_body) : one_inductive_body :=
   let debox := reindex (ind_type_vars oib) ∘ debox_box_type in
   {| ind_name := ind_name oib;
+     ind_propositional := ind_propositional oib;
+     ind_kelim := ind_kelim oib;
      ind_type_vars := filter keep_tvar (ind_type_vars oib);
      ind_ctors := map (on_snd (map debox)) (ind_ctors oib);
+     ind_ctor_original_arities := ind_ctor_original_arities oib;
      ind_projs := map (on_snd debox) (ind_projs oib); |}.
 
 Definition debox_type_mib (mib : mutual_inductive_body) : mutual_inductive_body :=

--- a/extraction/theories/OptimizeCorrectness.v
+++ b/extraction/theories/OptimizeCorrectness.v
@@ -202,7 +202,7 @@ Proof.
     cbn in *; auto.
   - propify.
     destruct (Nat.eqb_spec n n'); lia.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     propify.
     easy.
@@ -219,21 +219,21 @@ Proof.
     easy.
   - easy.
   - revert k n' clos klen.
-    induction H; [easy|]; intros k n' clos klen.
+    induction X; [easy|]; intros k n' clos klen.
     destruct x.
     cbn in *.
     propify.
     split; [easy|].
     rewrite <- Nat.add_succ_r in *.
-    now eapply IHAll.
+    now eapply IHX.
   - revert k n' clos klen.
-    induction H; [easy|]; intros k n' clos klen.
+    induction X; [easy|]; intros k n' clos klen.
     destruct x.
     cbn in *.
     propify.
     split; [easy|].
     rewrite <- Nat.add_succ_r in *.
-    now eapply IHAll.
+    now eapply IHX.
 Qed.
 
 Lemma is_dead_csubst k t u k' :
@@ -253,7 +253,7 @@ Proof.
     + cbn.
       propify.
       lia.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     propify.
     easy.
@@ -272,7 +272,7 @@ Proof.
     easy.
   - rewrite map_length.
     revert k k' kltn use_eq clos.
-    induction H; [easy|]; intros k k' kltn use_eq clos.
+    induction X; [easy|]; intros k k' kltn use_eq clos.
     destruct x.
     cbn in *.
     propify.
@@ -280,11 +280,11 @@ Proof.
     + apply p; [easy| |easy].
       now eapply closed_upwards.
     + rewrite <- !Nat.add_succ_r in *.
-      apply IHAll; [easy|easy|].
+      apply IHX; [easy|easy|].
       now eapply closed_upwards.
   - rewrite map_length.
     revert k k' kltn use_eq clos.
-    induction H; [easy|]; intros k k' kltn use_eq clos.
+    induction X; [easy|]; intros k k' kltn use_eq clos.
     destruct x.
     cbn in *.
     propify.
@@ -292,7 +292,7 @@ Proof.
     + apply p; [easy| |easy].
       now eapply closed_upwards.
     + rewrite <- !Nat.add_succ_r in *.
-      apply IHAll; [easy|easy|].
+      apply IHX; [easy|easy|].
       now eapply closed_upwards.
 Qed.
 
@@ -419,7 +419,7 @@ Proof.
     + easy.
   - easy.
   - f_equal.
-    induction H; [easy|].
+    induction X; [easy|].
     cbn in *.
     propify.
     now f_equal.
@@ -438,7 +438,7 @@ Proof.
   - now f_equal.
   - f_equal.
     revert k no_use.
-    induction H; [easy|]; intros k no_use.
+    induction X; [easy|]; intros k no_use.
     unfold map_def in *.
     destruct x; cbn in *; propify.
     f_equal.
@@ -447,10 +447,10 @@ Proof.
       rewrite <- (proj1 no_use).
       now f_equal.
     + rewrite <- Nat.add_succ_r in *.
-      now apply IHAll.
+      now apply IHX.
   - f_equal.
     revert k no_use.
-    induction H; [easy|]; intros k no_use.
+    induction X; [easy|]; intros k no_use.
     unfold map_def in *.
     destruct x; cbn in *; propify.
     f_equal.
@@ -459,7 +459,7 @@ Proof.
       rewrite <- (proj1 no_use).
       now f_equal.
     + rewrite <- !Nat.add_succ_r in *.
-      now apply IHAll.
+      now apply IHX.
 Qed.
 
 Lemma masked_nil {X} mask :
@@ -680,9 +680,9 @@ Proof.
     cbn.
     f_equal.
     f_equal.
-    induction H; [easy|].
+    induction X; [easy|].
     cbn in *.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
   - rewrite lift_mkApps.
     cbn.
     now rewrite IHt.
@@ -725,10 +725,10 @@ Proof.
     f_equal.
     f_equal.
     rewrite map_length.
-    induction H in k |- *; [easy|].
+    induction X in k |- *; [easy|].
     cbn in *.
     rewrite <- Nat.add_succ_r.
-    rewrite IHAll.
+    rewrite IHX.
     f_equal.
     unfold map_def.
     cbn.
@@ -739,10 +739,10 @@ Proof.
     f_equal.
     f_equal.
     rewrite map_length.
-    induction H in k |- *; [easy|].
+    induction X in k |- *; [easy|].
     cbn in *.
     rewrite <- Nat.add_succ_r.
-    rewrite IHAll.
+    rewrite IHX.
     f_equal.
     unfold map_def.
     cbn.
@@ -850,9 +850,9 @@ Proof.
        cbn in *);
        lia.
   - easy.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
   - now rewrite IHt.
   - now rewrite IHt1, IHt2.
   - now rewrite IHt1, IHt2.
@@ -865,19 +865,19 @@ Proof.
     now rewrite p0, IHX.
   - now rewrite IHt.
   - rewrite map_length.
-    induction H in H, m, k, k', lt |- *; [easy|].
+    induction X in X, m, k, k', lt |- *; [easy|].
     cbn.
     rewrite p by lia.
     f_equal.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
   - rewrite map_length.
-    induction H in H, m, k, k', lt |- *; [easy|].
+    induction X in X, m, k, k', lt |- *; [easy|].
     cbn.
     rewrite p by lia.
     f_equal.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
 Qed.
 
 Lemma is_dead_lift_all k k' n t :
@@ -888,7 +888,7 @@ Proof.
   intros l1 l2.
   induction t using term_forall_list_ind in t, n, k, k', l1, l2 |- *; cbn in *; auto.
   - destruct (_ <=? _) eqn:?; cbn; propify; lia.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     now rewrite p.
   - now rewrite IHt.
@@ -901,19 +901,19 @@ Proof.
     cbn.
     now rewrite p0.
   - rewrite map_length.
-    induction H in H, m, k, k', n, l1, l2 |- *; [easy|].
+    induction X in X, m, k, k', n, l1, l2 |- *; [easy|].
     cbn in *.
     rewrite p by easy.
     cbn.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
   - rewrite map_length.
-    induction H in H, m, k, k', n, l1, l2 |- *; [easy|].
+    induction X in X, m, k, k', n, l1, l2 |- *; [easy|].
     cbn in *.
     rewrite p by easy.
     cbn.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
 Qed.
 
 Lemma is_dead_subst_other k k' s t :
@@ -935,7 +935,7 @@ Proof.
     + cbn.
       propify.
       lia.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     now rewrite p.
   - now rewrite IHt.
@@ -947,19 +947,19 @@ Proof.
     cbn.
     now rewrite p0.
   - rewrite map_length.
-    induction H in H, m, k, k', lt |- *; [easy|].
+    induction X in X, m, k, k', lt |- *; [easy|].
     cbn.
     rewrite p by easy.
     f_equal.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
   - rewrite map_length.
-    induction H in H, m, k, k', lt |- *; [easy|].
+    induction X in X, m, k, k', lt |- *; [easy|].
     cbn.
     rewrite p by easy.
     f_equal.
     rewrite <- !Nat.add_succ_r.
-    now apply IHAll.
+    now apply IHX.
 Qed.
 
 Lemma valid_dearg_mask_lift mask n k t :
@@ -1082,9 +1082,9 @@ Lemma is_expanded_aux_lift k n k' t :
 Proof.
   induction t in n, k, k', t |- * using term_forall_list_ind; cbn in *; auto.
   - now destruct (_ <=? _).
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
   - now rewrite IHt1, IHt2.
   - now rewrite IHt1, IHt2.
   - rewrite IHt.
@@ -1092,14 +1092,14 @@ Proof.
     induction X; [easy|].
     cbn in *.
     now rewrite p0, IHX.
-  - induction H in k' |- *; [easy|].
+  - induction X in k' |- *; [easy|].
     cbn.
     rewrite <- Nat.add_succ_r.
-    now rewrite p, IHAll.
-  - induction H in k' |- *; [easy|].
+    now rewrite p, IHX.
+  - induction X in k' |- *; [easy|].
     cbn.
     rewrite <- Nat.add_succ_r.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
 Qed.
 
 Lemma is_expanded_lift n k t :
@@ -1129,7 +1129,7 @@ Proof.
        try destruct (_ =? _) eqn:?; propify;
        cbn in *);
        lia.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     now rewrite p.
   - now rewrite IHt.
@@ -1140,20 +1140,20 @@ Proof.
     induction X; cbn in *; [easy|].
     now rewrite p0.
   - rewrite map_length.
-    induction H in H, m, k, k', n, l1, l2 |- *; [easy|].
+    induction X in X, m, k, k', n, l1, l2 |- *; [easy|].
     cbn in *.
     rewrite p by easy.
     cbn.
     rewrite <- !Nat.add_succ_r.
-    rewrite IHAll by easy.
+    rewrite IHX by easy.
     now replace (S (k - n)) with (S k - n) by lia.
   - rewrite map_length.
-    induction H in H, m, k, k', n, l1, l2 |- *; [easy|].
+    induction X in X, m, k, k', n, l1, l2 |- *; [easy|].
     cbn in *.
     rewrite p by easy.
     cbn.
     rewrite <- !Nat.add_succ_r.
-    rewrite IHAll by easy.
+    rewrite IHX by easy.
     now replace (S (k - n)) with (S k - n) by lia.
 Qed.
 
@@ -1210,9 +1210,9 @@ Proof.
         cbn in *.
         repeat (destruct (_ =? _) eqn:?; propify); auto; try lia.
     + destruct (n =? k) eqn:?, (n =? S k) eqn:?, (n =? k') eqn:?; propify; cbn in *; auto; lia.
-   - induction H; [easy|].
+   - induction X; [easy|].
      cbn.
-     rewrite !p, !IHAll by easy.
+     rewrite !p, !IHX by easy.
      bia.
    - now rewrite IHt.
    - rewrite IHt1, IHt2 by easy.
@@ -1228,22 +1228,22 @@ Proof.
      + now rewrite Bool.orb_true_r in IHX.
      + now rewrite Bool.orb_false_r in IHX.
    - rewrite map_length.
-     induction H in H, m, k, k', le |- *; cbn in *; [easy|].
+     induction X in X, m, k, k', le |- *; cbn in *; [easy|].
      rewrite p by easy.
-     specialize (IHAll (S k) (S k') ltac:(lia)).
+     specialize (IHX (S k) (S k') ltac:(lia)).
      rewrite !Nat.sub_succ in *.
      replace (#|l| + k - (#|l| + k')) with (k - k') by lia.
      rewrite <- !Nat.add_succ_r.
-     rewrite IHAll.
+     rewrite IHX.
      bia.
    - rewrite map_length.
-     induction H in H, m, k, k', le |- *; cbn in *; [easy|].
+     induction X in X, m, k, k', le |- *; cbn in *; [easy|].
      rewrite p by easy.
-     specialize (IHAll (S k) (S k') ltac:(lia)).
+     specialize (IHX (S k) (S k') ltac:(lia)).
      rewrite !Nat.sub_succ in *.
      replace (#|l| + k - (#|l| + k')) with (k - k') by lia.
      rewrite <- !Nat.add_succ_r.
-     rewrite IHAll.
+     rewrite IHX.
      bia.
 Qed.
 
@@ -1287,8 +1287,8 @@ Proof.
   - now rewrite no_use; apply forallb_Forall.
   - now apply forallb_Forall.
   - propify; split; [|now apply forallb_Forall].
-    induction H; [easy|]; cbn in *; propify.
-    now rewrite p, IHAll.
+    induction X; [easy|]; cbn in *; propify.
+    now rewrite p, IHX.
   - rewrite IHt by easy.
     now apply forallb_Forall.
   - propify.
@@ -1314,20 +1314,20 @@ Proof.
     now destruct (get_mib_masks _); apply IHt.
   - rewrite map_length.
     propify; split; [|now apply forallb_Forall].
-    induction H in k, m, H, no_use |- *; [easy|].
+    induction X in k, m, X, no_use |- *; [easy|].
     cbn in *; propify.
     rewrite <- !Nat.add_succ_r in *.
     rewrite p by easy.
     split; [easy|].
-    now apply IHAll.
+    now apply IHX.
   - rewrite map_length.
     propify; split; [|now apply forallb_Forall].
-    induction H in k, m, H, no_use |- *; [easy|].
+    induction X in k, m, X, no_use |- *; [easy|].
     cbn in *; propify.
     rewrite <- !Nat.add_succ_r in *.
     rewrite p by easy.
     split; [easy|].
-    now apply IHAll.
+    now apply IHX.
 Qed.
 
 Lemma valid_dearg_mask_dearg mask t :
@@ -1388,12 +1388,12 @@ Proof.
     rewrite !map_map.
     f_equal.
     f_equal.
-    induction H; [easy|].
+    induction X; [easy|].
     cbn in *.
     propify.
     f_equal.
     + now apply (p _ _ []).
-    + now apply IHAll.
+    + now apply IHX.
   - rewrite subst_mkApps, map_map.
     cbn.
     f_equal.
@@ -1442,11 +1442,11 @@ Proof.
     cbn.
     f_equal.
     rewrite map_length.
-    revert k; induction H; intros k; [easy|].
+    revert k; induction X; intros k; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    f_equal; [|now apply IHAll].
+    f_equal; [|now apply IHX].
     unfold map_def; cbn.
     f_equal.
     now apply (p _ _ []).
@@ -1457,11 +1457,11 @@ Proof.
     cbn.
     f_equal.
     rewrite map_length.
-    revert k; induction H; intros k; [easy|].
+    revert k; induction X; intros k; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    f_equal; [|now apply IHAll].
+    f_equal; [|now apply IHX].
     unfold map_def; cbn.
     f_equal.
     now apply (p _ _ []).
@@ -1555,9 +1555,9 @@ Proof.
     + easy.
     + easy.
   - easy.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *; propify.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
   - now apply IHt.
   - now propify.
   - now propify.
@@ -1571,16 +1571,16 @@ Proof.
     propify.
     now rewrite p0, IHX.
   - easy.
-  - induction H in m, H, k, expt |- *; [easy|].
+  - induction X in m, X, k, expt |- *; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    now rewrite p, IHAll.
-  - induction H in m, H, k, expt |- *; [easy|].
+    now rewrite p, IHX.
+  - induction X in m, X, k, expt |- *; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
 Qed.
 
 Lemma is_expanded_aux_subst s n t k :
@@ -1599,9 +1599,9 @@ Proof.
       now eapply is_expanded_aux_upwards.
     + now rewrite nth_error_nil in nth.
   - easy.
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *; propify.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
   - now apply IHt.
   - now propify.
   - now propify.
@@ -1615,16 +1615,16 @@ Proof.
     propify.
     now rewrite p0, IHX.
   - easy.
-  - induction H in m, H, k, expt |- *; [easy|].
+  - induction X in m, X, k, expt |- *; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    now rewrite p, IHAll.
-  - induction H in m, H, k, expt |- *; [easy|].
+    now rewrite p, IHX.
+  - induction X in m, X, k, expt |- *; [easy|].
     cbn in *.
     propify.
     rewrite <- !Nat.add_succ_r.
-    now rewrite p, IHAll.
+    now rewrite p, IHX.
 Qed.
 
 Lemma is_expanded_substl s n t :
@@ -1841,7 +1841,7 @@ Proof.
   intros valid_t.
   induction t in t, k, valid_t |- * using term_forall_list_ind; cbn in *; propify; auto.
   - now destruct (_ <=? _).
-  - induction H; [easy|].
+  - induction X; [easy|].
     cbn in *.
     now propify.
   - easy.
@@ -1856,11 +1856,11 @@ Proof.
     now propify.
   - destruct s as ((ind & npars) & arg).
     now propify.
-  - induction H in H, k, valid_t |- *; [easy|].
+  - induction X in X, k, valid_t |- *; [easy|].
     cbn in *.
     propify.
     now rewrite <- !Nat.add_succ_r.
-  - induction H in H, k, valid_t |- *; [easy|].
+  - induction X in X, k, valid_t |- *; [easy|].
     cbn in *.
     propify.
     now rewrite <- !Nat.add_succ_r.
@@ -1879,7 +1879,7 @@ Proof.
     + noconf nth.
       now apply valid_cases_lift.
     + now rewrite nth_error_nil in nth.
-  - induction H; [easy|].
+  - induction X; [easy|].
     now cbn in *; propify.
   - easy.
   - easy.
@@ -1892,10 +1892,10 @@ Proof.
     now cbn in *; propify.
   - destruct s0 as ((ind & npars) & arg).
     now propify.
-  - induction H in H, k, valid_t |- *; [easy|].
+  - induction X in X, k, valid_t |- *; [easy|].
     cbn in *; propify.
     now rewrite <- !Nat.add_succ_r.
-  - induction H in H, k, valid_t |- *; [easy|].
+  - induction X in X, k, valid_t |- *; [easy|].
     cbn in *; propify.
     now rewrite <- !Nat.add_succ_r.
 Qed.
@@ -1948,7 +1948,7 @@ Proof.
     try solve [now apply closedn_mkApps].
   - apply closedn_mkApps; [|easy].
     cbn.
-    induction H; [easy|].
+    induction X; [easy|].
     cbn in *.
     now propify.
   - apply closedn_mkApps; [|easy].
@@ -1982,19 +1982,19 @@ Proof.
   - apply closedn_mkApps; [|easy].
     cbn.
     rewrite map_length.
-    induction H in k, args, H, clos_t |- *; [easy|].
+    induction X in k, args, X, clos_t |- *; [easy|].
     cbn in *; propify.
     split; [easy|].
     rewrite <- !Nat.add_succ_r in *.
-    now apply IHAll.
+    now apply IHX.
   - apply closedn_mkApps; [|easy].
     cbn.
     rewrite map_length.
-    induction H in k, args, H, clos_t |- *; [easy|].
+    induction X in k, args, X, clos_t |- *; [easy|].
     cbn in *; propify.
     split; [easy|].
     rewrite <- !Nat.add_succ_r in *.
-    now apply IHAll.
+    now apply IHX.
 Qed.
 
 Hint Resolve

--- a/extraction/theories/OptimizeCorrectness.v
+++ b/extraction/theories/OptimizeCorrectness.v
@@ -27,108 +27,28 @@ Import Erasure.
 Import ExAst.
 Import ConCert.Extraction.Aux.
 
-(* We have our own environment which is different from MetaCoq's erased environment
-   (it includes more information and a different treatment of types).
-   To reconcile this, we map our environments to theirs, but the treatment of types
-   remains different. However, MetaCoq does not actually use information about types
-   for anything during evaluation, so we just filter them out. This is justified
-   by the following lemmas. *)
-Definition is_constant (decl : EAst.global_decl) : bool :=
-  match decl with
-  | EAst.ConstantDecl _ => true
-  | _ => false
-  end.
-
-Definition only_constants (Σ : EAst.global_context) : EAst.global_context :=
-  filter (is_constant ∘ snd) Σ.
-
-Lemma declared_constant_only_constants Σ kn decl :
-  ETyping.declared_constant Σ kn decl ->
-  ETyping.declared_constant (only_constants Σ) kn decl.
+Lemma lookup_env_trans_env Σ kn :
+  ETyping.lookup_env (trans_env Σ) kn =
+  option_map trans_global_decl (lookup_env Σ kn).
 Proof.
-  unfold ETyping.declared_constant.
-  intros lookup_decl.
-  induction Σ; [easy|].
-  destruct a as (kn' & decl').
-  cbn in *.
-  destruct (is_constant decl') eqn:isconst.
-  - cbn in *.
-    destruct (kername_eq_dec _ _) as [<-|?]; easy.
-  - apply IHΣ.
-    destruct (kername_eq_dec _ _).
-    + inversion lookup_decl; subst; easy.
-    + auto.
-Qed.
-
-Lemma eval_only_constants Σ s t :
-  Σ e⊢ s ▷ t ->
-  only_constants Σ e⊢ s ▷ t.
-Proof.
-  induction 1; eauto using eval, declared_constant_only_constants.
-Qed.
-
-Definition trans_cst (cst : constant_body) : EAst.constant_body :=
-  {| EAst.cst_body := cst_body cst |}.
-
-(* Translation from our global environment into MetaCoq's global environment.
-   We only translate constants which is justified by the proof above. *)
-Definition trans_env (Σ : global_env) : EAst.global_context :=
-  let map_decl kn (decl : global_decl) : list (kername * EAst.global_decl) :=
-      match decl with
-      | ConstantDecl cst => [(kn, EAst.ConstantDecl (trans_cst cst))]
-      | InductiveDecl _ => []
-      | TypeAliasDecl o =>
-        [(kn, EAst.ConstantDecl
-                {| EAst.cst_body := option_map (fun _ => tBox) o |})]
-      end in
-  flat_map (fun '(kn, _, decl) => map_decl kn decl) Σ.
-
-Lemma declared_constant_trans Σ kn cst :
-  ETyping.declared_constant (trans_env Σ) kn cst ->
-  (exists n has_deps typ,
-    nth_error Σ n =
-    Some (kn, has_deps, ConstantDecl {| cst_type := typ; cst_body := EAst.cst_body cst |})) \/
-  ((EAst.cst_body cst = Some tBox \/ EAst.cst_body cst = None) /\
-    exists n has_deps typ,
-      nth_error Σ n = Some (kn, has_deps, TypeAliasDecl typ)).
-Proof.
-  unfold ETyping.declared_constant.
-  intros decl.
+  unfold lookup_env, eq_kername.
   induction Σ as [|((kn' & has_deps') & cst') Σ IH]; [easy|].
-  destruct cst'; cbn in *.
-  - destruct (kername_eq_dec _ _) as [->|].
-    + noconf decl.
-      cbn in *.
-      left.
-      eexists 0, has_deps', (cst_type c).
-      now destruct c.
-    + destruct IH as [(n' & typ & cond)|(isbox & n' & typ & cond)].
-      * eassumption.
-      * left.
-        now exists (S n').
-      * right.
-        split; [easy|].
-        now exists (S n').
-  - destruct IH as [(n' & typ & cond)|(isbox & n' & typ & cond)].
-    + eassumption.
-    + left.
-      now exists (S n').
-    + right.
-      split; [easy|].
-      now exists (S n').
-  - destruct (kername_eq_dec _ _) as [->|].
-    + noconf decl.
-      cbn in *.
-      right.
-      split; [destruct o; tauto|].
-      now eexists 0, _, _.
-    + destruct IH as [(n' & typ & cond)|(isbox & n' & typ & cond)].
-      * eassumption.
-      * left.
-        now exists (S n').
-      * right.
-        split; [easy|].
-        now exists (S n').
+  cbn in *.
+  now destruct (kername_eq_dec _ _) as [->|].
+Qed.
+
+Lemma declared_constant_trans_env Σ kn ecst :
+  declared_constant (trans_env Σ) kn ecst ->
+  (exists cst, ecst = trans_cst cst /\ lookup_env Σ kn = Some (ConstantDecl cst)) \/
+  (exists ta, ecst = {| EAst.cst_body := option_map (fun _ => tBox) ta |} /\
+              lookup_env Σ kn = Some (TypeAliasDecl ta)).
+Proof.
+  unfold declared_constant.
+  rewrite lookup_env_trans_env.
+  cbn.
+  intros decl.
+  destruct (lookup_env Σ kn) as [cst|]; cbn in *; [|congruence].
+  destruct cst; cbn in *; [|congruence|]; noconf decl; eauto.
 Qed.
 
 Fixpoint is_dead (rel : nat) (t : term) : bool :=
@@ -437,25 +357,18 @@ Proof.
       * now rewrite IH.
 Qed.
 
-Lemma eval_dearg_single_head Σ mask head args v :
+Lemma dearg_single_masked mask t args :
   #|mask| <= #|args| ->
-  Σ e⊢ dearg_single mask head args ▷ v ->
-  ∑ hdv, Σ e⊢ head ▷ hdv.
+  dearg_single mask t args = mkApps t (masked mask args).
 Proof.
-  revert head args v.
-  induction mask as [|[] mask IH]; intros head args v l ev.
-  - cbn in *.
-    now apply eval_mkApps_head in ev.
-  - destruct args as [|a args]; cbn in *; [easy|].
-    now eapply (IH _ args).
-  - destruct args as [|a args]; cbn in *; [easy|].
-    edestruct (IH (tApp head a) args) as (appv & ev_app).
-    + easy.
-    + exact ev.
-    + now apply eval_tApp_head in ev_app.
+  intros le.
+  induction mask in mask, t, args, le |- *.
+  - now destruct args.
+  - destruct args; [easy|].
+    now destruct a; cbn in *; apply IHmask.
 Qed.
 
-Lemma eval_dearg_lambdas_inv Σ mask Γ inner v :
+Lemma eval_dearg_lambdas_inv {wfl:WcbvFlags} Σ mask Γ inner v :
   env_closed Σ ->
   closed (it_mkLambda_or_LetIn Γ inner) ->
   #|mask| = #|vasses Γ| ->
@@ -492,28 +405,6 @@ Proof.
         now eapply eval_atom.
       * eexists.
         now eapply eval_atom.
-Qed.
-
-Lemma eval_dearg_single_heads mask args Σ hd hd' hdv v :
-  #|mask| <= #|args| ->
-  Σ e⊢ hd ▷ hdv ->
-  Σ e⊢ dearg_single mask hd' args ▷ v ->
-  Σ e⊢ hd' ▷ hdv ->
-  Σ e⊢ dearg_single mask hd args ▷ v.
-Proof.
-  revert hd hd' hdv args v.
-  induction mask as [|[] mask IH]; intros hd hd' hdv args v len ev_hd ev ev_hd';
-    cbn in *.
-  - now eapply eval_mkApps_heads; [|eassumption|eassumption].
-  - now destruct args; cbn in *.
-  - destruct args; cbn in *; [easy|].
-    apply eval_dearg_single_head in ev as ev_app_hd; [|easy].
-    destruct ev_app_hd as (app_hdv & ev_app_hd).
-    eapply IH.
-    + easy.
-    + now eapply eval_tApp_heads; [| |exact ev_app_hd].
-    + eassumption.
-    + easy.
 Qed.
 
 Lemma no_use_subst k t s s' :
@@ -571,21 +462,9 @@ Proof.
       now apply IHAll.
 Qed.
 
-
 Lemma masked_nil {X} mask :
   @masked X mask [] = [].
 Proof. now destruct mask as [|[] ?]. Qed.
-
-Lemma dearg_single_masked mask t args :
-  #|mask| <= #|args| ->
-  dearg_single mask t args = mkApps t (masked mask args).
-Proof.
-  intros le.
-  induction mask in mask, t, args, le |- *.
-  - now destruct args.
-  - destruct args; [easy|].
-    now destruct a; cbn in *; apply IHmask.
-Qed.
 
 Lemma All2_masked {X Y} {T : X -> Y -> Type} xs ys mask :
   All2 T xs ys ->
@@ -599,7 +478,7 @@ Proof.
     + now constructor.
 Qed.
 
-Lemma dearg_lambdas_correct Σ body args mask v :
+Lemma dearg_lambdas_correct {wfl:WcbvFlags} Σ body args mask v :
   env_closed Σ ->
   closed body ->
   Forall (closedn 0) args ->
@@ -1812,6 +1691,22 @@ Proof.
   now apply Forall_is_expanded_cofix_subst.
 Qed.
 
+Lemma lookup_env_Forall {P} Σ kn decl :
+  lookup_env Σ kn = Some decl ->
+  Forall P Σ ->
+  exists b, P (kn, b, decl).
+Proof.
+  intros look all.
+  unfold lookup_env in *.
+  destruct find as [((kn' & b) & decl')|] eqn:find; cbn in *; [|congruence].
+  noconf look.
+  apply find_some in find as (isin & name_eq).
+  unfold eq_kername in *.
+  destruct kername_eq_dec as [->|]; [|congruence].
+  rewrite Forall_forall in all.
+  now eexists; apply all.
+Qed.
+
 Lemma is_expanded_constant Σ kn cst body :
   is_expanded_env Σ ->
   ETyping.declared_constant (trans_env Σ) kn cst ->
@@ -1821,14 +1716,16 @@ Proof.
   intros exp_env decl body_eq.
   unfold is_expanded_env in *.
   apply forallb_Forall in exp_env.
-  eapply declared_constant_trans in decl as [(? & ? & ? & nth)|(is_box & _)].
-  - rewrite body_eq in nth.
-    now eapply nth_error_forall in nth; [|eassumption].
-  - destruct is_box; [|congruence].
+  apply declared_constant_trans_env in decl as [(? & -> & look)|(? & -> & look)]; cbn in *.
+  - eapply lookup_env_Forall in look as (? & P); eauto.
+    destruct x.
+    cbn in *.
+    now rewrite body_eq in P.
+  - destruct x; cbn in *; [|congruence].
     now replace body with tBox by congruence.
 Qed.
 
-Lemma eval_is_expanded_aux Σ t v k :
+Lemma eval_is_expanded_aux {wfl:WcbvFlags} Σ t v k :
   trans_env Σ e⊢ t ▷ v ->
   is_expanded_env Σ ->
   is_expanded_aux k t ->
@@ -2258,12 +2155,13 @@ Lemma valid_cases_constant Σ kn cst body :
   valid_cases body.
 Proof.
   intros valid_env decl_const body_eq.
-  eapply declared_constant_trans in decl_const as [(? & ? & ? & nth)|(is_box & _)].
-  - eapply nth_error_forallb in valid_env.
-    rewrite nth in valid_env.
+  eapply declared_constant_trans_env in decl_const as [(? & -> & look)|(? & -> & look)].
+  - apply forallb_Forall in valid_env.
+    eapply lookup_env_Forall in valid_env as (? & valid); eauto.
+    destruct x.
     cbn in *.
-    now rewrite body_eq in valid_env; propify.
-  - destruct is_box; [|congruence].
+    now rewrite body_eq in valid; propify.
+  - destruct x; cbn in *; [|congruence].
     now replace body with tBox by congruence.
 Qed.
 
@@ -2274,21 +2172,20 @@ Lemma valid_dearg_mask_constant Σ kn cst body :
   valid_dearg_mask (get_const_mask kn) body.
 Proof.
   intros valid_env decl_const body_eq.
-  eapply declared_constant_trans in decl_const as [(? & ? & ? & nth)|(is_box & ? & ? & ? & nth)].
-  - eapply nth_error_forallb in valid_env.
-    rewrite nth in valid_env.
+  apply forallb_Forall in valid_env.
+  eapply declared_constant_trans_env in decl_const as [(? & -> & look)|(? & -> & look)].
+  - eapply lookup_env_Forall in valid_env as (? & valid); eauto.
+    destruct x.
     cbn in *.
-    now rewrite body_eq in valid_env; propify.
-  - eapply nth_error_forallb in valid_env.
-    rewrite nth in valid_env.
-    cbn in *.
-    destruct is_box; [|congruence].
+    now rewrite body_eq in valid; propify.
+  - eapply lookup_env_Forall in valid_env as (? & valid); eauto.
+    destruct x; cbn in *; [|congruence].
     replace body with tBox by congruence.
     cbn.
     now destruct get_const_mask.
 Qed.
 
-Lemma eval_valid_cases Σ t v :
+Lemma eval_valid_cases {wfl:WcbvFlags} Σ t v :
   trans_env Σ e⊢ t ▷ v ->
 
   env_closed (trans_env Σ) ->
@@ -2381,31 +2278,34 @@ Proof with auto with dearg.
   - easy.
 Qed.
 
+Lemma lookup_env_dearg_env Σ kn :
+  lookup_env (dearg_env Σ) kn = option_map (dearg_decl kn) (lookup_env Σ kn).
+Proof.
+  unfold lookup_env.
+  induction Σ as [|((kn', has_deps), decl) Σ IH]; [easy|].
+  cbn.
+  unfold eq_kername.
+  destruct kername_eq_dec as [->|]; [easy|].
+  apply IH.
+Qed.
+
 Lemma declared_constant_dearg Σ k cst :
-  ETyping.declared_constant (trans_env Σ) k cst ->
+  declared_constant (trans_env Σ) k cst ->
   ∑ cst',
-    ETyping.declared_constant (trans_env (dearg_env Σ)) k cst' ×
+    declared_constant (trans_env (dearg_env Σ)) k cst' ×
     EAst.cst_body cst' = option_map (dearg ∘ dearg_lambdas (get_const_mask k))
                                     (EAst.cst_body cst).
 Proof.
-  unfold ETyping.declared_constant.
+  unfold declared_constant.
+  rewrite !lookup_env_trans_env, lookup_env_dearg_env.
   intros typ.
-  induction Σ as [|((kn, has_deps), decl) Σ IH]; [easy|].
-  cbn in *.
-  destruct decl; cbn in *.
-  - destruct (kername_eq_dec k kn) as [->|].
-    + noconf typ.
-      eexists.
-      now split; [reflexivity|].
-    + now apply IH.
-  - now apply IH.
-  - destruct (kername_eq_dec k kn) as [->|].
-    + noconf typ.
-      eexists.
-      split; [reflexivity|].
-      cbn.
-      now destruct o.
-    + now apply IH.
+  destruct lookup_env as [decl|]; cbn in *; [|congruence].
+  destruct decl; cbn in *; [|congruence|]; noconf typ; eauto.
+  cbn.
+  eexists.
+  split; [reflexivity|].
+  cbn.
+  now destruct o.
 Qed.
 
 Inductive dearg_spec : term -> term -> Type :=
@@ -2611,7 +2511,7 @@ Proof.
     right; easy.
 Qed.
 
-Lemma eval_mkApps_tConstruct Σ ind c args argsv
+Lemma eval_mkApps_tConstruct {wfl:WcbvFlags} Σ ind c args argsv
       (a : All2 (eval Σ) args argsv) :
   Σ e⊢ mkApps (tConstruct ind c) args ▷ mkApps (tConstruct ind c) argsv.
 Proof.
@@ -2665,6 +2565,7 @@ Ltac facts :=
      end).
 
 Section dearg.
+  Context {wfl:WcbvFlags}.
   Context (n : nat).
   Context (Σ : global_env).
   Context (clos_Σ : env_closed (trans_env Σ)).
@@ -2980,7 +2881,23 @@ Proof.
         apply filter_length.
 Qed.
 
-Lemma dearg_correct Σ t v :
+Lemma is_propositional_trans_env_dearg_env Σ ind :
+  is_propositional (trans_env (dearg_env Σ)) ind =
+  is_propositional (trans_env Σ) ind.
+Proof.
+  unfold is_propositional.
+  rewrite !lookup_env_trans_env, lookup_env_dearg_env.
+  destruct lookup_env; cbn in *; [|reflexivity].
+  destruct g; cbn in *; auto.
+  rewrite !nth_error_map.
+  unfold dearg_mib.
+  destruct get_mib_masks; [|reflexivity].
+  cbn.
+  rewrite nth_error_mapi.
+  now destruct nth_error.
+Qed.
+
+Lemma dearg_correct {wfl:WcbvFlags} Σ t v :
   env_closed (trans_env Σ) ->
   closed t ->
 
@@ -3005,6 +2922,7 @@ Proof.
   destruct (dearg_elim t).
   - apply is_expanded_aux_mkApps_inv in exp_t as (exp_hd & exp_args).
     cbn in *; propify.
+    rewrite dearg_single_masked by (now rewrite map_length).
     specialize (eval_mkApps_deriv ev) as (? & ev_const & argsv & ev_args & deriv).
     depelim ev_const; cbn in *; [|easy].
     eapply declared_constant_dearg in isdecl as isdecl_dearg.
@@ -3012,14 +2930,14 @@ Proof.
     rewrite e in body_dearg; cbn in *.
 
     enough (trans_env (dearg_env Σ)
-            e⊢ dearg_single (get_const_mask kn)
-                           (dearg (dearg_lambdas (get_const_mask kn) body))
-                           (map dearg args) ▷ dearg v) as ev'.
-    { eapply eval_dearg_single_head in ev' as ev_hd; [|now rewrite map_length].
+            e⊢ mkApps (dearg (dearg_lambdas (get_const_mask kn) body))
+                      (masked (get_const_mask kn) (map dearg args)) ▷ dearg v) as ev'.
+    { eapply eval_mkApps_head in ev' as ev_hd.
       destruct ev_hd as (hdv & ev_hd).
-      eapply eval_dearg_single_heads; try eassumption.
-      - now rewrite map_length.
-      - econstructor; eassumption. }
+      eapply eval_mkApps_heads.
+      3: eassumption.
+      1: eassumption.
+      econstructor; eassumption. }
 
     rewrite dearg_dearg_lambdas by
         eauto using valid_dearg_mask_constant, valid_cases_constant.
@@ -3030,7 +2948,6 @@ Proof.
       - exists ev'.
         now cbn in *. }
 
-    rewrite dearg_single_masked by (now rewrite map_length).
     apply dearg_lambdas_correct.
     + now apply env_closed_dearg.
     + apply closedn_dearg_aux; [|easy].
@@ -3113,6 +3030,7 @@ Proof.
         rewrite dearg_mkApps in *.
         cbn in *.
         now rewrite dearg_single_masked in * by (now rewrite map_length).
+      * rewrite is_propositional_trans_env_dearg_env; eauto.
       * destruct (get_mib_masks _) eqn:mm; cycle 1.
         { cbn in *.
           unfold get_ctor_mask.
@@ -3214,8 +3132,10 @@ Proof.
                           end).
       apply (eval_iota_sing _ _ _ _ _ (n - count_ones branch_mask)
                             (dearg_lambdas branch_mask (dearg f))).
+      * eauto.
       * unshelve eapply (IH _ tBox); eauto.
         lia.
+      * rewrite is_propositional_trans_env_dearg_env; eauto.
       * destruct (get_mib_masks _); cbn in *; [easy|].
         now rewrite dearg_lambdas_nil, Nat.sub_0_r.
       * replace (repeat tBox _) with (masked branch_mask (repeat tBox n)); cycle 1.
@@ -3341,6 +3261,7 @@ Proof.
         rewrite dearg_mkApps in *.
         cbn in *.
         now rewrite dearg_single_masked in * by (now rewrite map_length).
+      * rewrite is_propositional_trans_env_dearg_env; eauto.
       * clear clos_constr valid_constr.
         unfold get_ctor_mask in *.
         revert ev2 deriv_len.
@@ -3383,9 +3304,11 @@ Proof.
       propify.
       destruct valid_hd as (valid_hd & valid_p).
       unfold dearg_proj.
-      apply eval_proj_box.
-      unshelve eapply (IH _ _ _ _ _ ev _); auto.
-      lia.
+      apply eval_proj_prop.
+      * eauto.
+      * unshelve eapply (IH _ _ _ _ _ ev _); auto.
+        lia.
+      * rewrite is_propositional_trans_env_dearg_env; eauto.
     + congruence.
 
   - facts.
@@ -3417,17 +3340,48 @@ Proof.
 Qed.
 End dearg_correct.
 
-Lemma trans_env_debox_env_types Σ :
-  trans_env (debox_env_types Σ) = trans_env Σ.
+Lemma lookup_env_debox_env_types Σ kn :
+  lookup_env (debox_env_types Σ) kn = option_map (debox_type_decl Σ) (lookup_env Σ kn).
 Proof.
-  unfold debox_env_types.
-  generalize Σ at 1 as masks.
-  induction Σ as [|(kn, decl) Σ IH]; intros masks; [easy|].
-  cbn in *.
-  destruct decl; cbn in *.
-  - f_equal.
-    apply IH.
-  - easy.
-  - f_equal.
-    apply IH.
+  unfold debox_env_types, lookup_env.
+  generalize Σ at 1 3.
+  intros masks.
+  induction Σ as [|((kn', has_deps), decl) Σ IH]; [easy|].
+  cbn.
+  unfold eq_kername.
+  destruct kername_eq_dec as [->|]; [easy|].
+  apply IH.
+Qed.
+
+Lemma is_propositional_trans_env_debox_env_types Σ ind :
+  is_propositional (trans_env (debox_env_types Σ)) ind =
+  is_propositional (trans_env Σ) ind.
+Proof.
+  unfold is_propositional.
+  rewrite !lookup_env_trans_env, lookup_env_debox_env_types.
+  destruct lookup_env; cbn in *; [|reflexivity].
+  destruct g; cbn in *; auto.
+  rewrite !nth_error_map.
+  now destruct nth_error.
+Qed.
+
+Lemma eval_debox_env_types {wfl:WcbvFlags} Σ t v :
+  trans_env Σ e⊢ t ▷ v ->
+  trans_env (debox_env_types Σ) e⊢ t ▷ v.
+Proof.
+  induction 1; try solve [econstructor; eauto].
+  - eapply eval_iota; eauto.
+    now rewrite is_propositional_trans_env_debox_env_types.
+  - eapply eval_iota_sing; eauto.
+    now rewrite is_propositional_trans_env_debox_env_types.
+  - eapply eval_delta; eauto.
+    unfold declared_constant in *.
+    rewrite !lookup_env_trans_env, lookup_env_debox_env_types in *.
+    destruct lookup_env; cbn in *; [|congruence].
+    destruct g; cbn in *; auto.
+    congruence.
+  - eapply eval_proj; eauto.
+    now rewrite is_propositional_trans_env_debox_env_types.
+  - eapply eval_proj_prop; eauto.
+    now rewrite is_propositional_trans_env_debox_env_types.
 Qed.

--- a/extraction/theories/WcbvEvalAux.v
+++ b/extraction/theories/WcbvEvalAux.v
@@ -21,6 +21,13 @@ Set Equations Transparent.
 
 Notation "Σ 'e⊢' s ▷ t" := (eval Σ s t) (at level 50, s, t at next level) : type_scope.
 
+Global Arguments eval_unique_sig {_ _ _ _ _}.
+Global Arguments eval_deterministic {_ _ _ _ _}.
+Global Arguments eval_unique {_ _ _ _}.
+
+Section fix_flags.
+Context {wfl : WcbvFlags}.
+
 Lemma eval_tApp_head Σ hd arg v :
   Σ e⊢ tApp hd arg ▷ v ->
   ∑ hdv, Σ e⊢ hd ▷ hdv.
@@ -139,6 +146,15 @@ Proof.
     }
     + easy.
     + easy.
+Qed.
+
+Lemma lookup_env_find Σ kn :
+  ETyping.lookup_env Σ kn =
+  option_map snd (find (fun '(kn', _) => if kername_eq_dec kn kn' then true else false) Σ).
+Proof.
+  induction Σ as [|(kn' & decl) Σ IH]; [easy|].
+  cbn.
+  now destruct (kername_eq_dec kn kn').
 Qed.
 
 Lemma closed_constant Σ kn cst body :
@@ -324,13 +340,13 @@ Fixpoint deriv_length {Σ t v} (ev : Σ e⊢ t ▷ v) : nat :=
   | red_cofix_case _ _ _ _ _ _ _ _ _ ev
   | red_cofix_proj _ _ _ _ _ _ _ _ ev
   | eval_delta _ _ _ _ _ _ ev
-  | eval_proj_box _ _ _ _ ev => S (deriv_length ev)
+  | eval_proj_prop _ _ _ _ _ ev _ => S (deriv_length ev)
   | eval_box _ _ _ ev1 ev2
   | eval_zeta _ _ _ _ _ ev1 ev2
-  | eval_iota _ _ _ _ _ _ _ ev1 ev2
-  | eval_iota_sing _ _ _ _ _ _ _ ev1 _ ev2
+  | eval_iota _ _ _ _ _ _ _ ev1 _ ev2
+  | eval_iota_sing _ _ _ _ _ _ _ _ ev1 _ _ ev2
   | eval_fix_value _ _ _ _ _ _ _ _ ev1 ev2 _ _
-  | eval_proj _ _ _ _ _ _ ev1 ev2
+  | eval_proj _ _ _ _ _ _ ev1 _ ev2
   | eval_app_cong _ _ _ _ ev1 _ ev2 => S (deriv_length ev1 + deriv_length ev2)
   | eval_beta _ _ _ _ _ _ ev1 ev2 ev3
   | eval_fix _ _ _ _ _ _ _ _ ev1 ev2 _ ev3 =>
@@ -500,3 +516,5 @@ Proof.
     exists ev.
     lia.
 Qed.
+
+End fix_flags.


### PR DESCRIPTION
Update for the new MetaCoq version that has a flag that decides whether
matches on boxes can be done. The new relation also requires information
about inductives to be present to determine whether matches are
propositional, so because of this our erasure also needed to change a
bit. In particular, trans_env now has a straightforward translation for
each declaration type.

This should allow us to use MetaCoq's box optimization in a follow-up
change.