### PR TITLE
Add inlining pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-extraction:
 	$(foreach file, $(wildcard ./extraction/examples/liquidity-extract/tests/*.liq), liquidity $(file);)
 .PHONY: test-extraction
 
-process-extraction: code
+process-extraction: extraction
 	./process-extraction.sh
 .PHONY: process-extraction
 

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -23,6 +23,7 @@ theories/ExpandBranches.v
 theories/ExtractExtraction.v
 theories/Extraction.v
 theories/ExtractionCorrectness.v
+theories/Inlining.v
 theories/LPretty.v
 theories/LiquidityExtract.v
 theories/MidlangExtract.v

--- a/extraction/theories/Inlining.v
+++ b/extraction/theories/Inlining.v
@@ -1,0 +1,81 @@
+(* This implements a very rudimentary inlining pass without many heuristics.
+   The pass is passed the name of definitions to be inlined and will inline
+   beta, and iota reduce those definitions. *)
+From ConCert.Extraction Require Import ExAst.
+From ConCert.Extraction Require Import Transform.
+From ConCert.Extraction Require Import Optimize.
+From ConCert.Extraction Require Import ResultMonad.
+From ConCert.Extraction Require Import Utils.
+From MetaCoq.Erasure Require Import EAstUtils.
+From MetaCoq.Erasure Require Import ELiftSubst.
+
+Section inlining.
+  Context (should_inline : kername -> bool).
+  Context (Σ : global_env).
+
+  Fixpoint beta_body (body : term) (args : list term) {struct args} : term :=
+    match args with
+    | [] => body
+    | a :: args =>
+      match body with
+      | tLambda na body => beta_body (body{0 := a}) args
+      | _ => mkApps (tApp body a) args
+      end
+    end.
+
+  Definition iota_body (body : term) : term :=
+    match body with
+    | tCase (ind, pars) discr brs =>
+      let (hd, args) := decompose_app discr in
+      match hd with
+      | tConstruct _ c =>
+        match nth_error brs c with
+        | Some (_, br) => beta_body br (skipn pars args)
+        | None => body
+        end
+      | _ => body
+      end
+    | t => t
+    end.
+
+  Fixpoint inline_aux (args : list term) (t : term) : term :=
+    match t with
+    | tApp hd arg => inline_aux (inline_aux [] arg :: args) hd
+    | tConst kn =>
+      if should_inline kn then
+        match lookup_env Σ kn with
+        | Some (ConstantDecl cst) =>
+          match cst_body cst with
+          | Some body (* once told me *) =>
+            (* Often the first beta will expose an iota (record projection),
+               and the projected field is often a function, so we do another beta *)
+            let (hd, args) := decompose_app (beta_body body args) in
+            beta_body (iota_body hd) args
+          | None => mkApps (tConst kn) args
+          end
+        | _ => mkApps (tConst kn) args
+        end
+      else
+        mkApps (tConst kn) args
+    | t => mkApps (map_subterms (inline_aux []) t) args
+    end.
+
+  Definition inline_in_constant_body cst :=
+    {| cst_type := cst_type cst;
+       cst_body := option_map (inline_aux []) (cst_body cst) |}.
+
+  Definition inline_in_decl d :=
+    match d with
+    | ConstantDecl cst => ConstantDecl (inline_in_constant_body cst)
+    | _ => d
+    end.
+End inlining.
+
+Definition inline_in_env (should_inline : kername -> bool) (Σ : global_env) : global_env :=
+  let newΣ := fold_right (fun '(kn, has_deps, decl) Σ =>
+                           (kn, has_deps, inline_in_decl should_inline Σ decl) :: Σ)
+                        [] Σ in
+  filter (fun '(kn, _, _) => negb (should_inline kn)) newΣ.
+
+Definition transform (should_inline : kername -> bool) : Transform :=
+  fun Σ => Ok (timed "Inlining" (fun _ => inline_in_env should_inline Σ)).

--- a/extraction/theories/Utils.v
+++ b/extraction/theories/Utils.v
@@ -4,6 +4,8 @@ From Coq Require Import List.
 From Coq Require Import Psatz.
 From Equations Require Import Equations.
 From MetaCoq Require Import utils.
+From MetaCoq.Template Require Import BasicAst.
+From MetaCoq.Template Require Import Kernames.
 
 Derive Signature for Alli.
 Derive Signature for Forall.
@@ -213,6 +215,9 @@ Arguments bigprod_map {_ _ _} _ {_}.
 Arguments bigprod_map_id {_ _} _ {_}.
 Arguments bigprod_mapi_rec {_ _ _} _ {_}.
 Arguments bigprod_find {_ _} _ {_}.
+
+Definition kername_set_of_list (l : list kername) : KernameSet.t :=
+  fold_left (fun s k => KernameSet.add k s) l KernameSet.empty.
 
 (* When extracting this can be remapped as something that measures and outputs some info *)
 Definition timed {A} (part : string) (f : unit -> A) : A :=

--- a/process-extraction.sh
+++ b/process-extraction.sh
@@ -30,5 +30,5 @@ echo "Processing Midlang extraction"
 for f in $MID_PATH/*.midlang.out;
 do
     echo $f "--->" $MID_TESTS/$(basename ${f%.out}) ;
-    sed -n 's/ *"//;/{-START-}/,/{-END-}/p' $f > $MID_TESTS/$(basename ${f%.out})
+    cp $f $MID_TESTS/$(basename ${f%.out})
 done


### PR DESCRIPTION
This adds a pass that unfolds, beta reduces and does a single iota
reduction of specified constants. This is enough to remove HKTs from at
least monads, and to make the escrow extract without needing to use Ltac
to unfold definitions.