### PR TITLE
Add remapping in Rust and Bernstein-Yang example

### DIFF
--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -31,6 +31,7 @@ theories/Optimize.v
 theories/OptimizeCorrectness.v
 theories/OptimizePropDiscr.v
 theories/PrettyPrinterMonad.v
+theories/Printing.v
 theories/ResultMonad.v
 theories/RustExtract.v
 theories/SpecializeChainBase.v

--- a/extraction/plugin/CoqMakefile.local
+++ b/extraction/plugin/CoqMakefile.local
@@ -1,5 +1,6 @@
 COQ_SRC_SUBDIRS+=user-contrib/MetaCoq/Template
-OPENS=-open Metacoq_template_plugin
+OPENS+=-open Metacoq_template_plugin
+OPENS+=-open Extraction_plugin
 CAMLFLAGS+=$(OPENS)
 CAMLFLAGS+=-w -20 # Unused arguments
 CAMLFLAGS+=-w -32 # Unused values

--- a/extraction/plugin/_CoqProject
+++ b/extraction/plugin/_CoqProject
@@ -43,6 +43,8 @@ src/fin.ml
 src/fin.mli
 src/init.ml
 src/init.mli
+src/inlining.ml
+src/inlining.mli
 src/kernames.ml
 src/kernames.mli
 src/monad_utils.ml
@@ -87,6 +89,8 @@ src/pCUICUnivSubst.ml
 src/pCUICUnivSubst.mli
 src/prettyPrinterMonad.ml
 src/prettyPrinterMonad.mli
+src/printing.ml
+src/printing.mli
 src/reflect.ml
 src/reflect.mli
 src/resultMonad.ml
@@ -125,4 +129,8 @@ src/wGraph.mli
 src/g_concert_extraction.mlg
 src/concert_extraction_plugin.mlpack
 
+theories/BernsteinYangTermination.v
+theories/ExtrRustBasic.v
+theories/ExtrRustCheckedArith.v
+theories/ExtrRustUncheckedArith.v
 theories/Loader.v

--- a/extraction/plugin/src/.gitignore
+++ b/extraction/plugin/src/.gitignore
@@ -32,6 +32,8 @@ fin.ml
 fin.mli
 init.ml
 init.mli
+inlining.ml
+inlining.mli
 kernames.ml
 kernames.mli
 monad_utils.ml
@@ -76,6 +78,8 @@ pCUICUnivSubst.ml
 pCUICUnivSubst.mli
 prettyPrinterMonad.ml
 prettyPrinterMonad.mli
+printing.ml
+printing.mli
 reflect.ml
 reflect.mli
 resultMonad.ml

--- a/extraction/plugin/src/concert_extraction_plugin.mlpack
+++ b/extraction/plugin/src/concert_extraction_plugin.mlpack
@@ -49,12 +49,14 @@ StringExtra
 ResultMonad
 ExAst
 ClosedAux
+Printing
 Transform
 Common1
 Erasure
 ExpandBranches
 Optimize
 OptimizePropDiscr
+Inlining
 TopLevelFixes
 PrettyPrinterMonad
 Extraction0

--- a/extraction/plugin/src/g_concert_extraction.mlg
+++ b/extraction/plugin/src/g_concert_extraction.mlg
@@ -2,13 +2,13 @@ DECLARE PLUGIN "concert_extraction_plugin"
 
 {
 
-open Stdarg
-open Pp
-open PeanoNat.Nat
 open Datatypes
+open Extraction_plugin
+open Names
+open PeanoNat.Nat
+open Pp
 open ResultMonad
-
-let pr_char c = str (Char.escaped c)
+open Stdarg
 
 let bytes_of_list l =
   let bytes = Bytes.create (List.length l) in
@@ -19,9 +19,15 @@ let bytes_of_list l =
       fill (1 + acc) cs
   in fill 0 l
 
-let pr_char_list l =
-  (* We allow utf8 encoding *)
-  str (Bytes.to_string (bytes_of_list l))
+let string_of_char_list l = Bytes.to_string (bytes_of_list l)
+
+let char_list_of_string s = List.init (String.length s) (String.get s)
+
+let int_of_nat =
+  let rec aux acc = function
+    | O -> acc
+    | S n -> aux (1 + acc) n in
+  aux 0
 
 let time prefix f x =
   let start = Unix.gettimeofday () in
@@ -32,10 +38,73 @@ let time prefix f x =
       (Pp.str (Printf.sprintf "%s executed in: %fs" prefix (stop -. start))) in
   res
 
+let locate_kn kn =
+  let as_str = string_of_char_list (BasicAst.string_of_kername kn) in
+  let qid = Libnames.qualid_of_string as_str in
+  Nametab.locate qid
+
+let should_inline kn =
+  let gr = locate_kn kn in
+  Table.to_inline gr && not (Table.is_custom gr)
+
+let remap_inductive ind =
+  let kn_gr = locate_kn (BasicAst.inductive_mind ind) in
+  match kn_gr with
+  | GlobRef.IndRef (mind, _) ->
+      let ip = (mind, int_of_nat (BasicAst.inductive_ind ind)) in
+      let gr = GlobRef.IndRef ip in
+
+      if Table.is_custom gr then
+        let na = Table.find_custom gr in
+        let rec get_ctors n =
+          let ctor_gr = GlobRef.ConstructRef (ip, n) in
+          if Table.is_custom ctor_gr then
+            let ctor_na = Table.find_custom ctor_gr in
+            char_list_of_string ctor_na :: get_ctors (1 + n)
+          else
+            [] in
+
+        (* For custom matches for some reason the interface takes an array of
+         * ml_branch where it then only uses the name... *)
+        let lookup_key = [| ([], Miniml.Pusual (GlobRef.ConstructRef (ip, 0)), Miniml.MLaxiom) |] in
+        let custom_match =
+          if Table.is_custom_match lookup_key then
+            Some (char_list_of_string (Table.find_custom_match lookup_key))
+          else
+            None in
+
+        let res = { Printing.re_ind_name = char_list_of_string na;
+                    Printing.re_ind_ctors = get_ctors 1;
+                    Printing.re_ind_match = custom_match } in
+        Some res
+      else
+        None
+  | _ -> None
+
+let remap_constant kn =
+  let gr = locate_kn kn in
+  if Table.is_custom gr && not (Table.to_inline gr) then
+    Some (char_list_of_string (Table.find_custom gr))
+  else
+    None
+
+let remap_inline_constant kn =
+  let gr = locate_kn kn in
+  if Table.is_custom gr && Table.to_inline gr then
+    Some (char_list_of_string (Table.find_custom gr))
+  else
+    None
+
 let check env evm c =
   let prog = time "Quoting" (Ast_quoter.quote_term_rec false env) (EConstr.to_constr evm c) in
-  let res = time "Extraction" RustExtract.extract prog in
-  Feedback.msg_info (pr_char_list (match res with | Ok s -> s | Err s -> s))
+  let remaps = { Printing.remap_inductive = remap_inductive;
+                 Printing.remap_constant = remap_constant;
+                 Printing.remap_inline_constant = remap_inline_constant; } in
+  let do_extract _ =
+    RustExtract.extract prog remaps should_inline in
+  let res = time "Extraction" do_extract () in
+  Feedback.msg_info (str (string_of_char_list (match res with | Ok s -> s | Err s -> s)))
+
 }
 
 VERNAC COMMAND EXTEND ConCertExtract CLASSIFIED AS QUERY

--- a/extraction/plugin/theories/BernsteinYangTermination.v
+++ b/extraction/plugin/theories/BernsteinYangTermination.v
@@ -1,0 +1,54 @@
+(* Computation needed to show termination of the Bernstein-Yang modular inversion algorithm *)
+
+From ConCert.Extraction Require Import Loader.
+From Coq Require Import Arith.
+From Coq Require Import Bool.
+From Coq Require Import Extraction.
+From Coq Require Import List.
+From Coq Require Import Program.
+From Coq Require Import ZArith.
+
+Import ListNotations.
+
+Import Z.
+Local Open Scope Z.
+Definition steps := Eval vm_compute in 2 ^ 44 : N.
+Definition shiftl a b := Eval cbv in Z.shiftl a b.
+Definition shiftr a b := Eval cbv in Z.shiftr a b.
+Definition divstep d f g :=
+  if (0 <? d) && odd g
+  then (1 - d, g, shiftr (g - f) 1)
+  else (1 + d, f, shiftr (g + (if odd g then 1 else 0) * f) 1 ).
+Fixpoint needs_n_steps (d a b : Z) n :=
+  match n with
+  | 0%nat => true
+  | S n => if (b =? 0)
+          then false
+          else let '(d', a', b') := divstep d a b in needs_n_steps d' a' b' n
+  end.
+Fixpoint min_needs_n_steps_nat (a b : Z) n (acc : Z) fuel :=
+  match fuel with
+  | 0%nat => 0
+  | S fuel =>
+    let a2 := a * a in
+    if acc <? a2
+        then acc
+        else
+          let length := a2 + b * b in
+          if acc <? length
+             then min_needs_n_steps_nat (a + 2) 0 n acc fuel
+             else if needs_n_steps 1 a (shiftr b 1) n || needs_n_steps 1 a (- (shiftr b 1)) n
+                  then min_needs_n_steps_nat (a + 2) 0 n (min length acc) fuel
+                  else min_needs_n_steps_nat a (b + 2) n acc fuel
+  end.
+Definition nat_shiftl := Eval cbv in Nat.shiftl.
+Definition W n := min_needs_n_steps_nat 1 0 n (shiftl 1 62) (nat_shiftl 1 44).
+
+Extract Constant nat_shiftl => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a << b }".
+(* Unsound in general, but fine for this program *)
+Extract Constant shiftl => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a << b }".
+Extract Constant shiftr => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a >> b }".
+
+From ConCert.Extraction Require Import ExtrRustBasic.
+From ConCert.Extraction Require Import ExtrRustUncheckedArith.
+Redirect "../examples/rust-extract/BernsteinYangTermination.rs" ConCert Extract W.

--- a/extraction/plugin/theories/ExtrRustBasic.v
+++ b/extraction/plugin/theories/ExtrRustBasic.v
@@ -1,0 +1,8 @@
+From Coq Require Import Extraction.
+
+Extract Inductive bool => "bool" ["true" "false"].
+Extract Inductive option => "Option" ["Some" "None"].
+Extract Inductive unit => "()" ["()"].
+Extract Inductive prod => "__pair" ["__mk_pair"] "__pair_elim!".
+Extract Inlined Constant andb => "__andb!".
+Extract Inlined Constant orb => "__orb!".

--- a/extraction/plugin/theories/ExtrRustCheckedArith.v
+++ b/extraction/plugin/theories/ExtrRustCheckedArith.v
@@ -1,0 +1,70 @@
+From Coq Require Import Arith.
+From Coq Require Import Extraction.
+From Coq Require Import NArith.
+From Coq Require Import PArith.
+From Coq Require Import ZArith.
+
+Extract Inductive nat => "u64" ["0" "__nat_succ"] "__nat_elim!".
+Extract Inductive positive => "u64" ["__pos_onebit" "__pos_zerobit" "1"] "__pos_elim!".
+Extract Inductive N => "u64" ["0" "__N_frompos"] "__N_elim!".
+Extract Inductive Z => "i64" ["0" "__Z_frompos" "__Z_fromneg"] "__Z_elim!".
+Extract Inductive comparison =>
+  "std::cmp::Ordering"
+    ["std::cmp::Ordering::Equal"
+     "std::cmp::Ordering::Less"
+     "std::cmp::Ordering::Greater"].
+
+Extract Constant BinPosDef.Pos.add => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_add(b).unwrap() }".
+Extract Constant BinPosDef.Pos.succ => "fn ##name##(&'a self, a: u64) -> u64 { a.checked_add(1).unwrap() }".
+Extract Constant BinPosDef.Pos.pred => "fn ##name##(&'a self, a: u64) -> u64 { a.checked_sub(1).unwrap_or(1) }".
+Extract Constant BinPosDef.Pos.sub => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_sub(b).unwrap_or(1) }".
+Extract Constant BinPosDef.Pos.mul => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_mul(b).unwrap() }".
+Extract Constant BinPosDef.Pos.min => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::min(a, b) }".
+Extract Constant BinPosDef.Pos.max => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::max(a, b) }".
+Extract Constant BinPosDef.Pos.eqb => "fn ##name##(&'a self, a: u64, b: u64) -> bool { a == b }".
+Extract Constant BinPosDef.Pos.compare =>
+"fn ##name##(&'a self, a: u64, b: u64) -> std::cmp::Ordering {
+  a.cmp(&b)
+}".
+Extract Constant BinPosDef.Pos.compare_cont =>
+"fn ##name##(&'a self, cont: std::cmp::Ordering, a: u64, b: u64) -> std::cmp::Ordering {
+  if a < b then
+    std::cmp::Ordering::Less
+  else if a == b then
+    cont
+  else
+    std::cmp::Ordering::Greater".
+
+Extract Constant BinNatDef.N.add => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_add(b).unwrap() }".
+Extract Constant BinNatDef.N.succ => "fn ##name##(&'a self, a: u64) -> u64 { a.checked_add(1).unwrap() }".
+Extract Constant BinNatDef.N.pred => "fn ##name##(&'a self, a: u64) -> u64 { a.checked_sub(1).unwrap_or(0) }".
+Extract Constant BinNatDef.N.sub => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_sub(b).unwrap_or(0) }".
+Extract Constant BinNatDef.N.mul => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_mul(b).unwrap() }".
+Extract Constant BinNatDef.N.div => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_div(b).unwrap_or(0) }".
+Extract Constant BinNatDef.N.modulo => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a.checked_rem(b).unwrap_or(a) }".
+Extract Constant BinNatDef.N.min => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::min(a, b) }".
+Extract Constant BinNatDef.N.max => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::max(a, b) }".
+Extract Constant BinNatDef.N.eqb => "fn ##name##(&'a self, a: u64, b: u64) -> bool { a == b }".
+Extract Constant BinNatDef.N.compare =>
+"fn ##name##(&'a self, a: u64, b: u64) -> std::cmp::Ordering { a.cmp(&b) }".
+
+Extract Constant BinIntDef.Z.add => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a.checked_add(b).unwrap() }".
+Extract Constant BinIntDef.Z.succ => "fn ##name##(&'a self, a: i64) -> i64 { a.checked_add(1).unwrap() }".
+Extract Constant BinIntDef.Z.pred => "fn ##name##(&'a self, a: i64) -> i64 { a.checked_sub(1).unwrap() }".
+Extract Constant BinIntDef.Z.sub => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a.checked_sub(b).unwrap() }".
+Extract Constant BinIntDef.Z.mul => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a.checked_mul(b).unwrap() }".
+Extract Constant BinIntDef.Z.opp => "fn ##name##(&'a self, a: i64) -> i64 { a.checked_neg().unwrap() }".
+Extract Constant BinIntDef.Z.min => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { std::cmp::min(a, b) }".
+Extract Constant BinIntDef.Z.max => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { std::cmp::max(a, b) }".
+Extract Constant BinIntDef.Z.eqb => "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }".
+(* TODO: div and modulo are nontrivial since Coq rounds towards negative infinity *)
+(*Extract ConstanBinIntDef.t Z.div => "fn ##name##(a: i64, b: i64) -> i64 { a.checked_div(b).unwrap_or(0) }".
+Extract Constant BinIntDef.Z.modulo => "fn ##name##(a: i64, b: i64) -> i64 { a.checked_rem(b).unwrap_or(a) }".*)
+Extract Constant BinIntDef.Z.compare =>
+"fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }".
+Extract Constant BinIntDef.Z.of_N =>
+"fn ##name##(&'a self, a: u64) -> i64 {
+  use std::convert::TryFrom;
+  i64::try_from(a).unwrap()
+}".
+Extract Constant BinIntDef.Z.abs_N => "fn ##name#(&'a self, a: i64) -> u64 { a.unsigned_abs() }".

--- a/extraction/plugin/theories/ExtrRustUncheckedArith.v
+++ b/extraction/plugin/theories/ExtrRustUncheckedArith.v
@@ -1,0 +1,70 @@
+From Coq Require Import Arith.
+From Coq Require Import Extraction.
+From Coq Require Import NArith.
+From Coq Require Import PArith.
+From Coq Require Import ZArith.
+
+Extract Inductive nat => "u64" ["0" "__nat_succ"] "__nat_elim!".
+Extract Inductive positive => "u64" ["__pos_onebit" "__pos_zerobit" "1"] "__pos_elim!".
+Extract Inductive N => "u64" ["0" "__N_frompos"] "__N_elim!".
+Extract Inductive Z => "i64" ["0" "__Z_frompos" "__Z_fromneg"] "__Z_elim!".
+Extract Inductive comparison =>
+  "std::cmp::Ordering"
+    ["std::cmp::Ordering::Equal"
+     "std::cmp::Ordering::Less"
+     "std::cmp::Ordering::Greater"].
+
+Extract Constant BinPosDef.Pos.add => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a + b }".
+Extract Constant BinPosDef.Pos.succ => "fn ##name##(&'a self, a: u64) -> u64 { a + 1 }".
+Extract Constant BinPosDef.Pos.pred => "fn ##name##(&'a self, a: u64) -> u64 { a - 1 }".
+Extract Constant BinPosDef.Pos.sub => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a - b }".
+Extract Constant BinPosDef.Pos.mul => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a * b }".
+Extract Constant BinPosDef.Pos.min => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::min(a, b) }".
+Extract Constant BinPosDef.Pos.max => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::max(a, b) }".
+Extract Constant BinPosDef.Pos.eqb => "fn ##name##(&'a self, a: u64, b: u64) -> bool { a == b }".
+Extract Constant BinPosDef.Pos.compare =>
+"fn ##name##(&'a self, a: u64, b: u64) -> std::cmp::Ordering {
+  a.cmp(&b)
+}".
+Extract Constant BinPosDef.Pos.compare_cont =>
+"fn ##name##(&'a self, cont: std::cmp::Ordering, a: u64, b: u64) -> std::cmp::Ordering {
+  if a < b then
+    std::cmp::Ordering::Less
+  else if a == b then
+    cont
+  else
+    std::cmp::Ordering::Greater".
+
+Extract Constant BinNatDef.N.add => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a + b }".
+Extract Constant BinNatDef.N.succ => "fn ##name##(&'a self, a: u64) -> u64 { a + 1 }".
+Extract Constant BinNatDef.N.pred => "fn ##name##(&'a self, a: u64) -> u64 { a - 1 }".
+Extract Constant BinNatDef.N.sub => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a - b }".
+Extract Constant BinNatDef.N.mul => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a * b }".
+Extract Constant BinNatDef.N.div => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a / b }".
+Extract Constant BinNatDef.N.modulo => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { a % b }".
+Extract Constant BinNatDef.N.min => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::min(a, b) }".
+Extract Constant BinNatDef.N.max => "fn ##name##(&'a self, a: u64, b: u64) -> u64 { std::cmp::max(a, b) }".
+Extract Constant BinNatDef.N.eqb => "fn ##name##(&'a self, a: u64, b: u64) -> bool { a == b }".
+Extract Constant BinNatDef.N.compare =>
+"fn ##name##(&'a self, a: u64, b: u64) -> std::cmp::Ordering { a.cmp(&b) }".
+
+Extract Constant BinIntDef.Z.add => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a + b }".
+Extract Constant BinIntDef.Z.succ => "fn ##name##(&'a self, a: i64) -> i64 { a + 1 }".
+Extract Constant BinIntDef.Z.pred => "fn ##name##(&'a self, a: i64) -> i64 { a - 1 }".
+Extract Constant BinIntDef.Z.sub => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a - b }".
+Extract Constant BinIntDef.Z.mul => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a * b }".
+Extract Constant BinIntDef.Z.opp => "fn ##name##(&'a self, a: i64) -> i64 { -a }".
+Extract Constant BinIntDef.Z.min => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { std::cmp::min(a, b) }".
+Extract Constant BinIntDef.Z.max => "fn ##name##(&'a self, a: i64, b: i64) -> i64 { std::cmp::max(a, b) }".
+Extract Constant BinIntDef.Z.eqb => "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }".
+(* TODO: div and modulo are nontrivial since Coq rounds towards negative infinity *)
+(*Extract ConstanBinIntDef.t Z.div => "fn ##name##(a: i64, b: i64) -> i64 { a.checked_div(b).unwrap_or(0) }".
+Extract Constant BinIntDef.Z.modulo => "fn ##name##(a: i64, b: i64) -> i64 { a.checked_rem(b).unwrap_or(a) }".*)
+Extract Constant BinIntDef.Z.compare =>
+"fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }".
+Extract Constant BinIntDef.Z.of_N =>
+"fn ##name##(&'a self, a: u64) -> i64 {
+  use std::convert::TryFrom;
+  i64::try_from(a).unwrap()
+}".
+Extract Constant BinIntDef.Z.abs_N => "fn ##name#(&'a self, a: i64) -> u64 { a.unsigned_abs() }".

--- a/extraction/plugin/theories/Loader.v
+++ b/extraction/plugin/theories/Loader.v
@@ -1,4 +1,5 @@
 From MetaCoq.Template Require Import All.
 
+Declare ML Module "extraction_plugin".
 Declare ML Module "metacoq_template_plugin".
 Declare ML Module "concert_extraction_plugin".

--- a/extraction/theories/Printing.v
+++ b/extraction/theories/Printing.v
@@ -1,0 +1,19 @@
+From Coq Require Import String.
+From MetaCoq.Template Require Import BasicAst.
+
+Record remapped_inductive := build_remapped_inductive {
+  re_ind_name : string;
+  re_ind_ctors : list string;
+  re_ind_match : option string;
+  }.
+
+Record remaps := {
+  remap_inductive : inductive -> option remapped_inductive;
+  remap_constant : kername -> option string;
+  remap_inline_constant : kername -> option string;
+  }.
+
+Definition no_remaps :=
+  {| remap_inductive _ := None;
+     remap_constant _ := None;
+     remap_inline_constant _ := None |}.


### PR DESCRIPTION
- Pull out common remapping things into a Printing file
- Support remapping types (to copyable types) in Rust extraction
- The plugin now uses the same tables as normal extraction
- Support Extract Inductive, Extract Constant, Extract Inlined Constant
  in Rust
- Fix printing of tConsts without args: we were not properly using
  curried versions if this was necessary
- Fix missing blocks in heads and arguments of applications
- Use only remapping info to find out what declarations to print/ignore
  printing of. This information subsumes "has_deps" anyway.