### PR TITLE
Only allow contracts access to their own balance

### DIFF
--- a/embedding/examples/ExecFrameworkIntegration.v
+++ b/embedding/examples/ExecFrameworkIntegration.v
@@ -74,7 +74,7 @@ Section Wrappers.
   Definition Setup := (nat * Z)%type.
 
   Definition init_wrapper (f : SimpleContractCallContext_coq -> nat -> Z -> State_coq):
-    Chain -> ContractCallContext (Base:=CB) -> Setup -> option State_coq
+    Chain -> ContractCallContext -> Setup -> option State_coq
     := fun c cc setup => Some (f (of_contract_call_context cc) (fst setup) (snd setup)).
 
   Definition wrapped_init

--- a/embedding/examples/ExecFrameworkIntegration.v
+++ b/embedding/examples/ExecFrameworkIntegration.v
@@ -31,10 +31,10 @@ Next Obligation.
 Defined.
 
 Definition to_chain (sc : SimpleChain_coq) : Chain :=
-  let '(Build_chain_coq h s fh ab) := sc in build_chain h s fh ab.
+  let '(Build_chain_coq h s fh) := sc in build_chain h s fh.
 
 Definition of_chain (c : Chain) : SimpleChain_coq :=
-  let '(build_chain h s fh ab) := c in Build_chain_coq h s fh ab.
+  let '(build_chain h s fh) := c in Build_chain_coq h s fh.
 
 Definition to_action_body (sab : SimpleActionBody_coq) : ActionBody :=
   match sab with
@@ -42,10 +42,12 @@ Definition to_action_body (sab : SimpleActionBody_coq) : ActionBody :=
   end.
 
 Definition to_contract_call_context (scc : SimpleContractCallContext_coq) : ContractCallContext :=
-  let '(Build_ctx_coq from contr_addr am) := scc in build_ctx from contr_addr am.
+  let '(Build_ctx_coq from contr_addr contr_bal am) := scc in
+  build_ctx from contr_addr contr_bal am.
 
 Definition of_contract_call_context (cc : ContractCallContext) : SimpleContractCallContext_coq :=
-  let '(build_ctx from contr_addr am) := cc in Build_ctx_coq from contr_addr am.
+  let '(build_ctx from contr_addr contr_bal am) := cc in
+  Build_ctx_coq from contr_addr contr_bal am.
 
 Import Serializable Prelude.Maps.
 
@@ -72,7 +74,7 @@ Section Wrappers.
   Definition Setup := (nat * Z)%type.
 
   Definition init_wrapper (f : SimpleContractCallContext_coq -> nat -> Z -> State_coq):
-    Chain (Base:=CB) -> ContractCallContext (Base:=CB) -> Setup -> option State_coq
+    Chain -> ContractCallContext (Base:=CB) -> Setup -> option State_coq
     := fun c cc setup => Some (f (of_contract_call_context cc) (fst setup) (snd setup)).
 
   Definition wrapped_init
@@ -96,41 +98,8 @@ Section Wrappers.
 
 End Wrappers.
 
-(** Taken from [Congress] *)
-Ltac solve_contract_proper :=
-  repeat
-    match goal with
-    | [ |- ?x _  = ?x _] => unfold x
-    | [ |- ?x _ _ = ?x _ _] => unfold x
-    | [ |- ?x _ _ _ = ?x _ _ _] => unfold x
-    | [ |- ?x _ _ _ _ = ?x _ _ _ _] => unfold x
-    | [ |- ?x _ _ _ _ = ?x _ _ _ _] => unfold x
-    | [ |- ?x _ _ _ _ _ = ?x _ _ _ _ _] => unfold x
-    | [ |- Some _ = Some _] => f_equal
-    | [ |- pair _ _ = pair _ _] => f_equal
-    | [ |- (if ?x then _ else _) = (if ?x then _ else _)] => destruct x
-    | [ |- match ?x with | _ => _ end = match ?x with | _ => _ end ] => destruct x
-    | [H: ChainEquiv _ _ |- _] => rewrite H in *
-    | _ => subst; auto
-    end.
-
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) wrapped_init.
-Proof. repeat intro; solve_contract_proper. Qed.
-
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) wrapped_receive.
-Proof.
-  repeat intro. unfold wrapped_receive,receive_wrapper.
-  subst. destruct y2;auto.
-  f_equal.
-  unfold Receive.receive. destruct x,y;simpl in *.
-  inversion H;cbn in *;subst.
-  destruct m;solve_contract_proper.
-Qed.
-
 Definition cf_contract : Contract Setup Msg_coq State_coq :=
-  build_contract wrapped_init init_proper wrapped_receive receive_proper.
+  build_contract wrapped_init wrapped_receive.
 
 Definition cf_state (env : Environment) (address : Blockchain.Address) : option State_coq :=
   match (env_contract_states env address) with
@@ -253,7 +222,7 @@ Lemma undeployed_balance_0 (bstate : ChainState) addr :
   reachable bstate ->
   address_is_contract addr = true ->
   env_contracts bstate addr = None ->
-  (account_balance bstate addr = 0%Z).
+  (env_account_balances bstate addr = 0%Z).
 Proof.
   intros [trace] is_contract no_contract.
   rewrite (account_balance_trace _ trace); auto.
@@ -422,7 +391,7 @@ Theorem cf_backed bstate cf_addr lstate:
   reachable bstate ->
   env_contracts bstate cf_addr = Some (cf_contract : WeakContract) ->
   cf_state bstate cf_addr = Some lstate ->
-  (account_balance (env_chain bstate) cf_addr >=
+  (env_account_balances bstate cf_addr >=
    balance_coq lstate + sumZ act_body_amount (outgoing_acts bstate cf_addr)).
 Proof.
   cbn in *.
@@ -430,7 +399,7 @@ Proof.
   revert lstate.
   enough (H: exists lstate',
              cf_state bstate cf_addr = Some lstate' /\
-             (account_balance bstate cf_addr >=
+             (env_account_balances bstate cf_addr >=
               balance_coq lstate' + sumZ act_body_amount (outgoing_acts bstate cf_addr))).
   { intros. destruct H as [lstate' [? ?]].
     now replace lstate with lstate' by congruence. }
@@ -507,7 +476,7 @@ Corollary cf_backed_after_block {ChainBuilder : ChainBuilderType}
   builder_add_block prev hd acts = Ok new ->
   env_contracts new cf_addr = Some (cf_contract : WeakContract) ->
   cf_state new cf_addr = Some lstate ->
-  (account_balance (env_chain new) cf_addr >= balance_coq lstate)%Z.
+  (env_account_balances new cf_addr >= balance_coq lstate)%Z.
 Proof.
   intros Hnew Hcf Hst.
   destruct ChainBuilder;cbn in *.
@@ -526,7 +495,7 @@ Corollary cf_donations_backed_after_block {ChainBuilder : ChainBuilderType}
   env_contracts new cf_addr = Some (cf_contract : WeakContract) ->
   cf_state new cf_addr = Some lstate ->
   ~~ lstate.(done_coq) ->
-  (account_balance (env_chain new) cf_addr >= sum_map (lstate.(donations_coq)))%Z.
+  (env_account_balances new cf_addr >= sum_map (lstate.(donations_coq)))%Z.
 Proof.
   intros Hnew Hcf Hst Hdone.
   destruct ChainBuilder;cbn in *.

--- a/embedding/examples/crowdfunding/Crowdfunding.v
+++ b/embedding/examples/crowdfunding/Crowdfunding.v
@@ -159,9 +159,9 @@ Module CrowdfundingProperties.
   Qed.
 
   (** This lemma states that the only relevant part of the blockchain state is the current slot, because we check if the deadline have passed by comparing the deadline recoded in the internal state with the current slot number.*)
-  Lemma receive_blockchain_state height1 height2 cur_slot fheight1 fheight2 bal1 bal2 msg st ctx :
-    Receive.receive (Build_chain_coq height1 cur_slot fheight1 bal1) ctx msg st  =
-    Receive.receive (Build_chain_coq height2 cur_slot fheight2 bal2) ctx msg st.
+  Lemma receive_blockchain_state height1 height2 cur_slot fheight1 fheight2 msg st ctx :
+    Receive.receive (Build_chain_coq height1 cur_slot fheight1) ctx msg st  =
+    Receive.receive (Build_chain_coq height2 cur_slot fheight2) ctx msg st.
   Proof.
     destruct msg;
       simpl;

--- a/embedding/extraction/PreludeExt.v
+++ b/embedding/extraction/PreludeExt.v
@@ -161,7 +161,7 @@ Definition init_wrapper {setup storage}
   let simple_ctx :=
       (Time_coq ch.(current_slot),
        ((ctx.(ctx_from)),
-        ((ctx.(ctx_amount), ch.(account_balance) ctx.(ctx_contract_address))))) in
+        ((ctx.(ctx_amount), ctx.(ctx_contract_balance))))) in
     init simple_ctx.
 
 

--- a/embedding/extraction/SimpleBlockchainExt.v
+++ b/embedding/extraction/SimpleBlockchainExt.v
@@ -34,8 +34,7 @@ Module AcornBlockchain.
     [\ record SimpleChain :=
        Build_chain { "Chain_height" : BaseTypes.Nat;
                      "Current_slot" : BaseTypes.Nat;
-                     "Finalized_height" : BaseTypes.Nat;
-                     "Account_balance" : Address -> Money } \].
+                     "Finalized_height" : BaseTypes.Nat } \].
 
   MetaCoq Unquote Inductive (global_to_tc SimpleChainAcorn).
 
@@ -50,6 +49,7 @@ Module AcornBlockchain.
            "Ctx_from" : Address;
            (* Address of the contract being called *)
            "Ctx_contract_address" : Address;
+           "Ctx_contract_balance" : Money;
            (* Amount of currency passed in call *)
            "Ctx_amount" : Money} \].
 

--- a/embedding/theories/SimpleBlockchain.v
+++ b/embedding/theories/SimpleBlockchain.v
@@ -33,8 +33,7 @@ Module AcornBlockchain.
     [\ record SimpleChain :=
        Build_chain { "Chain_height" : BaseTypes.Nat;
                      "Current_slot" : BaseTypes.Nat;
-                     "Finalized_height" : BaseTypes.Nat;
-                     "Account_balance" : Address -> Money } \].
+                     "Finalized_height" : BaseTypes.Nat } \].
 
   MetaCoq Unquote Inductive (global_to_tc SimpleChainAcorn).
 
@@ -49,6 +48,7 @@ Module AcornBlockchain.
            "Ctx_from" : Address;
            (* Address of the contract being called *)
            "Ctx_contract_address" : Address;
+           "Ctx_contract_balance" : Money;
            (* Amount of currency passed in call *)
            "Ctx_amount" : Money} \].
 

--- a/execution/examples/BAT.v
+++ b/execution/examples/BAT.v
@@ -171,7 +171,7 @@ Definition receive_bat (chain : Chain)
   let sender := ctx.(ctx_from) in
   let sender_payload := ctx.(ctx_amount) in
   let slot := chain.(current_slot) in
-  let contract_balance := chain.(account_balance) ctx.(ctx_contract_address) in
+  let contract_balance := ctx.(ctx_contract_balance) in
   let without_actions := option_map (fun new_state => (new_state, [])) in
   match maybe_msg with
   | Some create_tokens => without_actions (try_create_tokens sender sender_payload slot state)
@@ -195,17 +195,7 @@ Definition receive (chain : Chain)
   | _ => receive_bat chain ctx state maybe_msg
   end.
 
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; solve_contract_proper.	Qed.
-
-(* Not sure if this is the most succint and "pretty" proof, but it works. *)
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof. repeat intro; solve_contract_proper.
-Qed.
-
 Definition contract : Contract Setup Msg State :=
-  build_contract init init_proper receive receive_proper.
+  build_contract init receive.
 
 End BAT.

--- a/execution/examples/BoardroomVoting.v
+++ b/execution/examples/BoardroomVoting.v
@@ -222,38 +222,8 @@ Definition receive : ContractReceiver State Msg State :=
     accept_call (state<|tally := Some res|>)
   end.
 
-Definition boardroom_voting : Contract Setup Msg State.
-Proof with cbn -[Nat.ltb].
-  refine (build_contract init receive _ _).
-  - repeat intro; subst.
-    cbn -[Nat.ltb].
-    destruct (_ <? _)%nat; auto.
-  - intros c1 c2 ceq ctx ? <- state ? <- msg ? <-.
-    unfold run_contract_receiver...
-    destruct msg as [msg|]; [|congruence]...
-    destruct msg.
-    + rewrite <- ceq.
-      destruct (_ <? _)%nat; auto.
-      destruct (FMap.find _ _); auto.
-      destruct (FMap.find _ _); auto.
-      destruct (_ =? _)%Z; auto.
-      destruct (_ <? _); auto.
-      destruct (verify_secret_key_proof _ _ _); auto.
-    + destruct (finish_commit_by _); auto.
-      rewrite <- ceq.
-      destruct (_ <? _)%nat; auto.
-      destruct (FMap.find _ _); auto.
-    + rewrite <- ceq.
-      destruct (_ <? _)%nat; auto.
-      destruct (FMap.find _ _); auto.
-      destruct (finish_commit_by _); [destruct (_ =? _)%positive; auto|].
-      all: destruct (verify_secret_vote_proof _ _ _ _); auto.
-    + rewrite <- ceq.
-      destruct (_ <? _)%nat; auto.
-      destruct (tally _); auto.
-      destruct (existsb _ _); auto.
-      destruct (bruteforce_tally _); auto.
-Defined.
+Definition boardroom_voting : Contract Setup Msg State :=
+  build_contract init receive.
 
 Section Theories.
 

--- a/execution/examples/Congress.v
+++ b/execution/examples/Congress.v
@@ -251,37 +251,8 @@ Definition receive
 
   end.
 
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; solve_contract_proper. Qed.
-
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof.
-  repeat intro.
-  subst.
-  unfold receive.
-  destruct y2; auto.
-  destruct m; auto.
-  - destruct FMap.mem; auto.
-    f_equal.
-    f_equal.
-    unfold add_proposal.
-    f_equal.
-    f_equal.
-    f_equal.
-    f_equal.
-    apply H.
-  - unfold do_finish_proposal.
-    cbn.
-    destruct FMap.find; auto.
-    rewrite H.
-    auto.
-Qed.
-
 Definition contract : Contract Setup Msg State :=
-  build_contract init init_proper receive receive_proper.
-
+  build_contract init receive.
 
 Section Theories.
 Local Open Scope nat.

--- a/execution/examples/Congress_Buggy.v
+++ b/execution/examples/Congress_Buggy.v
@@ -259,36 +259,8 @@ Definition receive
 
   end.
 
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; solve_contract_proper. Qed.
-
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof.
-  repeat intro.
-  subst.
-  unfold receive.
-  destruct y2; auto.
-  destruct m; auto.
-  - destruct FMap.mem; auto.
-    f_equal.
-    f_equal.
-    unfold add_proposal.
-    f_equal.
-    f_equal.
-    f_equal.
-    f_equal.
-    apply H.
-  - unfold do_finish_proposal.
-    cbn.
-    destruct FMap.find; auto.
-    rewrite H.
-    auto.
-Qed.
-
 Definition contract : Contract Setup Msg State :=
-  build_contract init init_proper receive receive_proper.
+  build_contract init receive.
 
 End CongressBuggy.
 (* We will show that this contract is buggy and does not satisfy the
@@ -319,16 +291,8 @@ Definition exploit_receive
     let again := finish_proposal 1 in
     Some (S state, [act_call (ctx_from ctx) 0 (serialize again)]).
 
-Instance exploit_init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) exploit_init.
-Proof. now subst. Qed.
-
-Instance exploit_receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) exploit_receive.
-Proof. now subst. Qed.
-
 Definition exploit_contract : Contract ExploitSetup ExploitMsg ExploitState :=
-  build_contract exploit_init exploit_init_proper exploit_receive exploit_receive_proper.
+  build_contract exploit_init exploit_receive.
 
 End ExploitContract.
 

--- a/execution/examples/Counter.v
+++ b/execution/examples/Counter.v
@@ -80,8 +80,8 @@ Section Counter.
     Derive Serializable Msg_rect<Inc, Dec>.
 
   (** The counter contract *)
-  Program Definition counter_contract : Contract Z Msg State :=
-    build_contract counter_init _ counter_receive _.
+  Definition counter_contract : Contract Z Msg State :=
+    build_contract counter_init counter_receive.
 
 End Counter.
 

--- a/execution/examples/EIP20Token.v
+++ b/execution/examples/EIP20Token.v
@@ -129,15 +129,7 @@ Section EIP20Token.
    end.
   Close Scope Z_scope.
 
-  Lemma init_proper :
-    Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-  Proof. repeat intro; solve_contract_proper. Qed.
-
-  Lemma receive_proper :
-    Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-  Proof. repeat intro; solve_contract_proper. Qed.
-
   Definition contract : Contract Setup Msg State :=
-    build_contract init init_proper receive receive_proper.
+    build_contract init receive.
 
 End EIP20Token.

--- a/execution/examples/FA2Token.v
+++ b/execution/examples/FA2Token.v
@@ -497,15 +497,7 @@ Definition init (chain : Chain)
           operators := FMap.empty;
           tokens := setup.(setup_tokens) |}.
 
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; solve_contract_proper.	Qed.
-
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof. repeat intro; solve_contract_proper. Qed.
-
 Definition contract : Contract Setup Msg State :=
-  build_contract init init_proper receive receive_proper.
+  build_contract init receive.
 
 End FA2Token.

--- a/execution/examples/LocalBlockchainTests.v
+++ b/execution/examples/LocalBlockchainTests.v
@@ -50,15 +50,15 @@ Section LocalBlockchainTests.
   Definition chain2 : ChainBuilder :=
     unpack_result (add_block chain1 []).
 
-  Compute (account_balance chain2 person_1).
-  Compute (account_balance chain2 creator).
+  Compute (env_account_balances chain2 person_1).
+  Compute (env_account_balances chain2 creator).
 
   (* Creator transfers 10 coins to person_1 *)
   Definition chain3 : ChainBuilder :=
     unpack_result (add_block chain2 [build_act creator (act_transfer person_1 10)]).
 
-  Compute (account_balance chain3 person_1).
-  Compute (account_balance chain3 creator).
+  Compute (env_account_balances chain3 person_1).
+  Compute (env_account_balances chain3 creator).
 
   (* person_1 deploys a Congress contract *)
   Definition setup_rules :=
@@ -80,9 +80,9 @@ Section LocalBlockchainTests.
     | _ => person_1
     end.
 
-  Compute (account_balance chain4 person_1).
-  Compute (account_balance chain4 creator).
-  Compute (account_balance chain4 congress_1).
+  Compute (env_account_balances chain4 person_1).
+  Compute (env_account_balances chain4 creator).
+  Compute (env_account_balances chain4 congress_1).
 
   Definition congress_ifc : ContractInterface Congress.Msg :=
     match get_contract_interface chain4 congress_1 Congress.Msg with
@@ -119,7 +119,7 @@ Section LocalBlockchainTests.
     unpack_result (add_block chain4 acts).
 
   Compute (FMap.elements (congress_state chain5).(members)).
-  Compute (account_balance chain5 congress_1).
+  Compute (env_account_balances chain5 congress_1).
 
   (* person_1 creates a proposal to send 3 coins to person_3 using funds
      of the contract *)
@@ -150,11 +150,11 @@ Section LocalBlockchainTests.
 
   Compute (FMap.elements (congress_state chain8).(proposals)).
   (* Balances before: *)
-  Compute (account_balance chain7 congress_1).
-  Compute (account_balance chain7 person_3).
+  Compute (env_account_balances chain7 congress_1).
+  Compute (env_account_balances chain7 person_3).
   (* Balances after: *)
-  Compute (account_balance chain8 congress_1).
-  Compute (account_balance chain8 person_3).
+  Compute (env_account_balances chain8 congress_1).
+  Compute (env_account_balances chain8 person_3).
   Print Assumptions chain8.
 
   Hint Resolve congress_correct_after_block : core.

--- a/execution/tests/ChainPrinters.v
+++ b/execution/tests/ChainPrinters.v
@@ -99,6 +99,7 @@ Instance showLocalContractCallContext : Show (@ContractCallContext Base) :=
 show cctx := "ContractCallContext{"
              ++ "ctx_from: " ++ show (@ctx_from Base cctx) ++ sep
              ++ "ctx_contract_addr: " ++ show (@ctx_contract_address Base cctx) ++ sep
+             ++ "ctx_contract_balance: " ++ show (@ctx_contract_balance Base cctx) ++ sep
              ++ "ctx_amount: " ++ show (@ctx_amount Base cctx) ++ "}"
 |}.
 
@@ -195,7 +196,7 @@ Instance showLCB `{Show (@Action Base)} : Show ChainBuilder :=
 Instance showChainBuilderType {BaseTypes : ChainBase}: Show (@ChainBuilderType BaseTypes) :=
   {| show a := "ChainBuilderType{...}" |}.
 
-Instance showChain (BaseTypes : ChainBase) : Show (@Chain BaseTypes) :=
+Instance showChain (BaseTypes : ChainBase) : Show Chain :=
 {|
   show c :=
     let height := show (chain_height c) in

--- a/execution/tests/CongressTests/CongressGens.v
+++ b/execution/tests/CongressTests/CongressGens.v
@@ -141,7 +141,7 @@ Definition finishable_proposals (state : Congress.State)
 
 Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GOpt Action :=
   let call contract_addr caller_addr msg :=
-    amount <- match env.(account_balance) caller_addr with
+    amount <- match env.(env_account_balances) caller_addr with
               | 0%Z => returnGenSome 0%Z
               | caller_balance => genToOpt (choose (0%Z, caller_balance))
               end ;;

--- a/execution/tests/CongressTests/Congress_BuggyGens.v
+++ b/execution/tests/CongressTests/Congress_BuggyGens.v
@@ -141,7 +141,7 @@ Definition lc_contract_members_and_proposals_with_votes (state : Congress_Buggy.
 
 Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GOpt Action :=
   let call contract_addr caller_addr msg :=
-    amount <- match env.(account_balance) caller_addr with
+    amount <- match env.(env_account_balances) caller_addr with
               | 0%Z => returnGenSome 0%Z
               | caller_balance => genToOpt (choose (0%Z, caller_balance))
               end ;;
@@ -211,4 +211,3 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
       end)
   ]
   end.
-

--- a/execution/tests/DexterTests/Dexter.v
+++ b/execution/tests/DexterTests/Dexter.v
@@ -164,7 +164,7 @@ Definition receive (chain : Chain)
                    : option (State * list ActionBody) :=
   let sender := ctx.(ctx_from) in
   let caddr := ctx.(ctx_contract_address) in
-  let dexter_balance := chain.(account_balance) caddr in
+  let dexter_balance := ctx.(ctx_contract_balance) in
   let amount := ctx.(ctx_amount) in
   match maybe_msg with
   | Some (receive_balance_of_param responses) => receive_balance_response responses caddr dexter_balance state
@@ -180,15 +180,7 @@ Definition init (chain : Chain)
           ongoing_exchanges := [];
           price_history := [] |}.
 
-Lemma init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-Proof. repeat intro; solve_contract_proper.	Qed.
-
-Lemma receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-Proof. repeat intro; solve_contract_proper. Qed.
-
 Definition contract : Contract Setup Msg State :=
-  build_contract init init_proper receive receive_proper.
+  build_contract init receive.
 
 End Dexter.

--- a/execution/tests/DexterTests/DexterGens.v
+++ b/execution/tests/DexterTests/DexterGens.v
@@ -58,12 +58,12 @@ Definition liftOptGen {A : Type} (g : G A) : GOpt A :=
   a <- g ;;
   returnGenSome a.
 
-Definition gAddTokensToReserve (c : Chain)
+Definition gAddTokensToReserve (env : Environment)
                                (state : FA2Token.State)
                                : GOpt (Address * Amount * Dexter.Msg) :=
   tokenid <- liftM fst (sampleFMapOpt state.(assets)) ;;
   caller <- liftOptGen gAccountAddress ;;
-  amount <- liftOptGen (choose (0%Z, c.(account_balance) caller)) ;;
+  amount <- liftOptGen (choose (0%Z, env.(env_account_balances) caller)) ;;
   returnGenSome (caller, amount, (other_msg (add_to_tokens_reserve tokenid))).
 
 Definition gDexterAction (env : Environment) : GOpt Action :=
@@ -92,7 +92,7 @@ Definition gDexterChain max_acts_per_block cb length :=
 Definition token_reachableFrom max_acts_per_block cb pf : Checker :=
   reachableFrom_chaintrace cb (gDexterChain max_acts_per_block) pf.
 
-Definition token_reachableFrom_implies_reachable 
+Definition token_reachableFrom_implies_reachable
            {A} length max_acts_per_block cb (pf1 : ChainState -> option A) pf2 : Checker :=
   reachableFrom_implies_chaintracePropSized length cb (gDexterChain max_acts_per_block) pf1 pf2.
 

--- a/execution/tests/EscrowTests/EscrowGens.v
+++ b/execution/tests/EscrowTests/EscrowGens.v
@@ -28,8 +28,8 @@ Open Scope Z_scope.
 
 (* Try to generate an account which has balance > 0. Returns None whenever no such address could be found.  *)
 Definition gAccountWithBalance (e : Env) (gAccOpt : GOpt Address) : GOpt (Address * Amount) :=
-  addr <- suchThatMaybeOpt gAccOpt (fun addr => 0 <? e.(account_balance) addr) ;;
-  returnGenSome (addr, e.(account_balance) addr).
+  addr <- suchThatMaybeOpt gAccOpt (fun addr => 0 <? e.(env_account_balances) addr) ;;
+  returnGenSome (addr, e.(env_account_balances) addr).
 
 Definition gEscrowMsg (e : Env) : GOpt Action :=
   let call caller amount msg :=
@@ -44,9 +44,9 @@ Definition gEscrowMsg (e : Env) : GOpt Action :=
      backtrack if one fails. *)
   backtrack [
     (* commit money *)
-    (1%nat, 
+    (1%nat,
         (* amount <- choose (0%Z, e.(account_balance) buyer) ;; *)
-        if e.(account_balance) buyer <? 2
+        if e.(env_account_balances) buyer <? 2
         then returnGen None
         else call buyer 2 commit_money
     ) ;
@@ -74,7 +74,7 @@ Definition gEscrowMsgBetter (e : Env) : GOpt Action :=
   match state.(next_step) with
   (* Waiting for buyer to commit itemvalue * 2. In this state, the seller can also choose to withdraw their deposit *)
   | buyer_commit => backtrack [
-                      (2%nat, if e.(account_balance) buyer <? 2
+                      (2%nat, if e.(env_account_balances) buyer <? 2
                               then returnGen None
                               else call buyer 2 commit_money
                       );

--- a/execution/tests/FA2Tests/FA2Gens.v
+++ b/execution/tests/FA2Tests/FA2Gens.v
@@ -144,11 +144,11 @@ Definition gTransfer (state : FA2Token.State)
 
 Local Close Scope N_scope.
 Local Open Scope Z_scope.
-Definition gCreateTokens (chain : Chain)
+Definition gCreateTokens (env : Environment)
                          (caller : Address)
                          (state : FA2Token.State)
                          : G (option (Z * FA2Token.Msg)) :=
-  let balance := chain.(account_balance) caller in
+  let balance := env.(env_account_balances) caller in
   bindGenOpt (liftM fst (sampleFMapOpt state.(assets)))
   (fun tokenid =>
     if 0 <? balance then
@@ -248,7 +248,7 @@ Definition gClientAction (env : Environment) : GOpt Action :=
   caller <- liftOptGen (gAddrWithout []) ;;
   msg <- gIsOperatorMsg ;;
   mk_call_fa2 caller fa2_caddr msg.
-  
+
 End FA2ClientGens.
 
 (* --------------------- FA2 Hook Generators --------------------- *)
@@ -271,9 +271,9 @@ Definition gFA2ChainTraceList max_acts_per_block cb length :=
 Definition token_reachableFrom (cb : ChainBuilder) pf : Checker :=
   reachableFrom_chaintrace cb (gFA2ChainTraceList 1) pf.
 
-Definition token_reachableFrom_implies_reachable {A} 
-                                                 (size : nat) 
-                                                 (cb : ChainBuilder) 
+Definition token_reachableFrom_implies_reachable {A}
+                                                 (size : nat)
+                                                 (cb : ChainBuilder)
                                                  (pf1 : ChainState -> option A)
                                                  pf2
                                                   : Checker :=

--- a/execution/tests/FA2Tests/TestContracts.v
+++ b/execution/tests/FA2Tests/TestContracts.v
@@ -81,16 +81,8 @@ Definition client_receive (chain : Chain)
   | _ => None
   end.
 
-Lemma client_init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) client_init.
-Proof. repeat intro; solve_contract_proper.	Qed.
-
-Lemma client_receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) client_receive.
-Proof. repeat intro; solve_contract_proper. Qed.
-
 Definition client_contract : Contract FA2Client.ClientSetup ClientMsg FA2Client.ClientState :=
-  build_contract client_init client_init_proper client_receive client_receive_proper.
+  build_contract client_init client_receive.
 
 End FA2Client.
 
@@ -201,15 +193,7 @@ Definition hook_receive (chain : Chain)
   | _ => None
   end.
 
-Lemma hook_init_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq) hook_init.
-Proof. repeat intro; solve_contract_proper.	Qed.
-
-Lemma hook_receive_proper :
-  Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) hook_receive.
-Proof. repeat intro; solve_contract_proper. Qed.
-
 Definition hook_contract : Contract HookSetup TransferHookMsg HookState :=
-  build_contract hook_init hook_init_proper hook_receive hook_receive_proper.
+  build_contract hook_init hook_receive.
 
 End FA2TransferHook.

--- a/execution/tests/TraceGens.v
+++ b/execution/tests/TraceGens.v
@@ -3,7 +3,7 @@
   This file defines a generator combinator, gChain, for the ChainBuilder type.
   From this, a generator/arbitrary instance for the ChainTrace type is derived automatically.
 
-  This file also contains checker combinator  over ChainBuilders/ChainTraces, 
+  This file also contains checker combinator  over ChainBuilders/ChainTraces,
   like forAllChainTrace, reachableFrom_chaintrace, and pre_post_assertion.
 *)
 
@@ -57,7 +57,7 @@ Section TraceGens.
                     (max_length : nat)
                     (act_depth : nat)
                     (max_acts_per_block : nat)
-                    : G ChainBuilder := 
+                    : G ChainBuilder :=
     let gAdd_block' lc := gAdd_block lc gActOptFromChainSized act_depth max_acts_per_block in
     let default_error := action_evaluation_depth_exceeded in (* Not ideal approach, but it suffices for now *)
     let try_twice g := backtrack_result default_error [(1, g);(1, g)] in
@@ -68,9 +68,9 @@ Section TraceGens.
               match lc' with
               | Ok lc' => rec n lc'
               (* if no new chain could be generated without error, return the old chain *)
-              | err => returnGen lc 
+              | err => returnGen lc
               end
-      end in 
+      end in
     rec max_length init_lc.
 
 
@@ -84,11 +84,11 @@ Section TraceGens.
   {|
     shrink a := [a]
   |}.
-    
+
   Global Instance genReachableSized `{GenSized ChainBuilder} : GenSized {to | reachable to}.
   Proof.
     constructor.
-    intros H2. 
+    intros H2.
     apply H1 in H2.
     apply (bindGen H2).
     intros cb.
@@ -99,14 +99,14 @@ Section TraceGens.
     apply trace.
   Defined.
 
-  Global Instance shrinkChainTraceSig : Shrink {to : ChainState & ChainTrace empty_state to} := 
+  Global Instance shrinkChainTraceSig : Shrink {to : ChainState & ChainTrace empty_state to} :=
   {|
     shrink a := [a]
   |}.
 
   Global Instance genChainTraceSigSized `{GenSized ChainBuilder} : GenSized {to : ChainState & ChainTrace empty_state to}.
   Proof.
-    constructor. 
+    constructor.
     intros n.
     apply H1 in n.
     apply (bindGen n).
@@ -139,7 +139,7 @@ Section TraceGens.
   (* Variant that only gathers ChainStates of step_block steps in the trace. *)
   Fixpoint trace_states_step_block {from to} (trace : ChainTrace from to) : list ChainState :=
     match trace with
-    | snoc trace' (Blockchain.step_block _ _ _ _ _ _ _ as step) => 
+    | snoc trace' (Blockchain.step_block _ _ _ _ _ _ _ as step) =>
       trace_states_step_block trace' ++ [snd (chainstep_states step)]
     | snoc trace' _ => trace_states_step_block trace'
     | clnil => []
@@ -168,7 +168,7 @@ Section TraceGens.
     forAll (gTrace init_lc maxLength)
     (fun cb => ChainTrace_ChainTraceProp cb.(builder_trace) pf).
 
-  (* Checker combinators on ChainTrace, asserting holds a property on 
+  (* Checker combinators on ChainTrace, asserting holds a property on
     each pair of succeeding ChainStates in the trace. *)
   Definition forAllChainStatePairs {prop : Type}
                                   `{Checkable prop}
@@ -186,7 +186,7 @@ Section TraceGens.
         | Blockchain.step_block _ _ _ _ _ _ _ =>
           (* next_bstate has acts, bstate_before_step_block has no acts *)
           let '(bstate_before_step_block, next_bstate) := chainstep_states step in
-          conjoin [(checker (pf next_bstate prev_bstate)); all_statepairs trace' bstate_before_step_block] 
+          conjoin [(checker (pf next_bstate prev_bstate)); all_statepairs trace' bstate_before_step_block]
         | _ => all_statepairs trace' prev_bstate
           end
       | clnil  => checker true
@@ -196,7 +196,7 @@ Section TraceGens.
 
   (* Asserts that a boolean predicate holds for at least one ChainState in the given ChainTrace *)
   Definition existsb_chaintrace {from to}
-                                (pf : ChainState -> bool)  
+                                (pf : ChainState -> bool)
                                 (trace : ChainTrace from to) : bool :=
     existsb pf (trace_states trace).
 
@@ -207,7 +207,7 @@ Section TraceGens.
                           (gTrace : ChainBuilder -> nat -> G ChainBuilder )
                           (pf : ChainState -> bool)
                           : Checker :=
-    existsP (gTrace init_lc maxLength) (fun cb => 
+    existsP (gTrace init_lc maxLength) (fun cb =>
       existsb_chaintrace pf cb.(builder_trace)).
 
   Definition reachableFrom_chaintrace init_lc gTrace pf : Checker :=
@@ -234,7 +234,7 @@ Section TraceGens.
       (* last_step is the element satisfying reachable_prop_bool *)
       let last_step := (List.last pre x) in
       isSomeCheck (reachable_prop last_step)
-        (fun a => 
+        (fun a =>
           (* assert that implied_prop holds on the post trace *)
           implied_prop a pre post
         )
@@ -266,8 +266,8 @@ Section TraceGens.
           | _ => acc
           end
         ) [] acts in
-      let post_helper '(cctx, post_state) cstate msg : Checker := 
-        whenFail 
+      let post_helper '(cctx, post_state) cstate msg : Checker :=
+        whenFail
           ("On Msg: " ++ show msg)
           (checker (post cctx cstate msg post_state)) in
       let stepProp (cs : ChainState) :=
@@ -279,7 +279,12 @@ Section TraceGens.
             | act_call _ amount _ => amount
             | _ => 0%Z
             end in
-          let cctx := build_ctx act.(act_from) caddr amount in
+          let new_balance :=
+              if (act.(act_from) =? caddr)%address then
+                env.(env_account_balances) caddr
+              else
+                (env.(env_account_balances) caddr + amount)%Z in
+          let cctx := build_ctx act.(act_from) caddr new_balance amount in
           let new_state := c.(receive) env cctx cstate (Some msg) in
           (cctx, new_state) in
         match get_contract_state State env caddr with

--- a/execution/tests/iTokenBuggyTests/iTokenBuggy.v
+++ b/execution/tests/iTokenBuggyTests/iTokenBuggy.v
@@ -137,15 +137,7 @@ Section iTokenBuggy.
    end.
   Close Scope Z_scope.
 
-  Lemma init_proper :
-    Proper (ChainEquiv ==> eq ==> eq ==> eq) init.
-  Proof. repeat intro; Blockchain.solve_contract_proper. Qed.
-
-  Lemma receive_proper :
-    Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) receive.
-  Proof. repeat intro; solve_contract_proper. Qed.
-
   Definition contract : Contract Setup Msg State :=
-    build_contract init init_proper receive receive_proper.
+    build_contract init receive.
 
 End iTokenBuggy.

--- a/execution/theories/Circulation.v
+++ b/execution/theories/Circulation.v
@@ -10,8 +10,8 @@ Context {ChainBase : ChainBase}.
 Context `{Finite Address}.
 
 Local Open Scope Z.
-Definition circulation (chain : Chain) :=
-  sumZ (account_balance chain) (elements Address).
+Definition circulation (env : Environment) :=
+  sumZ (env_account_balances env) (elements Address).
 
 (* We prove first that over any single action, the circulation is preserved.
 The idea behind this proof is that addrs contain from and to so
@@ -69,7 +69,8 @@ Proof.
   cbn.
   rewrite (account_balance_post_to eval from_neq_to).
   rewrite (account_balance_post_from eval from_neq_to).
-  enough (sumZ (account_balance pre) suf = sumZ (account_balance post) suf) by lia.
+  enough (sumZ (env_account_balances pre) suf = sumZ (env_account_balances post) suf)
+    by lia.
 
   pose proof (Permutation_NoDup perm) as perm_set.
   assert (from_not_in_suf: ~In (eval_from eval) suf).
@@ -87,10 +88,10 @@ Qed.
 Hint Resolve eval_action_circulation_unchanged : core.
 
 Instance circulation_proper :
-  Proper (ChainEquiv ==> eq) circulation.
+  Proper (EnvironmentEquiv ==> eq) circulation.
 Proof.
   intros x y [].
-  unfold circulation, account_balance.
+  unfold circulation, env_account_balances.
   induction (elements Address) as [|z zs IH]; auto.
   cbn.
   now
@@ -99,6 +100,7 @@ Proof.
     | [H: _ |- _] => rewrite H
   end.
 Qed.
+
 
 (* Now we prove that adding a block _does_ increase the circulation
 by what we would expect. *)

--- a/execution/theories/ContractMonads.v
+++ b/execution/theories/ContractMonads.v
@@ -135,14 +135,14 @@ Definition current_slot : ContractReader nat :=
 Definition finalized_height : ContractReader nat :=
   fun chain ctx => (chain, ctx, finalized_height chain).
 
-Definition account_balance (addr : Address) : ContractReader Amount :=
-  fun chain ctx => (chain, ctx, account_balance chain addr).
-
 Definition caller_addr : ContractReader Address :=
   fun chain ctx => (chain, ctx, ctx_from ctx).
 
 Definition my_addr : ContractReader Address :=
   fun chain ctx => (chain, ctx, ctx_contract_address ctx).
+
+Definition my_balance : ContractReader Amount :=
+  fun chain ctx => (chain, ctx, ctx_contract_balance ctx).
 
 Definition call_amount : ContractReader Amount :=
   fun chain ctx => (chain, ctx, ctx_amount ctx).
@@ -183,15 +183,8 @@ Definition build_contract
            {Setup Msg State : Type}
            `{Serializable Setup} `{Serializable Msg} `{Serializable State}
            (init : ContractIniter Setup State)
-           (receive : ContractReceiver State Msg State)
-           (init_proper :
-              Proper (ChainEquiv ==> eq ==> eq ==> eq) (run_contract_initer init))
-           (receive_proper :
-              Proper (ChainEquiv ==> eq ==> eq ==> eq ==> eq) (run_contract_receiver receive))
-  : Contract Setup Msg State :=
+           (receive : ContractReceiver State Msg State) : Contract Setup Msg State :=
   {| init := (run_contract_initer init);
-     receive := (run_contract_receiver receive);
-     init_proper := init_proper;
-     receive_proper := receive_proper; |}.
+     receive := (run_contract_receiver receive); |}.
 
 End ContractMonads.

--- a/extraction/examples/CounterCertifiedExtraction.v
+++ b/extraction/examples/CounterCertifiedExtraction.v
@@ -105,9 +105,8 @@ Module Counter.
             Derive Serializable msg_rect<Inc, Dec>.
 
   (** A contract instance used by the execution framework *)
-  Program Definition CounterContract :=
-    build_contract counter_init _ counter_receive _.
-  Next Obligation. easy. Qed.
+  Definition CounterContract :=
+    build_contract counter_init counter_receive.
 
 End Counter.
 

--- a/extraction/examples/MidlangCounterRefTypes.v
+++ b/extraction/examples/MidlangCounterRefTypes.v
@@ -34,7 +34,6 @@ Instance MidlangBoxes : MidlangPrintConfig :=
 
 Definition midlang_translation_map :=
   [(<%% @current_slot %%>, "current_slot");
-  (<%% @account_balance %%>, "account_balance");
   (<%% @address_eqb %%>, "address_eq");
   (<%% @ctx_amount %%>, "amount");
   (<%% @ctx_from %%>, "from");

--- a/extraction/examples/MidlangEscrow.v
+++ b/extraction/examples/MidlangEscrow.v
@@ -40,7 +40,6 @@ Definition TT_escrow : list (kername * string) :=
 Definition midlang_translation_map :=
   Eval compute in
         [(<%% @current_slot %%>, "current_slot");
-        (<%% @account_balance %%>, "account_balance");
         (<%% @address_eqb %%>, "Order.eq");
         (<%% @ctx_amount %%>, "ctx_amount");
         (<%% @ctx_from %%>, "ctx_from");

--- a/extraction/examples/MidlangEscrow.v
+++ b/extraction/examples/MidlangEscrow.v
@@ -41,13 +41,14 @@ Definition midlang_translation_map :=
   Eval compute in
         [(<%% @current_slot %%>, "current_slot");
         (<%% @address_eqb %%>, "Order.eq");
-        (<%% @ctx_amount %%>, "ctx_amount");
         (<%% @ctx_from %%>, "ctx_from");
+        (<%% @ctx_contract_address %%>, "ctx_contract_address");
+        (<%% @ctx_contract_balance %%>, "ctx_contract_balance");
+        (<%% @ctx_amount %%>, "ctx_amount");
         (<%% @Chain %%>, "ConCertChain");
         (<%% @ContractCallContext %%>, "ConCertCallContext");
         (<%% @ConCert.Execution.Blockchain.ActionBody %%>, "ConCertAction");
         (<%% @ChainBase %%>, "ChainBaseWTF");
-        (<%% @ctx_contract_address %%>, "contract_address");
         (<%% @Amount %%>,"Z" )].
 
 Definition midlang_escrow_translate (name : kername) : option string :=
@@ -125,9 +126,9 @@ Definition midlang_prelude :=
   "type ConCertCallContext = CCtx Unit";
   "type ConCertChain = CChain Unit";
   "ctx_from ctx = 0";
+  "ctx_contract_address _ = 0";
+  "ctx_contract_balance _ = (Zpos (XO XH))";
   "ctx_amount ctx = (Zpos (XO XH))";
-  "contract_address _ = 0";
-  "account_balance _ _ = (Zpos (XO XH))";
   "current_slot _ = O"].
 
 Definition escrow_result :=


### PR DESCRIPTION
Remove the account_balance function from Chain and add instead
ctx_contract_balance to the ContractCallContext. This is is the only
thing our contracts use and it means that we match the models of our
target languages better. It also means we do not need Proper instances
anymore for contracts.