### PR TITLE
Adapting ConCert to the newest MetaCoq (coq-8.11 branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ opam switch create . 4.07.1
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install -j 4 coq.8.11.2 coq-bignums coq-stdpp coq-quickchick
-opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#77adb13585d2f357b78642c16b6c4da817f35eff
+opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#8d576c70957c0dce2053f2a7272b231f41c3d43f
 ```
 
 After completing the procedures above, run `make` to build the development, and

--- a/extraction/examples/ErasureTests.v
+++ b/extraction/examples/ErasureTests.v
@@ -21,6 +21,7 @@ Local Open Scope string_scope.
 Import String.
 Import ListNotations.
 Import MonadNotation.
+Import PCUICErrors.
 Set Equations Transparent.
 
 Local Existing Instance extraction_checker_flags.
@@ -151,7 +152,7 @@ Definition print_box_type (Σ : P.global_env) (tvars : list name) :=
                 | None => "'a" ++ string_of_nat i
                 end
     | TInd s =>
-      match @lookup_ind_decl (empty_ext Σ) s with
+      match @PCUICSafeRetyping.lookup_ind_decl (empty_ext Σ) s with
       | Checked (decl; oib; _) => oib.(P.ind_name)
       | TypeError te => "UndeclaredInductive("
                           ++ string_of_kername s.(inductive_mind)

--- a/extraction/plugin/_CoqProject
+++ b/extraction/plugin/_CoqProject
@@ -41,6 +41,8 @@ src/extraction0.ml
 src/extraction0.mli
 src/fin.ml
 src/fin.mli
+src/floatOps.ml
+src/floatOps.mli
 src/init.ml
 src/init.mli
 src/inlining.ml
@@ -63,6 +65,8 @@ src/pCUICChecker.ml
 src/pCUICChecker.mli
 src/pCUICCumulativity.ml
 src/pCUICCumulativity.mli
+src/pCUICErrors.ml
+src/pCUICErrors.mli
 src/pCUICEquality.ml
 src/pCUICEquality.mli
 src/pCUICLiftSubst.ml
@@ -73,6 +77,8 @@ src/pCUICPosition.ml
 src/pCUICPosition.mli
 src/pCUICPretty.ml
 src/pCUICPretty.mli
+src/pCUICPrimitive.ml
+src/pCUICPrimitive.mli
 src/pCUICReduction.ml
 src/pCUICReduction.mli
 src/pCUICSafeChecker.ml
@@ -97,12 +103,18 @@ src/resultMonad.ml
 src/resultMonad.mli
 src/rustExtract.ml
 src/rustExtract.mli
+src/int63.ml
+src/int63.mli
+src/primFloat.ml
+src/primFloat.mli
 src/pluginExtract.ml
 src/pluginExtract.mli
 src/erasureFunction.ml
 src/erasureFunction.mli
 src/safeTemplateChecker.ml
 src/safeTemplateChecker.mli
+src/specFloat.ml
+src/specFloat.mli
 src/ssrbool.ml
 src/ssrbool.mli
 src/ssreflect.ml

--- a/extraction/plugin/src/.gitignore
+++ b/extraction/plugin/src/.gitignore
@@ -4,6 +4,8 @@ closedAux.ml
 closedAux.mli
 common1.ml
 common1.mli
+decimalString.ml
+decimalString.mli
 eAst.ml
 eAst.mli
 eAstUtils.ml
@@ -20,6 +22,8 @@ environmentTyping.ml
 environmentTyping.mli
 erasure.ml
 erasure.mli
+eqDecInstances.ml
+eqDecInstances.mli
 exAst.ml
 exAst.mli
 expandBranches.ml
@@ -30,12 +34,18 @@ extraction0.ml
 extraction0.mli
 fin.ml
 fin.mli
+floatOps.ml
+floatOps.mli
 init.ml
 init.mli
 inlining.ml
 inlining.mli
+int63.ml
+int63.mli
 kernames.ml
 kernames.mli
+mCPrelude.ml
+mCPrelude.mli
 monad_utils.ml
 monad_utils.mli
 optimize.ml
@@ -48,6 +58,8 @@ pCUICAst.ml
 pCUICAst.mli
 pCUICAstUtils.ml
 pCUICAstUtils.mli
+pCUICErrors.ml
+pCUICErrors.mli
 pCUICChecker.ml
 pCUICChecker.mli
 pCUICCumulativity.ml
@@ -62,6 +74,8 @@ pCUICPosition.ml
 pCUICPosition.mli
 pCUICPretty.ml
 pCUICPretty.mli
+pCUICPrimitive.ml
+pCUICPrimitive.mli
 pCUICReduction.ml
 pCUICReduction.mli
 pCUICSafeChecker.ml
@@ -80,6 +94,8 @@ pluginExtract.ml
 pluginExtract.mli
 prettyPrinterMonad.ml
 prettyPrinterMonad.mli
+primFloat.ml
+primFloat.mli
 printing.ml
 printing.mli
 reflect.ml
@@ -92,6 +108,8 @@ erasureFunction.ml
 erasureFunction.mli
 safeTemplateChecker.ml
 safeTemplateChecker.mli
+specFloat.ml
+specFloat.mli
 ssrbool.ml
 ssrbool.mli
 ssreflect.ml

--- a/extraction/plugin/src/concert_extraction_plugin.mlpack
+++ b/extraction/plugin/src/concert_extraction_plugin.mlpack
@@ -15,15 +15,17 @@ OrderedTypeAlt
 Kernames
 Reflect
 
+PCUICPrimitive
 PCUICAst
 PCUICAstUtils
 PCUICChecker
 PCUICCumulativity
 PCUICEquality
 PCUICLiftSubst
+PCUICPretty
+PCUICErrors
 PCUICNormal
 PCUICPosition
-PCUICPretty
 PCUICReduction
 PCUICUnivSubst
 PCUICTyping
@@ -31,6 +33,10 @@ PCUICSafeReduce
 PCUICSafeChecker
 PCUICSafeConversion
 PCUICSafeRetyping
+Int63
+PrimFloat
+FloatOps
+SpecFloat
 TemplateToPCUIC
 
 EAst

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -600,6 +600,7 @@ Section print_term.
   | tFix [] _ => fun _ => "FixWithNoBody"
   | tFix _ _ => fun _ => "NotSupportedMutualFix"
   | tCoFix l n => fun _ => "NotSupportedCoFix"
+  | tPrim _ => fun _ => "NotSupportedCoqPrimitive"
   end.
 
 End print_term.

--- a/extraction/theories/CertifyingEta.v
+++ b/extraction/theories/CertifyingEta.v
@@ -172,6 +172,8 @@ Fixpoint change_modpath (mpath : modpath) (ignore : kername -> bool) (t : term) 
   | tProj proj t => tProj proj (change_modpath mpath ignore t)
   | tFix mfix idx => tFix (map (map_def (change_modpath mpath ignore) (change_modpath mpath ignore)) mfix) idx
   | tCoFix mfix idx => tCoFix (map (map_def (change_modpath mpath ignore) (change_modpath mpath ignore)) mfix) idx
+  | tInt _ => t
+  | tFloat _ => t
   end.
 
 Definition generate_proof (Σ1 Σ2 : global_env) (kn1 kn2 : kername) : TemplateMonad (term × term × term × term) :=

--- a/extraction/theories/Common.v
+++ b/extraction/theories/Common.v
@@ -24,7 +24,9 @@ Notation "<%% t %%>" :=
              | @Some _ ?kn => exact kn
              | _ => fail "not a name"
              end in quote_term t p)).
-             
+
+Import PCUICErrors.
+
 Definition result_of_typing_result
            {A}
            (Σ : PCUICAst.global_env_ext)

--- a/extraction/theories/ElmExtract.v
+++ b/extraction/theories/ElmExtract.v
@@ -480,6 +480,7 @@ Fixpoint print_term (Γ : list ident) (t : term) : PrettyPrinter unit :=
     pop_indent
 
   | tCoFix _ _ => printer_fail "Cannot handle cofix"
+  | tPrim _ => printer_fail "Cannot handle Coq primitive types"
   end.
 
 Definition print_constant

--- a/extraction/theories/Erasure.v
+++ b/extraction/theories/Erasure.v
@@ -48,6 +48,7 @@ From MetaCoq.Template Require TemplateMonad.
 
 Import PCUICEnvTyping.
 Import PCUICLookup.
+Import PCUICErrors.
 
 Local Open Scope string_scope.
 Import VectorDef.VectorNotations.
@@ -667,7 +668,7 @@ Next Obligation.
   now apply conv_arity_Is_conv_to_Arity in car.
 Qed.
 Next Obligation.
-  pose proof (PCUICSafeChecker.reduce_to_sort_complete _ _ (eq_sym eq)).
+  pose proof (PCUICSafeReduce.reduce_to_sort_complete _ _ (eq_sym eq)).
   clear eq.
   apply not_prod_or_sort_hnf in discr.
   destruct isT as [(u&typ)].
@@ -885,7 +886,7 @@ Next Obligation.
   destruct wfΣ as [wfΣu].
   sq.
   exists univ.
-  eapply type_reduction; [easy|exact typ|easy].
+  eapply type_reduction; [exact typ|easy].
 Qed.
 Next Obligation.
   reduce_term_sound; clear eq_hnf.
@@ -969,7 +970,11 @@ Proof.
       eapply isType_wf_local; eauto. }
     constructor.
     rewrite <- (PCUICSpine.subst_rel0_lift_id 0 (mkNormalArity ar_ctx univ)).
+    eapply validity in typ as typ_valid;auto.
+    destruct typ_valid as [u Hty].
     eapply type_App.
+    + eapply validity in typ as typ;auto.
+      eapply (PCUICWeakening.weakening _ _ [_] _ _ _ wflext Hty).
     + eapply (PCUICWeakening.weakening _ _ [_] _ _ _ wflext typ).
     + fold lift.
       eapply (type_Rel _ _ _ (vass na A)); auto.
@@ -1027,13 +1032,11 @@ Proof.
     assert (conv_context Σ (Γ,, vass na A) (Γ,, vass na' A')).
     { constructor; [reflexivity|].
       constructor; assumption. }
-    eapply context_conversion'; eauto.
-    1: now eapply typing_wf_local; eauto.
-    2: now apply conv_context_sym; eauto.
     eapply type_Cumul.
+    + eassumption.
     + eapply context_conversion; eauto.
       eapply typing_wf_local; eassumption.
-    + eassumption.
+      now apply conv_context_sym.
     + now eapply cumul_conv_ctx; eauto.
 Qed.
 

--- a/extraction/theories/ErasureCorrectness.v
+++ b/extraction/theories/ErasureCorrectness.v
@@ -174,7 +174,7 @@ Proof.
 
         destruct wfdecl as [wfdecl].
         destruct c0 as [ctx univ [r]].
-        eapply type_reduction in wfdecl; eauto.
+        apply @type_reduction with (B:=mkNormalArity ctx univ) in wfdecl; eauto.
         2: now inversion wfΣ.
         constructor.
         eapply (Is_type_extends (Σ, _)).
@@ -197,7 +197,7 @@ Proof.
         end.
         destruct wfdecl as [wfdecl].
         split.
-        -- eapply type_reduction in wfdecl; eauto.
+        -- apply @type_reduction with (B:=cst_type) in wfdecl; eauto.
            2: now inversion wfΣ.
            eapply (erases_extends (_, _)).
            2: now eauto.

--- a/extraction/theories/ExAst.v
+++ b/extraction/theories/ExAst.v
@@ -70,7 +70,7 @@ Record type_var_info :=
 Record one_inductive_body :=
   { ind_name : ident;
     ind_propositional : bool;
-    ind_kelim : sort_family;
+    ind_kelim : allowed_eliminations;
     ind_type_vars : list type_var_info;
     ind_ctors : list (ident * list (name * box_type));
     (* unfortunately needed for erases_one_inductive_body *)

--- a/extraction/theories/ExpandBranches.v
+++ b/extraction/theories/ExpandBranches.v
@@ -33,6 +33,7 @@ Fixpoint expand_branches (t : term) : term :=
   | tProj p t => tProj p (expand_branches t)
   | tFix defs i => tFix (map (map_def expand_branches) defs) i
   | tCoFix defs i => tCoFix (map (map_def expand_branches) defs) i
+  | tPrim _ => t
   end.
 
 Definition expand_constant_body cst :=

--- a/extraction/theories/ExtractExtraction.v
+++ b/extraction/theories/ExtractExtraction.v
@@ -34,7 +34,6 @@ Extraction Inline Equations.Prop.DepElim.solution_left.
 
 Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
 Extract Constant PCUICTyping.guard_checking => "{ fix_guard = (fun _ _ _ -> true); cofix_guard = (fun _ _ _ -> true) }".
-(* Extract Constant PCUICTyping.ind_guard => "(fun x -> true)". *)
 Extract Constant PCUICSafeChecker.check_one_ind_body => "(fun _ _ _ _ _ _ _ -> ret envcheck_monad __)".
 Extract Constant timed =>
 "(fun c x ->

--- a/extraction/theories/ExtractExtraction.v
+++ b/extraction/theories/ExtractExtraction.v
@@ -1,6 +1,9 @@
 (* This file is based on erasure/theories/Extraction.v from MetaCoq *)
 
 Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
+From MetaCoq.Template Require Import MC_ExtrOCamlInt63.
+From Coq Require Import ExtrOCamlFloats.
+
 
 (* Ignore [Decimal.int] before the extraction issue is solved:
    https://github.com/coq/coq/issues/7017. *)
@@ -30,9 +33,8 @@ Extraction Inline Equations.Init.hidebody.
 Extraction Inline Equations.Prop.DepElim.solution_left.
 
 Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
-Extract Constant PCUICTyping.fix_guard => "(fun x -> true)".
-Extract Constant PCUICTyping.cofix_guard => "(fun x -> true)".
-Extract Constant PCUICTyping.ind_guard => "(fun x -> true)".
+Extract Constant PCUICTyping.guard_checking => "{ fix_guard = (fun _ _ _ -> true); cofix_guard = (fun _ _ _ -> true) }".
+(* Extract Constant PCUICTyping.ind_guard => "(fun x -> true)". *)
 Extract Constant PCUICSafeChecker.check_one_ind_body => "(fun _ _ _ _ _ _ _ -> ret envcheck_monad __)".
 Extract Constant timed =>
 "(fun c x ->

--- a/extraction/theories/ExtractionCorrectness.v
+++ b/extraction/theories/ExtractionCorrectness.v
@@ -72,25 +72,19 @@ Proof.
   destruct dearg_transform eqn:dt; cbn -[dearg_transform] in *; [|congruence].
   injection ex as ->.
   destruct wfΣ.
-  eapply erases_correct in ev as (erv&erase_to&[erev]).
-  2: constructor; auto.
-  2: eassumption.
-  2: apply erases_tConst.
-  2: { eapply inversion_Const in wt as (?&?&?&?&?); auto.
-       eapply global_erased_with_deps_erases_deps_tConst; eauto.
-       eapply (erase_global_decls_deps_recursive_correct
-                 _ (wf_squash (sq w))
-                 (KernameSet.singleton kn)); eauto.
-       - intros ? ->%KernameSet.singleton_spec.
-         unfold declared_constant, PCUICAst.fst_ctx, fst_ctx in *.
-         congruence.
-       - now apply KernameSet.singleton_spec. }
-  depelim erase_to; [|easy].
-
-  constructor.
-  eapply dearg_transform_correct; eauto.
-  apply (OptimizePropDiscr.optimize_correct _ (tConst kn) (tConstruct ind c)).
-  assumption.
+  eapply erases_correct in ev as (erv&erase_to&[erev]);eauto.
+  + depelim erase_to; [|easy].
+    constructor.
+    eapply dearg_transform_correct; eauto.
+    now apply (OptimizePropDiscr.optimize_correct _ (tConst kn) (tConstruct ind c)).
+  + eapply inversion_Const in wt as (?&?&?&?&?); auto.
+    eapply global_erased_with_deps_erases_deps_tConst; eauto.
+    eapply (erase_global_decls_deps_recursive_correct
+              _ (wf_squash (sq w))
+              (KernameSet.singleton kn)); eauto.
+    * intros ? ->%KernameSet.singleton_spec.
+      now unfold declared_constant, PCUICAst.fst_ctx, fst_ctx in *.
+    * now apply KernameSet.singleton_spec.
 Qed.
 
 Print Assumptions extract_correct.

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -487,6 +487,7 @@ Section print_term.
     | _ => "NotSupportedMutualFix"
     end
   | tCoFix l n => "NotSupportedCoFix"
+  | tPrim _ => "NotSupportedCoqPrimitive"
   end.
 
 End print_term.

--- a/extraction/theories/Optimize.v
+++ b/extraction/theories/Optimize.v
@@ -364,6 +364,7 @@ Fixpoint is_expanded_aux (nargs : nat) (t : term) : bool :=
   | tProj _ t => is_expanded_aux 0 t
   | tFix defs _
   | tCoFix defs _ => forallb (is_expanded_aux 0 ∘ dbody) defs
+  | tPrim _ => true
   end.
 
 (* Check if all applications are applied enough to be deboxed without eta expansion *)
@@ -588,6 +589,7 @@ Fixpoint analyze (state : analyze_state) (t : term) {struct t} : analyze_state :
     let state := new_vars state #|defs| in
     let state := fold_left (fun state d => analyze state (dbody d)) defs state in
     remove_vars state #|defs|
+  | tPrim _ => state
   end.
 
 Fixpoint decompose_TArr (bt : box_type) : list box_type × box_type :=

--- a/extraction/theories/OptimizeCorrectness.v
+++ b/extraction/theories/OptimizeCorrectness.v
@@ -438,6 +438,7 @@ Proof.
       now f_equal.
     + rewrite <- !Nat.add_succ_r in *.
       now apply IHX.
+  - reflexivity.
 Qed.
 
 Lemma masked_nil {X} mask :
@@ -734,6 +735,7 @@ Proof.
     cbn.
     f_equal.
     now rewrite p.
+  - apply lift_mkApps.
 Qed.
 
 Lemma lift_dearg n k t :
@@ -781,6 +783,7 @@ Proof.
     f_equal.
     rewrite <- !Nat.add_succ_r.
     now apply IHX.
+  - reflexivity.
 Qed.
 
 Lemma is_dead_lift_all k k' n t :
@@ -1231,6 +1234,7 @@ Proof.
     rewrite p by easy.
     split; [easy|].
     now apply IHX.
+  - eapply Forall_forallb;eauto.
 Qed.
 
 Lemma valid_dearg_mask_dearg mask t :
@@ -1368,6 +1372,7 @@ Proof.
     unfold map_def; cbn.
     f_equal.
     now apply (p _ _ []).
+  - rewrite subst_mkApps. now rewrite map_map.
 Qed.
 
 Lemma dearg_subst s k t :
@@ -1484,6 +1489,7 @@ Proof.
     propify.
     rewrite <- !Nat.add_succ_r.
     now rewrite p, IHX.
+  - reflexivity.
 Qed.
 
 Lemma is_expanded_aux_subst s n t k :
@@ -1528,6 +1534,7 @@ Proof.
     propify.
     rewrite <- !Nat.add_succ_r.
     now rewrite p, IHX.
+  - reflexivity.
 Qed.
 
 Lemma is_expanded_substl s n t :

--- a/extraction/theories/PrettyPrinterMonad.v
+++ b/extraction/theories/PrettyPrinterMonad.v
@@ -10,6 +10,8 @@ From MetaCoq.Template Require Import BasicAst.
 
 Import String.
 
+Import PCUICErrors.
+
 Import ListNotations.
 Import MonadNotation.
 Local Open Scope string.

--- a/extraction/theories/RustExtract.v
+++ b/extraction/theories/RustExtract.v
@@ -595,7 +595,7 @@ Fixpoint print_term (Γ : list ident) (t : term) {struct t} : PrettyPrinter unit
     printer_fail ("unhandled tProj on " ^ string_of_kername (inductive_mind ind))
 
   | tCoFix _ _ => printer_fail "Cannot handle tCoFix yet"
-
+  | tPrim _ => printer_fail "Cannot handle Coq primitive types yet"
   end.
 
 Definition print_constant

--- a/extraction/theories/SpecializeChainBase.v
+++ b/extraction/theories/SpecializeChainBase.v
@@ -135,6 +135,7 @@ Section ChainBaseSpecialization.
                                     dbody := dbody;
                                     rarg := rarg d |}) defs;;
         ret (tCoFix defs i)
+      | tPrim _ => ret t
       end.
 
   Definition specialize_body

--- a/extraction/theories/TypeAnnotations.v
+++ b/extraction/theories/TypeAnnotations.v
@@ -176,7 +176,7 @@ Proof.
     intros Γ a.
     induction a; [now constructor|].
     constructor; [|now eauto].
-    destruct r as ((? & ?) & ? & ? & ?).
+    destruct r as (? & ? & ? & ?).
     split; [|now auto].
     econstructor; eauto.
   - apply inversion_CoFix in X as (?&?&?&?&?&?&?); auto.
@@ -377,6 +377,7 @@ Proof.
     apply bigprod_map; [|exact ta.2].
     intros.
     exact (f _ All_nil _ X).
+  - exact (annot_mkApps ta argsa).
 Defined.
 
 Definition annot_dearg im cm {t : term} (ta : annots box_type t) : annots box_type (dearg im cm t) :=


### PR DESCRIPTION
MetaCoq commit: https://github.com/MetaCoq/metacoq/commit/8d576c70957c0dce2053f2a7272b231f41c3d43f

Changes:
- some lemmas and definitions in PCUIC meta-theory, nothing seriously affecting our proofs.
- primitive data types (int63, float) are supported by MetaCoq now. We don't handle them in our pretty-printers for now.