### PR TITLE
ERC20 extraction to liquidity

### DIFF
--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -54,6 +54,7 @@ examples/ElmExtractTests.v
 examples/ElmExtractExamples.v
 examples/ElmForms.v
 examples/ErasureTests.v
+examples/ERC20LiquidityExtraction.v
 examples/ForPaper.v
 examples/MidlangCounterRefTypes.v
 examples/MidlangEscrow.v

--- a/extraction/examples/ERC20LiquidityExtraction.v
+++ b/extraction/examples/ERC20LiquidityExtraction.v
@@ -1,0 +1,237 @@
+(** * Extraction of a simple counter contract *)
+
+From Coq Require Import PeanoNat ZArith Notations.
+
+From MetaCoq.Template Require Import Loader.
+From MetaCoq.Erasure Require Import Loader.
+
+From ConCert.Embedding Require Import MyEnv CustomTactics.
+From ConCert.Embedding Require Import Notations.
+(* From ConCert.Embedding Require Import SimpleBlockchain. *)
+From ConCert.Embedding.Extraction Require Import PreludeExt.
+From ConCert.Extraction Require Import LPretty LiquidityExtract Common Optimize.
+From ConCert.Execution Require Import Automation.
+From ConCert.Execution Require Import Serializable.
+From ConCert.Execution Require Import Blockchain.
+From ConCert.Execution Require Import EIP20Token.
+From Coq Require Import List Ascii String.
+Local Open Scope string_scope.
+
+From MetaCoq.Template Require Import All.
+
+Import ListNotations.
+Import MonadNotation.
+
+Open Scope Z.
+
+Definition PREFIX := "".
+
+Definition TT_remap_default : list (kername * string) :=
+  [
+    (* types *)
+    remap <%% Z %%> "tez"
+  ; remap <%% N %%> "int"
+  ; remap <%% nat %%> "nat"
+  ; remap <%% bool %%> "bool"
+  ; remap <%% unit %%> "unit"
+  ; remap <%% list %%> "list"
+  ; remap <%% @fst %%> "fst"
+  ; remap <%% @snd %%> "snd"
+  ; remap <%% option %%> "option"
+  ; remap <%% gmap.gmap %%> "map"
+  ; remap <%% positive %%> "nat"
+  ; remap <%% Amount %%> "tez"
+  ; remap <%% @Address %%> "address"
+
+  (* operations *)
+  ; remap <%% List.fold_left %%> "List.fold"
+  ; remap <%% Pos.add %%> "addNat"
+  ; remap <%% Pos.sub %%> "subNat"
+  ; remap <%% Pos.leb %%> "leNat"
+  ; remap <%% Pos.eqb %%> "eqNat"
+  ; remap <%% Z.add %%> "addTez"
+  ; remap <%% Z.sub %%> "subTez"
+  ; remap <%% Z.leb %%> "leTez"
+  ; remap <%% Z.ltb %%> "ltTez"
+  ; remap <%% Z.eqb %%> "eqTez"
+  ; remap <%% Z.gtb %%> "gtbTez"
+  ; remap <%% N.add %%> "addInt"
+  ; remap <%% N.sub %%> "subInt"
+  ; remap <%% N.leb %%> "leInt"
+  ; remap <%% N.ltb %%> "ltInt"
+  ; remap <%% N.eqb %%> "eqInt"
+  ; remap <%% andb %%> "andb"
+  ; remap <%% negb %%> "not"
+  ; remap <%% orb %%> "orb"
+  ; remap <%% eqb_addr %%> "eq_addr"
+  ].
+
+From ConCert.Execution.Examples Require EIP20Token.
+
+Section EIP20TokenExtraction.
+  Import EIP20Token.
+  From ConCert.Utils Require Import RecordUpdate.
+  Import RecordSetNotations.
+  Require Import Containers.
+  From stdpp Require gmap.
+
+
+  (* Notation storage := ((time_coq × Z × address_coq) × Maps.addr_map_coq × bool). *)
+  Notation params := (ContractCallContext × option EIP20Token.Msg).
+  Open Scope N_scope.
+
+    (* A specialized version of FMap's partial alter, w.r.t. FMap Address N *)
+  Definition partial_alter_addr_nat : string :=
+       "let partial_alter_addr_nat (f : int option -> int option)" ++ nl
+    ++ "                           (k : address)" ++ nl
+    ++ "                           (m : (address,int) map) : (address,int) map =" ++ nl
+    ++ "  match Map.find k m with" ++ nl
+    ++ "    Some v -> Map.update k (f (Some v)) m" ++ nl
+    ++ "  | None -> Map.update k (f (None : int option)) m" ++ nl.
+
+  Definition test_try_transfer (from : Address)
+      (to_addr : Address)
+      (amountt : TokenValue)
+      (state : State) : option State :=
+    let from_balance := Extras.with_default 0 (FMap.find from state.(balances)) in
+    if from_balance <? amountt
+    then None
+    else let new_balances := FMap.add from (from_balance - amountt) state.(balances) in
+        let new_balances := FMap.partial_alter (fun balance => Some (Extras.with_default 0 balance + amountt)) to_addr new_balances in
+        Some ({|
+          balances := new_balances;
+          total_supply := state.(total_supply);
+          allowances := state.(allowances);
+        |}).
+  Open Scope bool_scope.
+  Definition test_try_transfer_from (delegate : Address)
+      (from : Address)
+      (to_addr : Address)
+      (amountt : TokenValue)
+      (state : State) : option State :=
+  match FMap.find from state.(allowances) with
+  | Some from_allowances_map =>
+  match FMap.find delegate from_allowances_map with
+  | Some delegate_allowance =>
+  let from_balance := Extras.with_default 0 (FMap.find from state.(balances)) in
+  if (delegate_allowance <? amountt) || (from_balance <? amountt)
+  then None
+  else let new_allowances := FMap.add delegate (delegate_allowance - amountt) from_allowances_map in
+      let new_balances := FMap.add from (from_balance - amountt) state.(balances) in
+      let new_balances := FMap.partial_alter (fun balance => Some (Extras.with_default 0 balance + amountt)) to_addr new_balances in
+      Some ({|
+        balances := new_balances;
+        allowances := FMap.add from new_allowances state.(allowances);
+        total_supply := state.(total_supply)|})
+  | _ => None
+  end
+  | _ => None
+  end.
+
+  Definition test_init (ctx : ContractCallContext) (setup : EIP20Token.Setup) : option EIP20Token.State :=
+    Some {| total_supply := setup.(init_amount);
+            balances := FMap.empty;
+            allowances := FMap.empty |}.
+
+  Open Scope Z_scope.
+  Definition test_receive
+      (ctx : ContractCallContext)
+      (state : EIP20Token.State)
+      (maybe_msg : option EIP20Token.Msg)
+    : option (list ActionBody * EIP20Token.State) :=
+    let sender := ctx.(ctx_from) in
+    let without_actions := option_map (fun new_state => ([], new_state)) in
+    match maybe_msg with
+    | Some (transfer to_addr amountt) => without_actions (test_try_transfer sender to_addr amountt state)
+    | Some (transfer_from from to_addr amountt) => without_actions (test_try_transfer_from sender from to_addr amountt state)
+    (* Other endpoints are not included in this extraction test *)
+    | _ => None
+    end.
+
+  Definition receive_wrapper
+             (params : params)
+             (st : State) : option (list ActionBody × State) :=
+    test_receive params.1 st params.2.
+
+  Definition init (ctx : ContractCallContext) (setup : EIP20Token.Setup) : option EIP20Token.State :=
+    let ctx_ := ctx in
+    Some {| total_supply := setup.(init_amount);
+            balances := FMap.add (EIP20Token.owner setup) (init_amount setup) FMap.empty;
+            allowances := FMap.empty |}.
+  Open Scope Z_scope.
+
+  Definition EIP20Token_MODULE : LiquidityMod params ContractCallContext EIP20Token.Setup EIP20Token.State ActionBody :=
+  {| (* a name for the definition with the extracted code *)
+      lmd_module_name := "liquidity_eip20token" ;
+
+      (* definitions of operations on pairs and ints *)
+      lmd_prelude := LiquidityPrelude ++ nl 
+                  ++ partial_alter_addr_nat;
+
+      (* initial storage *)
+      lmd_init := init ;
+
+      lmd_init_prelude := "type storage = state" ++ nl;
+
+      (* the main functionality *)
+      lmd_receive := receive_wrapper ;
+
+      (* code for the entry point *)
+      lmd_entry_point := printWrapper (PREFIX ++ "receive_wrapper") ++ nl
+      ++ printMain |}.
+
+  
+  Definition TT_remap_eip20token : list (kername * string) :=
+  TT_remap_default ++ [
+    remap <%% @ContractCallContext %%> "(address * (address * int))"
+  ; remap <%% @ctx_from %%> "fst"
+  ; remap <%% @stdpp.base.partial_alter %%> "partial_alter_addr_nat"
+  ; remap <%% @stdpp.base.insert %%> "Map.add"
+  ; remap <%% @fin_maps.map_insert %%> "Map.add"
+  ; remap <%% @stdpp.base.Lookup %%> "Map.find"
+  ; remap <%% @gmap.gmap_empty %%> "Map []"
+  ; remap <%% @stdpp.base.empty %%> ""
+  ; remap <%% @gmap.gmap_partial_alter %%> ""
+  ; remap <%% @gmap.gmap_lookup %%> "Map.find"
+  ; remap <%% @address_eqdec %%> ""
+  ; remap <%% @address_countable %%> ""
+  ].
+
+  Definition TT_rename_eip20token :=
+    [ ("Z0" ,"0tez")
+    ; ("N0", "0")
+    ; ("N1", "1")
+    ; ("nil", "[]")
+    ; ("tt", "()") ].
+
+  Definition TT_inlines_eip20token : list kername := 
+    [   
+        <%% Monads.Monad_option %%>
+      ; <%% bool_rect %%>
+      ; <%% bool_rec %%>
+      ; <%% option_map %%>
+      ; <%% @Extras.with_default %%>
+
+      ; <%% @stdpp.base.insert %%>
+      ; <%% @stdpp.base.empty %%>
+      ; <%% @stdpp.base.lookup %%>
+    ].
+  
+
+  (* Compute (liquidity_extraction_test PREFIX TT_remap_eip20token TT_rename_eip20token EIP20Token_MODULE). *)
+
+  Time MetaCoq Run
+      (t <- liquidity_extraction_specialize PREFIX TT_remap_eip20token TT_rename_eip20token TT_inlines_eip20token EIP20Token_MODULE ;;
+      tmDefinition EIP20Token_MODULE.(lmd_module_name) t).
+
+  Print liquidity_eip20token.
+
+  (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
+  Redirect "./examples/liquidity-extract/liquidity_eip20token.liq" Compute liquidity_eip20token.
+
+
+End EIP20TokenExtraction.
+
+
+
+

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -29,6 +29,13 @@ Import monad_utils.MonadNotation.
 Local Open Scope string_scope.
 Import String.
 
+(* F# style piping notation for convenience *)
+Notation "f <| x" := (f x) (at level 32, left associativity, only parsing).
+(* i.e. f <| x <| y = (f <| x) <| y, and means (f x) y *)
+Notation "x |> f" := (f x) (at level 31, left associativity, only parsing).
+(* i.e. x |> f |> g = (x |> f) |> g, and means g (f x) *)
+
+
 Section print_term.
   Context (Σ : ExAst.global_env).
 
@@ -115,11 +122,22 @@ Section print_term.
              (TT : env string)
              (ctor : ident × list (name × box_type)) :=
     let (nm,tys) := ctor in
+    let nm := capitalize nm in
     match tys with
     | [] => prefix ++ nm
     | _ => prefix ++ nm ++ " of "
                   ++ concat " * " (map (print_box_type prefix TT ∘ snd) tys)
     end.
+  
+  Definition print_proj (prefix : string) (TT : env string) (proj : ident × box_type) : string :=
+    let (nm, ty) := proj in
+    prefix
+      ^ nm
+      ^ " : "
+      ^ print_box_type prefix TT ty.
+
+  Compute print_proj "" []
+        ("blah",TInd (mkInd (MPfile [], "nat") 0)).
 
   Definition print_inductive (prefix : string) (TT : env string)
              (oib : ExAst.one_inductive_body) :=
@@ -131,38 +149,20 @@ Section print_term.
         if (Nat.eqb #|oib.(ind_type_vars)| 0) then ""
         else let ps := concat "," (mapi (fun i _ => print_type_var i) oib.(ind_type_vars)) in
              (parens (Nat.eqb #|oib.(ind_type_vars)| 1) ps) ++ " " in
-    "type " ++ params ++ uncapitalize ind_nm ++" = "
+    (* one-constructor inductives with non-empty ind_projs (projection identifiers) 
+       are assumed to be records *)
+    match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
+    | [build_record_ctor], _::_ =>
+      let '(_, ctors) := build_record_ctor in
+      let projs_and_ctors := combine oib.(ExAst.ind_projs) ctors in
+      let projs_and_ctors_printed := map (fun '(p, (proj_nm, ty)) => print_proj (capitalize prefix) TT (p.1, ty)) projs_and_ctors in
+      "type " ++ params ++ uncapitalize ind_nm ++ " = {" ++ nl
+              ++ concat (";" ++ nl) projs_and_ctors_printed ++ nl
+              ++  "}"
+    | _,_ => "type " ++ params ++ uncapitalize ind_nm ++" = "
             ++ nl
-            ++ concat "| " (map (fun p => print_ctor (capitalize prefix) TT p ++ nl) oib.(ExAst.ind_ctors)).
-
-  Fixpoint print_liq_type (prefix : string) (TT : env string) (t : Ast.term) :=
-  let error := "Error (not_supported_type " ++ Pretty.print_term (Ast.empty_ext []) [] true t ++ ")" in
-  match t with
-  | Ast.tInd ind _ =>
-    let nm := string_of_kername ind.(inductive_mind) in
-    from_option (look TT nm) (prefix ++ ind.(inductive_mind).2)
-  | Ast.tApp (Ast.tInd ind _) [t1;t2] =>
-    (* a special case of products - infix *)
-    if eq_kername <%% prod %%> ind.(inductive_mind) then
-      parens false (print_liq_type prefix TT t1 ++ " * " ++ print_liq_type prefix TT t2)
-      else error
-  | Ast.tApp (Ast.tInd ind i) args =>
-    (* the usual - postfix - case of an applied type constructor *)
-    let nm := string_of_kername ind.(inductive_mind) in
-    let nm' := from_option (look TT nm) (prefix ++ ind.(inductive_mind).2) in
-    let printed_args := map (print_liq_type prefix TT) args in
-    (print_uncurried "" printed_args) ++ " " ++ nm'
-  | Ast.tApp (Ast.tConst nm _) args =>
-    (* similarly we do for constants to enable remapping of aliases to types *)
-    let cst_nm := string_of_kername nm in
-    let nm' := from_option (look TT cst_nm) (prefix ++ nm.2) in
-    let printed_args := map (print_liq_type prefix TT) args in
-    (print_uncurried "" printed_args) ++ " " ++ nm'
-  | Ast.tConst nm _ =>
-    let cst_nm := string_of_kername nm in
-    from_option (look TT cst_nm) (prefix ++ nm.2)
-  | _ => error
-  end.
+            ++ concat "| " (map (fun p => print_ctor (capitalize prefix) TT p ++ nl) oib.(ExAst.ind_ctors))
+    end.
 
   Definition is_sort (t : Ast.term) :=
     match t with
@@ -278,6 +278,22 @@ Section print_term.
   Definition print_list_cons (f : term -> string) (t1 : term) (t2 : term) :=
     (f t1) ++ " :: " ++ (f t2).
 
+  Definition is_record_constr (t : term) : option ExAst.one_inductive_body := 
+    match t with
+    | tConstruct (mkInd mind j as ind) i =>
+      match lookup_ind_decl mind i with
+      | Some oib => if Nat.eqb 1 (List.length oib.(ExAst.ind_ctors))
+                    then Some oib
+                    else None
+      | _ => None
+      end
+    | _ => None
+  end.
+
+  (* Definition print_record_proj (f : term -> string) (apps : term) (oib : ExAst.one_inductive_body) TT prefix :=
+   *)
+
+
   Definition app_args {A} (f : term -> A) :=
     fix go (t : term) := match t with
     | tApp t1 t2 => f t2 :: go t1
@@ -310,7 +326,7 @@ Section print_term.
   Definition print_pat (prefix : string) (TT : env string) (ctor : string) (pt : list string * string) :=
     let ctor_nm := from_option (look TT ctor) ((capitalize prefix) ++ ctor) in
     let print_parens := (Nat.ltb 1 (List.length pt.1)) in
-    print_uncurried ctor_nm (rev pt.1) ++ " -> " ++ pt.2.
+    print_uncurried (capitalize ctor_nm) (rev pt.1) ++ " -> " ++ pt.2.
 
 
   Definition print_transfer (args : list string) :=
@@ -374,29 +390,38 @@ Section print_term.
     | tConst c =>
       let cst_name := string_of_kername c in
       let nm := from_option (look TT cst_name) (prefix ++ c.2) in
-      parens (top || inapp) (nm ++ " " ++ (concat " " (map (parens true) apps)))
+      if (nm =? "") then ""
+      else parens (top || inapp) (nm ++ " " ++ (concat " " (map (parens true) apps)))
     | tConstruct ind i =>
       let nm := get_constr_name ind i in
       (* is it a pair ? *)
       if (nm =? "pair") then print_uncurried "" apps
-      else
       (* is it a cons ? *)
-        if (nm =? "cons") then
-          parens top (concat " :: " apps)
-        else
+      else if (nm =? "cons") then
+        parens top (concat " :: " apps)
       (* is it a transfer *)
-          if (nm =? "Act_transfer") then print_transfer apps
-          else
-            let nm' := from_option (look TT nm) ((capitalize prefix) ++ nm) in
-            parens top (print_uncurried nm' apps)
+      else if (nm =? "Act_transfer") then print_transfer apps
+      (* is it a record declaration? *)
+      else match is_record_constr b with
+        | Some oib => let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in 
+        let field_decls_printed := projs_and_apps |> map (fun '(proj, e) => proj ++ " = " ++ e) 
+                                                  |> concat "; " in 
+        "{" ++ field_decls_printed ++ "}"
+        | None     => let nm' := from_option (look TT nm) ((capitalize prefix) ++ nm) in
+                      parens top (print_uncurried nm' apps)
+        end
     | _ =>  parens (top || inapp) (print_term prefix FT TT Γ false true f ++ " " ++ print_term prefix FT TT Γ false false l)
     end
   | tConst c =>
     let cst_name := string_of_kername c in
-    from_option (look TT cst_name) (prefix ++ c.2)
+    if cst_name =? ""
+    then ""
+    else from_option (look TT cst_name) (prefix ++ c.2)
   | tConstruct ind l =>
     let nm := get_constr_name ind l in
-    from_option (look TT nm) ((capitalize prefix) ++ nm)
+    if nm =? "" 
+    then ""
+    else capitalize (from_option (look TT nm) ((capitalize prefix) ++ nm))
   | tCase (mkInd mind i as ind, nparam) t brs =>
     (* [if-then-else] is a special case *)
     if eq_kername mind <%% bool %%> then
@@ -457,11 +482,10 @@ Section print_term.
               ++ string_of_list (fun b => string_of_term (snd b)) brs ++ ")"
     end
   | tProj (mkInd mind i as ind, pars, k) c =>
-    (*NOTE: since records are not supported, projections are not very meaningful, curretnly*)
     match lookup_ind_decl mind i with
     | Some oib =>
       match nth_error oib.(ExAst.ind_projs) k with
-      | Some (na, _) => print_term prefix FT TT Γ false false c ++ ".(" ++ na ++ ")"
+      | Some (na, _) => print_term prefix FT TT Γ false false c ++ "." ++ na
       | None =>
         "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ","
                        ++ print_term prefix FT TT Γ true false c ++ ")"
@@ -648,14 +672,22 @@ Definition tez_ops :=
     ++ "let[@inline] eqTez (a : tez ) (b : tez ) = a = b".
 
 Definition nat_ops :=
-       "let[@inline] eqN (a : nat ) (b : nat ) = a = b"
+      "let[@inline] addNat (i : nat) (j : nat) = i + j"
     ++ nl
-    ++ "let[@inline] lebN (a : nat ) (b : nat ) = a <= b"
+    ++ "let[@inline] mulNat (i : nat) (j : nat) = i * j"
     ++ nl
-    ++ "let[@inline] ltbN (a : nat ) (b : nat ) = a < b".
+    ++ "let[@inline] subNat (i : nat) (j : nat) = i - j"
+    ++ nl
+    ++ "let[@inline] leNat (i : nat) (j : nat) = i <= j"
+    ++ nl
+    ++ "let[@inline] ltNat (i : nat) (j : nat) = i < j"
+    ++ nl
+    ++ "let[@inline] eqNat (i : nat) (j : nat) = i = j".
 
 Definition bool_ops :=
-  "let[@inline] andb (a : bool ) (b : bool ) = a & b".
+     "let[@inline] andb (a : bool ) (b : bool ) = a & b"
+  ++ nl
+  ++ "let[@inline] orb (a : bool ) (b : bool ) = a || b".
 
 Definition time_ops :=
        "let[@inline] eqb_time (a1 : timestamp) (a2 : timestamp) = a1 = a2"

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -25,7 +25,6 @@ Local Open Scope string_scope.
 From MetaCoq.Template Require Import All.
 
 Import ListNotations.
-(* Import AcornBlockchain. *)
 Import MonadNotation.
 Import ResultMonad.
 


### PR DESCRIPTION
Extracted EIP20/ERC20 contract to Liquidity in [ERC20LiquidityExtraction.v](https://github.com/AU-COBRA/ConCert/compare/master...mikkelmilo:eip20-extract-liquidity?expand=1#diff-1b2b45d940b481119ac780015690511cfc057253e8acab2a85e7e8c0df6fa44b).

## Changes to Liquidity Extraction
- added printing of record definitions and record field accesses
- fixed printing of inductives; liquidity requires constructors' first letter to be capitalized
- fixed other edge cases in pretty printer
- added new extraction configuration with both chainbase specialization and inlining (other extractions are functionally unchanged to ensure backwards compatibility)
  + maybe there is a less verbose and more compositional way of configuring these different extractions? But it works for now. 
- expanded default translation/ignore tables (`N`, `Z`, `list`, `map`, `positive`, and some definitions from the execution framework...) 