### PR TITLE
Remove partial_alter, improvements in certifying inlining

### DIFF
--- a/execution/_CoqProject
+++ b/execution/_CoqProject
@@ -22,6 +22,7 @@ examples/BAT.v
 examples/BoardroomMath.v
 examples/BoardroomVoting.v
 examples/BoardroomVotingTest.v
+examples/Common.v
 examples/Congress.v
 examples/Congress_Buggy.v
 examples/Counter.v

--- a/execution/examples/Common.v
+++ b/execution/examples/Common.v
@@ -1,0 +1,27 @@
+(** * Definitions shared among the examples *)
+
+Require Import Containers.
+From ConCert.Execution Require Import Blockchain.
+
+(** A type of  finite maps (dictionaries) with addresses as keys.
+Basically, it's just a specilisation of [FMap] to [Address] as keys.
+This definitions is more extraction-friendly. *)
+
+Module AddressMap.
+
+  Definition AddrMap `{ChainBase} := FMap Address.
+
+  Definition find `{ChainBase} {V : Type} (addr : Address) (m : AddrMap V) : option V :=
+    FMap.find addr m.
+
+  Definition add  `{ChainBase} {V : Type} (addr : Address) (val : V) (m : AddrMap V) : AddrMap V :=
+    FMap.add addr val m.
+
+  Definition empty  `{ChainBase} {V : Type} : AddrMap V := FMap.empty.
+
+End AddressMap.
+
+(** The specialised version is convertible to [FMap.find] after resolving the instances *)
+Lemma AddressMap_find_convertible  `{ChainBase} {V : Type} :
+  AddressMap.find (V:=V) = FMap.find.
+Proof. reflexivity. Qed.

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -405,7 +405,7 @@ Section print_term.
       else match is_record_constr b with
         | Some oib => let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in 
         let field_decls_printed := projs_and_apps |> map (fun '(proj, e) => proj ++ " = " ++ e) 
-                                                  |> concat "; " in 
+                                                  |> concat "; " in
         "{" ++ field_decls_printed ++ "}"
         | None     => let nm' := from_option (look TT nm) ((capitalize prefix) ++ nm) in
                       parens top (print_uncurried nm' apps)
@@ -700,10 +700,13 @@ Definition address_ops :=
   "let[@inline] eq_addr (a1 : address) (a2 : address) = a1 = a2".
 
 
+Definition address_map :=
+  "type 'a addrMap = (address, 'a) map".
+
 Definition LiquidityPrelude :=
   print_list id (nl ++ nl)
              [prod_ops; int_ops; tez_ops; nat_ops;
-             bool_ops; time_ops; address_ops].
+             bool_ops; time_ops; address_ops; address_map].
 
 Definition printWrapper (contract : string): string :=
   "let wrapper param (st : storage)"


### PR DESCRIPTION
* `partial_alter` is replaced with more "domain-specific" `increment_balance`;
* certifying inlining now is capable of removing casts from terms, that helps to perform beta-reductions after unfolding constants; this was necessary for inlining the record update functionality properly;
* added a specialised module containing `Definition AddrMap `{ChainBase} := FMap Address.` and corresponding functions; this simplifies the remapping a lot, because type classes are resolved and function's signatures have correct types (without implicit arguments, corresponding to type classes).
* inline `bind`, `ret` and record update stuff for ERC20 extracted to Liquidity: now we can use the actual definitions from EIP20Token, instead of rewriting them (however, more work on making the actual definition signatures is still needed).