### PR TITLE
Opam config, pin to a new MetaCoq commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ opam switch create . 4.07.1
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install -j 4 coq.8.11.2 coq-bignums coq-stdpp coq-quickchick
-opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#8d576c70957c0dce2053f2a7272b231f41c3d43f
+opam pin -j 4 add https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447
 ```
 
 After completing the procedures above, run `make` to build the development, and

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -19,7 +19,7 @@ depends: [
   "coq-stdpp" {= "1.5.0"}
 ]
 pin-depends : [
-  [ "coq-metacoq.concert" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447" ]
+  [ "coq-metacoq.dev" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447" ]
 ]
 
 build: [

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "ConCert"
+name: "coq-concert"
 version: "dev"
 synopsis: "A framework for smart contract verification in Coq"
 description: """
@@ -14,12 +14,20 @@ depends: [
   "coq" {>= "8.11" & < "8.12~"}
   "coq-bignums" {= "8.11.0"}
   "coq-quickchick" {= "1.3.2"}
-  "coq-metacoq" {pinned}
+  "coq-metacoq-template" {pinned}
+  "coq-metacoq-pcuic" {pinned}
+  "coq-metacoq-safechecker" {pinned}
+  "coq-metacoq-erasure" {pinned}
+  "coq-metacoq-translations" {pinned}
   "coq-equations" {= "1.2.3+8.11"}
   "coq-stdpp" {= "1.5.0"}
 ]
 pin-depends : [
-  [ "coq-metacoq.dev" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447" ]
+  ["coq-metacoq-template.pinned" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447"]
+  ["coq-metacoq-pcuic.pinned" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447"]
+  ["coq-metacoq-safechecker.pinned" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447"]
+  ["coq-metacoq-erasure.pinned" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447"]
+  ["coq-metacoq-translations.pinned" "git+https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447"]
 ]
 
 build: [

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -14,7 +14,7 @@ depends: [
   "coq" {>= "8.11" & < "8.12~"}
   "coq-bignums" {= "8.11.0"}
   "coq-quickchick" {= "1.3.2"}
-  "coq-metacoq" {= "concert"}
+  "coq-metacoq" {pinned}
   "coq-equations" {= "1.2.3+8.11"}
   "coq-stdpp" {= "1.5.0"}
 ]

--- a/extra/docker/ConCert-8.11/Dockerfile
+++ b/extra/docker/ConCert-8.11/Dockerfile
@@ -7,7 +7,7 @@ RUN ["/bin/bash", "--login", "-c", "set -x \
   && opam repository add --all-switches --set-default iris-dev https://gitlab.mpi-sws.org/iris/opam.git \
   && opam update -y -u \
   && opam install -y -v -j ${NJOBS} coq-equations.1.2.1+8.11 coq-stdpp coq-quickchick \
-  && opam pin -y -j ${NJOBS} add https://github.com/MetaCoq/metacoq.git#8d576c70957c0dce2053f2a7272b231f41c3d43f \
+  && opam pin -y -j ${NJOBS} add https://github.com/MetaCoq/metacoq.git#75f0cb9b8494cd0a856b77a664c662a59ddde447 \
   && opam clean -a -c -s --logs \
   && opam config list \
   && opam list"]


### PR DESCRIPTION
Working opam configuration.
I also pin to [this MetaCoq commit](https://github.com/MetaCoq/metacoq/commit/f4e9a80ea336fc7154aac9cce5385bd36a48125a), to make it more friendly for compiling with newer versions of the OCaml compiler.