### PR TITLE
Handling the elimination from empty types

### DIFF
--- a/extraction/examples/CounterRefinementTypes.v
+++ b/extraction/examples/CounterRefinementTypes.v
@@ -27,7 +27,6 @@ Import Lia.
 
 Definition PREFIX := "coq_".
 
-(** We use parameterised modules (functors) to isolate proof terms from the extracted parts. Otherwise type cheking and erasing is taking too long *)
 Module CounterRefinementTypes.
 
   (** Enabling recursors for records allows for deriving [Serializable] instances. *)
@@ -64,12 +63,12 @@ Module CounterRefinementTypes.
     Zleb_ltb_to_prop. lia.
   Qed.
 
-  Definition counter (msg : msg) (st : storage)
+  Definition counter (Msg : msg) (st : storage)
     : option (Transaction * storage) :=
-    match msg with
+    match Msg with
     | Inc i =>
       match (bool_dec true (0 <? i)) with
-      | left h => Some (Transaction_none, proj1_sig (inc_counter st (exist _ i (eq_sym h))))
+      | left H => Some (Transaction_none, proj1_sig (inc_counter st (exist _ i (eq_sym H))))
       | right _ => None
       end
     | Dec i =>

--- a/extraction/examples/ElmExtractExamples.v
+++ b/extraction/examples/ElmExtractExamples.v
@@ -198,9 +198,6 @@ Module ElmExamples.
   (Preambule "Last")
   (main_and_test "Expect.equal (last (Cons 1 (Cons 10 Nil)) 0) 10").
 
-  Lemma O_gt_False : 0 > 0 -> False.
-  Proof. intros H;inversion H. Qed.
-
   Program Definition safe_head {A} (non_empty_list : {l : list A | length l > 0}) : A :=
     match non_empty_list as l' return l' = non_empty_list -> A  with
     | [] =>
@@ -216,22 +213,24 @@ Module ElmExamples.
     | hd :: tl => fun _ => hd
     end eq_refl.
   Next Obligation.
-    intros. destruct non_empty_list as [l H1]. cbn in *;subst.
-    exact (O_gt_False H1).
+    intros.
+    destruct non_empty_list as [l H1];cbn in *;subst.
+    inversion H1.
   Qed.
 
-  Program Definition head_of_repeat_2 {A} (a : A) := safe_head (repeat a 2).
+  Program Definition head_of_repeat_plus_one {A} (n : nat) (a : A) : A
+    := safe_head (repeat a (1+n)).
   Next Obligation.
-    intros. cbn. auto.
+    intros. cbn. lia.
   Qed.
 
-  MetaCoq Run (t <- tmQuoteRecTransp (@head_of_repeat_2) false ;;
-               tmDefinition "head_of_repeat_2_syn" t).
+  MetaCoq Run (t <- tmQuoteRecTransp (@head_of_repeat_plus_one) false ;;
+               tmDefinition "head_of_repeat_plus_one_syn" t).
 
- Redirect "examples/elm-extract/SafeHead.elm"
- Compute general_wrapped head_of_repeat_2_syn
- (Preambule "SafeHead" ++ nl ++ elm_false_rec)
- (main_and_test "Expect.equal (head_of_repeat_2 1) 1")
- [] [].
+  Redirect "examples/elm-extract/SafeHead.elm"
+  Compute general_wrapped head_of_repeat_plus_one_syn
+  (Preambule "SafeHead" ++ nl ++ elm_false_rec)
+  (main_and_test "Expect.equal (head_of_repeat_plus_one (S O) 1) 1")
+  [] [].
 
 End ElmExamples.

--- a/extraction/examples/ElmExtractExamples.v
+++ b/extraction/examples/ElmExtractExamples.v
@@ -31,6 +31,7 @@ Instance ElmBoxes : ElmPrintConfig :=
   {| term_box_symbol := "()"; (* the inhabitant of the unit type *)
      type_box_symbol := "()"; (* unit type *)
      any_type_symbol := "()"; (* unit type *)
+     false_elim_def := "false_rec ()"; (* predefined function *)
      print_full_names := false (* short names for readability *)|}.
 
 Definition general_wrapped (p : program) (pre post : string)
@@ -60,11 +61,6 @@ Module ElmExamples.
                   "import Test";
                   "import Html";
                   "import Expect exposing (Expectation)"].
-
-  Definition elm_false_rec :=
-    String.concat nl
-                  ["false_rec : () -> a";
-                   "false_rec _ = false_rec ()"].
 
   Definition main_and_test (test : string) :=
     "main = Html.text "++ parens false ("Debug.toString " ++ parens false test) ++ nl ++
@@ -119,9 +115,10 @@ Module ElmExamples.
     extract nth_syn = Ok result_nth.
   Proof. reflexivity. Qed.
 
-  Redirect "examples/elm-extract/Nth.elm" Compute wrapped nth_syn
-          (Preambule "Nth")
-          (main_and_test "Expect.equal (nth O (Cons 1 (Cons 0 Nil)) 0) 1").
+  Redirect "examples/elm-extract/Nth.elm"
+  Compute wrapped nth_syn
+  (Preambule "Nth")
+  (main_and_test "Expect.equal (nth O (Cons 1 (Cons 0 Nil)) 0) 1").
 
   MetaCoq Quote Recursively Definition map_syn := List.map.
   Definition result_map :=
@@ -141,9 +138,10 @@ Module ElmExamples.
        "  in";
        "  map2" $>.
 
-  Redirect "examples/elm-extract/Map.elm" Compute wrapped map_syn
-          (Preambule "Map")
-          (main_and_test "Expect.equal (map (\x->x+1) (Cons 1 (Cons 0 Nil))) (Cons 2 (Cons 1 Nil))").
+  Redirect "examples/elm-extract/Map.elm"
+  Compute wrapped map_syn
+  (Preambule "Map")
+  (main_and_test "Expect.equal (map (\x->x+1) (Cons 1 (Cons 0 Nil))) (Cons 2 (Cons 1 Nil))").
 
   Example ElmList_map :
     extract map_syn = Ok result_map.
@@ -167,9 +165,10 @@ Module ElmExamples.
       "  in";
       "  fold_left2" $>.
 
-  Redirect "examples/elm-extract/Fold.elm" Compute wrapped foldl_syn
-         (Preambule "Fold")
-         (main_and_test "(Expect.equal (fold_left (+) (Cons 1 (Cons 0 Nil)) 0)) 1").
+  Redirect "examples/elm-extract/Fold.elm"
+  Compute wrapped foldl_syn
+  (Preambule "Fold")
+  (main_and_test "(Expect.equal (fold_left (+) (Cons 1 (Cons 0 Nil)) 0)) 1").
 
   Example ElmList_foldl :
     extract foldl_syn = Ok result_foldl.
@@ -192,25 +191,33 @@ Module ElmExamples.
          (Preambule "Increment")
          (main_and_test "Expect.equal (inc_counter O (Exist (S O))) (Exist (S O))").
 
-
   MetaCoq Quote Recursively Definition last_syn := List.last.
 
-  Redirect "examples/elm-extract/Last.elm" Compute wrapped last_syn
-          (Preambule "Last")
-          (main_and_test "Expect.equal (last (Cons 1 (Cons 10 Nil)) 0) 10").
-
+  Redirect "examples/elm-extract/Last.elm"
+  Compute wrapped last_syn
+  (Preambule "Last")
+  (main_and_test "Expect.equal (last (Cons 1 (Cons 10 Nil)) 0) 10").
 
   Lemma O_gt_False : 0 > 0 -> False.
   Proof. intros H;inversion H. Qed.
 
   Program Definition safe_head {A} (non_empty_list : {l : list A | length l > 0}) : A :=
     match non_empty_list as l' return l' = non_empty_list -> A  with
-    | [] => fun _ => False_rect _ _
+    | [] =>
+      (* NOTE: we use [False_rect] to make the extracted code a bit nicer.
+         It's totally possible to leave the whole branch as an obligation,
+         the extraction will handle it.
+         However, if the whole branch is an abligation, the proof it should
+         be left transparent (using [Defined]), so the extraction could
+         produce reasonable code for it. If left opaque, it the body of
+         the obligation will be ignored by extraction producing no
+         corresponding definiton*)
+      fun _ => False_rect _ _
     | hd :: tl => fun _ => hd
     end eq_refl.
   Next Obligation.
     intros. destruct non_empty_list as [l H1]. cbn in *;subst.
-    apply O_gt_False;auto.
+    exact (O_gt_False H1).
   Qed.
 
   Program Definition head_of_repeat_2 {A} (a : A) := safe_head (repeat a 2).
@@ -221,10 +228,10 @@ Module ElmExamples.
   MetaCoq Run (t <- tmQuoteRecTransp (@head_of_repeat_2) false ;;
                tmDefinition "head_of_repeat_2_syn" t).
 
-  Redirect "examples/elm-extract/SafeHead.elm"
-           Compute general_wrapped head_of_repeat_2_syn
-          (Preambule "SafeHead" ++ nl ++ elm_false_rec)
-          (main_and_test "Expect.equal (head_of_repeat_2 1) 1")
-          [<%% False_rect %%>] [(<%% False_rect %%>, "false_rec ()")].
+ Redirect "examples/elm-extract/SafeHead.elm"
+ Compute general_wrapped head_of_repeat_2_syn
+ (Preambule "SafeHead" ++ nl ++ elm_false_rec)
+ (main_and_test "Expect.equal (head_of_repeat_2 1) 1")
+ [] [].
 
 End ElmExamples.

--- a/extraction/examples/ElmExtractTests.v
+++ b/extraction/examples/ElmExtractTests.v
@@ -22,6 +22,7 @@ Instance StandardBoxes : ElmPrintConfig :=
   {| term_box_symbol := "□";
      type_box_symbol := "□";
      any_type_symbol := "𝕋";
+     false_elim_def := "false_rec ()";
      print_full_names := false |}.
 
 Definition no_check_args :=

--- a/extraction/examples/ElmForms.v
+++ b/extraction/examples/ElmForms.v
@@ -200,6 +200,7 @@ Instance ElmBoxes : ElmPrintConfig :=
   {| term_box_symbol := "()"; (* the inhabitant of the unit type *)
      type_box_symbol := "()"; (* unit type *)
      any_type_symbol := "()"; (* unit type *)
+     false_elim_def := "false_rec ()";
      print_full_names := false |}.
 
 Definition general_wrapped (Σ : global_env) (pre post : string)
@@ -296,7 +297,7 @@ Definition to_inline :=
 Definition elm_extraction (m : ElmMod) (TT : list (kername * string)) : TemplateMonad _ :=
   '(Σ,_) <- tmQuoteRecTransp m false ;;
   seeds <- monad_map extract_def_name_exists m.(elmmd_extract);;
-  general_wrapped Σ (header_and_imports ++ nl ++ nl ++ preamble) ""
+  general_wrapped Σ (header_and_imports ++ nl ++ nl ++ preamble ++ nl ++ nl ++ elm_false_rec) ""
                   (KernameSetProp.of_list seeds)
                   to_inline
                   (map fst TT)

--- a/extraction/examples/MidlangCounterRefTypes.v
+++ b/extraction/examples/MidlangCounterRefTypes.v
@@ -30,6 +30,7 @@ Instance MidlangBoxes : ElmPrintConfig :=
   {| term_box_symbol := "()";
      type_box_symbol := "()";
      any_type_symbol := "()";
+     false_elim_def := "false_rec ()";
      print_full_names := false |}.
 
 Definition midlang_translation_map :=

--- a/extraction/examples/MidlangEscrow.v
+++ b/extraction/examples/MidlangEscrow.v
@@ -31,6 +31,7 @@ Instance EscrowMidlangBoxes : ElmPrintConfig :=
   {| term_box_symbol := "()";
      type_box_symbol := "()";
      any_type_symbol := "()";
+     false_elim_def := "false_rec ()";
      print_full_names := true; (* full names to avoid clashes*)|}.
 
 Definition TT_escrow : list (kername * string) :=

--- a/extraction/examples/RustExtractTests.v
+++ b/extraction/examples/RustExtractTests.v
@@ -44,6 +44,10 @@ Definition extract (p : T.program) : result string string :=
       | Ex.ConstantDecl _ => true
       | _ => false
       end in
+  (* Filtering out empty type declarations *)
+  (* TODO: possibly, move to extraction (requires modifications of the correctness proof) *)
+  let Σ := filter (fun '(kn,d) => negb (is_empty_type_decl d)) Σ in
+
   let p :=
       print_decls Σ no_remaps default_attrs (filter (negb ∘ is_const) (List.rev Σ));;
       append_nl;;
@@ -295,3 +299,154 @@ Module ex5.
 "}" $>.
   Proof. vm_compute. reflexivity. Qed.
 End ex5.
+
+Module SafeHead.
+
+  Program Definition safe_head {A} (non_empty_list : {l : list A | length l > 0}) : A :=
+    match non_empty_list as l' return l' = non_empty_list -> A  with
+    | [] =>
+      (* NOTE: we use [False_rect] to make the extracted code a bit nicer.
+         It's totally possible to leave the whole branch as an obligation,
+         the extraction will handle it.
+         However, if the whole branch is an abligation, the proof it should
+         be left transparent (using [Defined]), so the extraction could
+         produce reasonable code for it. If left opaque, it the body of
+         the obligation will be ignored by extraction producing no
+         corresponding definiton*)
+      fun _ => False_rect _ _
+    | hd :: tl => fun _ => hd
+    end eq_refl.
+  Next Obligation.
+    intros.
+    destruct non_empty_list as [l H1];cbn in *;subst.
+    inversion H1.
+  Qed.
+
+  Program Definition head_of_repeat_plus_one {A} (n : nat) (a : A) : A
+    := safe_head (repeat a (S n)).
+  Next Obligation.
+    intros. cbn. lia.
+  Qed.
+
+  MetaCoq Run (p <- Core.tmQuoteRecTransp (@head_of_repeat_plus_one) false;;
+               Core.tmDefinition "Prog" p).
+
+  Compute extract Prog.
+
+  Example test : extract Prog = Ok <$
+"#[derive(Debug, Clone)]";
+"pub enum Nat<'a> {";
+"  O(PhantomData<&'a ()>),";
+"  S(PhantomData<&'a ()>, &'a Nat<'a>)";
+"}";
+"";
+"#[derive(Debug, Clone)]";
+"pub enum Sig<'a, A> {";
+"  exist(PhantomData<&'a A>, A)";
+"}";
+"";
+"#[derive(Debug, Clone)]";
+"pub enum List<'a, A> {";
+"  nil(PhantomData<&'a A>),";
+"  cons(PhantomData<&'a A>, A, &'a List<'a, A>)";
+"}";
+"";
+"fn proj1_sig<A: Copy>(&'a self, e: &'a Sig<'a, A>) -> A {";
+"  match e {";
+"    &Sig::exist(_, a) => {";
+"      a";
+"    },";
+"  }";
+"}";
+"fn proj1_sig__curried<A: Copy>(&'a self) -> &'a dyn Fn(&'a Sig<'a, A>) -> A {";
+"  self.closure(move |e| {";
+"    self.proj1_sig(";
+"      e)";
+"  })";
+"}";
+"";
+"fn False_rect<P: Copy>(&'a self, P: ()) -> P {";
+"  panic!(""Absurd case!"")";
+"}";
+"fn False_rect__curried<P: Copy>(&'a self) -> &'a dyn Fn(()) -> P {";
+"  self.closure(move |P| {";
+"    self.False_rect(";
+"      P)";
+"  })";
+"}";
+"";
+"fn safe_head<A: Copy>(&'a self, non_empty_list: &'a Sig<'a, &'a List<'a, A>>) -> A {";
+"  hint_app(match self.proj1_sig(";
+"                   non_empty_list) {";
+"             &List::nil(_) => {";
+"               self.closure(move |x| {";
+"                 self.False_rect(";
+"                   ())";
+"               })";
+"             },";
+"             &List::cons(_, hd, tl) => {";
+"               self.closure(move |x| {";
+"                 hd";
+"               })";
+"             },";
+"           })(())";
+"}";
+"fn safe_head__curried<A: Copy>(&'a self) -> &'a dyn Fn(&'a Sig<'a, &'a List<'a, A>>) -> A {";
+"  self.closure(move |non_empty_list| {";
+"    self.safe_head(";
+"      non_empty_list)";
+"  })";
+"}";
+"";
+"fn repeat<A: Copy>(&'a self, x: A, n: &'a Nat<'a>) -> &'a List<'a, A> {";
+"  match n {";
+"    &Nat::O(_) => {";
+"      self.alloc(";
+"        List::nil(";
+"          PhantomData))";
+"    },";
+"    &Nat::S(_, k) => {";
+"      self.alloc(";
+"        List::cons(";
+"          PhantomData,";
+"          x,";
+"          self.repeat(";
+"            x,";
+"            k)))";
+"    },";
+"  }";
+"}";
+"fn repeat__curried<A: Copy>(&'a self) -> &'a dyn Fn(A) -> &'a dyn Fn(&'a Nat<'a>) -> &'a List<'a, A> {";
+"  self.closure(move |x| {";
+"    self.closure(move |n| {";
+"      self.repeat(";
+"        x,";
+"        n)";
+"    })";
+"  })";
+"}";
+"";
+"fn head_of_repeat_plus_one<A: Copy>(&'a self, n: &'a Nat<'a>, a: A) -> A {";
+"  self.safe_head(";
+"    self.alloc(";
+"      Sig::exist(";
+"        PhantomData,";
+"        self.repeat(";
+"          a,";
+"          self.alloc(";
+"            Nat::S(";
+"              PhantomData,";
+"              n))))))";
+"}";
+"fn head_of_repeat_plus_one__curried<A: Copy>(&'a self) -> &'a dyn Fn(&'a Nat<'a>) -> &'a dyn Fn(A) -> A {";
+"  self.closure(move |n| {";
+"    self.closure(move |a| {";
+"      self.head_of_repeat_plus_one(";
+"        n,";
+"        a)";
+"    })";
+"  })";
+"}" $>.
+  Proof. vm_compute. reflexivity. Qed.
+
+End SafeHead.

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -12,6 +12,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping
 From MetaCoq.Template Require Pretty.
 
 From ConCert.Extraction Require Import ResultMonad.
+From ConCert.Extraction Require Import CertifyingInlining.
 From ConCert.Utils Require Import RecordSet RecordUpdate StringExtra.
 From ConCert.Execution Require Import Blockchain Serializable.
 
@@ -42,8 +43,8 @@ Arguments lmd_receive_prelude {_ _ _ _ _ _}.
 Arguments lmd_entry_point {_ _ _ _ _ _}.
 
 Definition cameligo_args :=
-  {| optimize_prop_discr := true;
-     extract_transforms := [Optimize.dearg_transform
+       {| optimize_prop_discr := true;
+               extract_transforms := [Optimize.dearg_transform
                               (fun _ => None)
                               true
                               false (* cannot have partially applied ctors *)
@@ -56,79 +57,28 @@ Definition annot_extract_env_cameligo
            (Σ : PCUICAst.global_env)
            (wfΣ : ∥wf Σ∥)
            (include : KernameSet.t)
-           (ignore : kername -> bool) : option (∑ Σ, env_annots box_type Σ).
+           (ignore : list kername) : result (∑ Σ, env_annots box_type Σ) string.
 Proof.
-  unshelve epose proof (annot_extract_pcuic_env cameligo_args Σ wfΣ include ignore _).
-  - constructor; [|constructor].
+  (* set (extract_cameligo_params inline) as params. *)
+  set (fun kn => existsb (eq_kername kn) ignore) as to_ignore.
+  unshelve epose proof (annot_extract_pcuic_env cameligo_args Σ wfΣ include to_ignore _).
+  - subst;cbn;constructor; [|constructor].
     apply annot_dearg_transform.
-  - destruct extract_pcuic_env; [|exact None].
-    exact (Some (t; X)).
+  - destruct extract_pcuic_env.
+    * exact (Ok (t; X)).
+    * exact (Err e).
 Defined.
 
 
-Definition annot_extract_template_env_specalize
+Program Definition annot_extract_template_env_specalize
            (e : TemplateEnvironment.global_env)
            (seeds : KernameSet.t)
-           (ignore : kername -> bool) : result (∑ e, env_annots box_type e) string :=
+           (ignore : list kername) : result (∑ e, env_annots box_type e) string :=
   let e := SafeTemplateChecker.fix_global_env_universes e in
   let e := TemplateToPCUIC.trans_global_decls e in
   e <- specialize_ChainBase_env e ;;
   wfe <-check_wf_env_func extract_within_coq e;;
-  match annot_extract_env_cameligo e wfe seeds ignore with
-  | Some s => Ok s
-  | None => Err "failed internally in annot_extract_template_env_specalize"
-  end.
-
-Definition printCameLIGODefs (prefix : string) (Σ : TemplateEnvironment.global_env)
-           (TT : MyEnv.env string)
-           (ignore : list kername)
-           (build_call_ctx : string)
-           (init_prelude : string)
-           (receive_prelude : string)
-           (init : kername)
-           (receive : kername)
-  : string + string :=
-  let seeds := KernameSet.union (KernameSet.singleton init) (KernameSet.singleton receive) in
-  match annot_extract_template_env_specalize Σ seeds (fun k => List.existsb (eq_kername k) ignore) with
-  | Ok (eΣ; annots) =>
-    (* dependencies should be printed before the dependent definitions *)
-    let ldef_list := List.rev (print_global_env prefix TT eΣ annots) in
-    (* filtering empty strings corresponding to the ignored definitions *)
-    let not_empty_str := (negb ∘ (String.eqb "") ∘ snd) in
-
-    let ldef_ty_list := ldef_list
-                          |> filter (fun d => match d with TyDecl _ => true | _ => false end)
-                          |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
-                          |> filter not_empty_str in
-    let ldef_const_list := ldef_list
-                            |> filter (fun d => match d with ConstDecl _ => true | _ => false end)
-                            |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
-                            |> filter not_empty_str in
-    (* look for init function *)
-    match bigprod_find (fun '(k, _, _) _ => eq_kername k init) annots with
-    | Some ((_, ExAst.ConstantDecl init_cst); annots) =>
-      match print_init prefix TT build_call_ctx init_prelude eΣ init_cst annots with
-      | Some init_code =>
-        (* filtering out the definition of [init] and projecting the code *)
-        (* and place receive_prelude after type decls and before constant decls *)
-        let defs : list string :=
-          ldef_const_list |> filter (negb ∘ (eq_kername init) ∘ fst)
-                          |> map snd
-                          |> List.app [receive_prelude] (* append const decls after receive prelude decls *)
-                          |> List.app (map snd ldef_ty_list) (* append the above after ty decls*)
-                          in
-          (* map snd (filter (negb ∘ (eq_kername init) ∘ fst) ldef_list) in *)
-        let res : string :=
-            String.concat (nl ++ nl) (defs ++ (cons init_code nil)) in
-        inl res
-      | None => inr "Error: Empty body for init"
-      end
-    | Some _ => inr "Error: init must be a constant"
-    | None => inr "Error: No init found"
-    end
-  | Err e => inr e
-  end.
-
+  annot_extract_env_cameligo e wfe seeds ignore.
 
 Definition CameLIGO_ignore_default {Base : ChainBase} :=
   [
@@ -213,27 +163,221 @@ Definition CameLIGO_call_ctx :=
 
 Definition wrap_in_delimiters s :=
   String.concat nl [""; s].
-Definition CameLIGO_extraction {Base : ChainBase} {msg ctx params storage operation : Type}
+
+Definition is_empty {A} (xs : list A) :=
+  match xs with
+  | [] => true
+  | _ => false
+  end.
+
+Definition printCameLIGODefs `{ChainBase} {Base : ChainBase} {msg ctx params storage operation : Type}
            (prefix : string)
+           (Σ : TemplateEnvironment.global_env)
            (TT_defs : list (kername *  string))
            (TT_ctors : MyEnv.env string)
-           (m : CameLIGOMod msg ctx params storage operation) :=
-  '(Σ,_) <- tmQuoteRecTransp m false ;;
-  init_nm <- extract_def_name m.(lmd_init);;
-  receive_nm <- extract_def_name m.(lmd_receive);;
+           (build_call_ctx : string)
+           (init : kername)
+           (receive : kername)
+           (m : CameLIGOMod msg ctx params storage operation)
+  : string + string :=
+  let prelude := m.(lmd_prelude) in
+  let init_prelude := m.(lmd_init_prelude) in
+  let entry_point := m.(lmd_entry_point) in
+  let seeds := KernameSet.union (KernameSet.singleton init) (KernameSet.singleton receive) in
   let TT_defs := TT_defs ++ TT_remap_default in
   let ignore := (map fst TT_defs ++ CameLIGO_ignore_default)%list in
   let TT :=
       (CameLIGO_rename_default ++ TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  match annot_extract_template_env_specalize Σ seeds ignore with
+  | Ok (eΣ; annots) =>
+    (* dependencies should be printed before the dependent definitions *)
+    let ldef_list := List.rev (print_global_env prefix TT eΣ annots) in
+    (* filtering empty strings corresponding to the ignored definitions *)
+    let not_empty_str := (negb ∘ (String.eqb "") ∘ snd) in
+
+    let ldef_ty_list := ldef_list
+                          |> filter (fun d => match d with TyDecl _ => true | _ => false end)
+                          |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
+                          |> filter not_empty_str in
+    let ldef_const_list := ldef_list
+                            |> filter (fun d => match d with ConstDecl _ => true | _ => false end)
+                            |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
+                            |> filter not_empty_str in
+    (* look for init function *)
+    match bigprod_find (fun '(k, _, _) _ => eq_kername k init) annots with
+    | Some ((_, ExAst.ConstantDecl init_cst); annots) =>
+      match print_init prefix TT build_call_ctx init_prelude eΣ init_cst annots with
+      | Some init_code =>
+        (* filtering out the definition of [init] and projecting the code *)
+        (* and place prelude after type decls and before constant decls *)
+        let defs : list string :=
+          ldef_const_list |> filter (negb ∘ (eq_kername init) ∘ fst)
+                          |> map snd
+                          |> List.app [prelude] (* append const decls after receive prelude decls *)
+                          |> List.app (map snd ldef_ty_list) (* append the above after ty decls*)
+                          in
+          (* map snd (filter (negb ∘ (eq_kername init) ∘ fst) ldef_list) in *)
+        let res : string :=
+            String.concat (nl ++ nl) (defs ++ (cons init_code nil)) in
+        (wrap_in_delimiters (String.concat (nl ++ nl) [prelude; res; entry_point])) |> inl
+      | None => inr "Error: Empty body for init"
+      end
+    | Some _ => inr "Error: init must be a constant"
+    | None => inr "Error: No init found"
+    end
+  | Err e => inr e
+  end.
+
+
+Definition unwrap_string_sum (s : string + string) : string :=
+  match s with
+  | inl v => v
+  | inr v => v
+  end.
+
+Definition quote_and_preprocess {Base : ChainBase}
+           {msg ctx params storage operation : Type}
+           (inline : list kername)
+           (m : CameLIGOMod msg ctx params storage operation)
+  : TemplateMonad (TemplateEnvironment.global_env * kername * kername) :=
+   (* we compute with projections before quoting to avoid unnecessary dependencies to be quoted *)
+   init <- tmEval cbn m.(lmd_init);;
+   receive <-tmEval cbn m.(lmd_receive);;
+  '(Σ,_) <- tmQuoteRecTransp (init,receive) false ;;
+  init_nm <- extract_def_name m.(lmd_init);;
+  receive_nm <- extract_def_name m.(lmd_receive);;
+  Σ <-
+  (if is_empty inline then ret Σ
+   else
+     let to_inline kn := existsb (eq_kername kn) inline in
+     Σcert <- tmEval lazy (inline_in_env to_inline Σ) ;;
+     mpath <- tmCurrentModPath tt;;
+     Certifying.gen_defs_and_proofs Σ Σcert mpath "_cert_pass"
+                                    (KernameSetProp.of_list [init_nm;receive_nm]);;
+     ret Σcert);;
+  ret (Σ, init_nm,receive_nm).
+
+(** Runs all the necessary steps in [TemplateMonad] and adds a definition
+    [<module_name>_prepared] to the Coq environment.
+    The definition consist of a call to erasure and pretty-printing for further
+    evaluation outside of [TemplateMonad], using, e.g. [Eval vm_compute in],
+    which is much faster than running the computations inside [TemplateMonad]. *)
+Definition CameLIGO_prepare_extraction {Base : ChainBase} {msg ctx params storage operation : Type}
+           (prefix : string)
+           (inline : list kername)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (m : CameLIGOMod msg ctx params storage operation) :=
+  '(Σ, init_nm, receive_nm) <- quote_and_preprocess inline m;;
+  let TT_defs := TT_defs ++ TT_remap_default in
+  let TT :=
+      (CameLIGO_rename_default ++ TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  let res := unwrap_string_sum (printCameLIGODefs prefix
+                                                  Σ
+                                                  TT_defs TT_ctors
+                                                  CameLIGO_call_ctx
+                                                  init_nm receive_nm
+                                                  m) in
+  tmDefinition (m.(lmd_module_name) ^ "_prepared") res.
+
+(** Bundles together quoting, inlining, erasure and pretty-printing.
+    Convenient to use, but might be slow, becase performance of [tmEval lazy] is not great. *)
+Definition CameLIGO_extract {Base : ChainBase} {msg ctx params storage operation : Type}
+           (prefix : string)
+           (inline : list kername)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (m : CameLIGOMod msg ctx params storage operation) :=
+  '(Σ, init_nm, receive_nm) <- quote_and_preprocess inline m;;
+  let TT_defs := TT_defs ++ TT_remap_default in
+  let TT :=
+      (CameLIGO_rename_default ++ TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
   p <- tmEval lazy
-             (printCameLIGODefs prefix Σ TT ignore
-                                 CameLIGO_call_ctx
-                                 m.(lmd_init_prelude)
-                                 m.(lmd_receive_prelude)
-                                 init_nm receive_nm) ;;
+             (printCameLIGODefs prefix
+                                Σ
+                                TT_defs TT_ctors
+                                CameLIGO_call_ctx
+                                init_nm receive_nm
+                                m) ;;
   match p with
   | inl s =>
     tmEval lazy
            (wrap_in_delimiters (String.concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)]))
   | inr s => tmFail s
   end.
+
+(** A simplified erasure/prinitng intended moslty for testing purposes *)
+Definition simple_def_print prefix TT_defs TT_ctors seeds prelude harness Σ
+  : string + string :=
+  let TT_defs := TT_defs ++ TT_remap_default in
+  let ignore := map fst TT_defs in
+  let TT := (CameLIGO_rename_default ++ TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  match annot_extract_template_env_specalize Σ seeds ignore with
+  | Ok annot_env =>
+  let '(eΣ; annots) := annot_env in
+      (* dependencies should be printed before the dependent definitions *)
+  let ldef_list := List.rev (print_global_env prefix TT eΣ annots) in
+    (* filtering empty strings corresponding to the ignored definitions *)
+    let not_empty_str := (negb ∘ (String.eqb "") ∘ snd) in
+
+    let ldef_ty_list := ldef_list
+                          |> filter (fun d => match d with TyDecl _ => true | _ => false end)
+                          |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
+                          |> filter not_empty_str in
+    let ldef_const_list := ldef_list
+                            |> filter (fun d => match d with ConstDecl _ => true | _ => false end)
+                            |> map (fun d => match d with ConstDecl d' => d' | TyDecl d' => d' end)
+                            |> filter not_empty_str in
+    let defs : list string :=
+        ldef_const_list  |> map snd
+                         |> List.app (map snd ldef_ty_list) in
+    String.concat (nl ^ nl) (prelude :: defs ++ [harness]) |> inl
+  | Err e => inr e
+  end.
+
+(** Quoting and inlining for a single definition.
+    Intended mostly for testing purposes *)
+Definition quote_and_preprocess_one_def {A}
+           (inline : list kername)
+           (def : A)
+  : TemplateMonad (TemplateEnvironment.global_env * kername) :=
+  '(Σ,_) <- tmQuoteRecTransp def false ;;
+  def_nm <- extract_def_name def;;
+  Σ <-(if is_empty inline then ret Σ
+      else
+        let to_inline kn := existsb (eq_kername kn) inline in
+        Σcert <- tmEval lazy (inline_in_env to_inline Σ) ;;
+        mpath <- tmCurrentModPath tt;;
+        Certifying.gen_defs_and_proofs Σ Σcert mpath "_cert_pass" (KernameSetProp.of_list [def_nm]);;
+        ret Σcert);;
+  ret (Σ,def_nm).
+
+(** Extraction for testing purposes.
+    Simply prints the definitions and allows for appending a prelude and a
+    hand-written harness code to run the extracted definition.
+    The harness is just a piece of code with definitions
+    of [storage], [main], etc.*)
+Definition CameLIGO_extract_single {A}
+           (prefix : string)
+           (inline : list kername)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (prelude : string)
+           (harness: string)
+           (def : A) : TemplateMonad string :=
+  '(Σ,def_nm) <- quote_and_preprocess_one_def inline def ;;
+  let seeds := KernameSetProp.of_list [def_nm] in
+  tmEval lazy (unwrap_string_sum (simple_def_print prefix TT_defs TT_ctors (KernameSet.singleton def_nm) prelude harness Σ)).
+
+(** Similar to [CameLIGO_prepare_extraction], but for a single definition  *)
+Definition CameLIGO_prepare_extraction_single {A}
+           (prefix : string)
+           (inline : list kername)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (prelude : string)
+           (harness: string)
+           (def : A) : TemplateMonad string :=
+    '(Σ,def_nm) <- quote_and_preprocess_one_def inline def ;;
+    let seeds := KernameSetProp.of_list [def_nm] in
+    tmDefinition (def_nm.2 ^ "_prepared") (unwrap_string_sum (simple_def_print prefix TT_defs TT_ctors (KernameSet.singleton def_nm) prelude harness Σ)).

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -527,28 +527,6 @@ Section print_term.
                  ++ string_of_nat (List.length brs) ++ " branches " ++ ")"
         end
       else
-        (* [list] is a special case *)
-      (*   if eq_kername mind <%% list %%> then *)
-      (*     match brs with *)
-      (*     | [b1;b2] => *)
-      (*       fun '(bt, (ta, (b1a, (b2a, _)))) => *)
-      (*         let nil_case := "[] -> " ++ print_term prefix FT TT ctx false false b1.2 b1a in *)
-      (*         let (args, _) := Edecompose_lam b2.2 in *)
-      (*         if #|args| <? 2 then "Error(MatchBranchedNotExpanded)" *)
-      (*         else *)
-      (*           let cons_args := firstn 2 args in *)
-      (*           let cons_pat := concat " :: " (map (fun x => string_of_name ctx (fresh_name ctx x b2.2)) cons_args) in *)
-      (*           let cons_ctx := rev (map vass cons_args) in *)
-      (*           let cons_case tbody tbodya := cons_pat ++ " -> " ++ print_term prefix FT TT (cons_ctx ++ ctx)%list top inapp tbody tbodya in *)
-      (*           parens top *)
-      (*                  ("match " *)
-      (*                     ++ print_term prefix FT TT ctx true false t ta *)
-      (*                     ++ " with " ++ nl *)
-      (*                     ++ concat (nl ++ " | ") [nil_case;(lam_body_annot_cont cons_case b2.2 b2a)]) *)
-      (*     | _ => fun bt => "Error (Malformed pattern-mathing on bool: given " *)
-      (*             ++ string_of_nat (List.length brs) ++ " branches " ++ ")" *)
-      (*     end *)
-      (* else *)
         fun '(bt, (ta, trs)) =>
       match lookup_ind_decl mind i with
       | Some oib =>

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -197,22 +197,24 @@ Section print_term.
     | _ => None
     end.
 
-  Definition is_fresh (ctx : context) (id : ident) :=
+  Definition is_fresh (Γ : context) (id : ident) :=
     List.forallb
       (fun decl =>
          match decl.(decl_name) with
-         | nNamed id' => negb (ident_eq id id')
+         | nNamed id' =>
+           (* NOTE: we compare the identifiers up to the capitalisation of the first letters *)
+           negb (ident_eq (uncapitalize id) (uncapitalize id'))
          | nAnon => true
-         end) ctx.
+         end) Γ.
 
   Fixpoint name_from_term (t : term) :=
     match t with
-    | tRel _ | tVar _ | tEvar _ _ => "H"
+    | tRel _ | tVar _ | tEvar _ _ => "h"
     | tLambda na t => "f"
     | tLetIn na b t' => name_from_term t'
     | tApp f _ => name_from_term f
     | tConst c => "x"
-    | _ => "U"
+    | _ => "u"
     end.
 
   Definition fresh_id_from ctx n id :=
@@ -240,6 +242,7 @@ Section print_term.
               | nNamed id => id
               end
     in
+    let id := uncapitalize id in
     if is_fresh ctx id then nNamed id
     else nNamed (fresh_id_from ctx 10 id).
 


### PR DESCRIPTION
This PR:
- if all arguments are logical - keep at least one (dummy) argument; with that constants like `False_rect` will be guarded by a lambda with the following type `unit -> a`, which is necessary to prevent `False_rect` from looping forever of throwing an exception immediately;
- handling empty pattern-matching in Elm and CameLIGO (with tests);
- handling empty pattern-matching in Rust and Liquidity (tested manually);
- add inlining to the CameLIGO pipeline; 
- improve performance of CameLIGO extraction by moving erasure/pretty-printing out of `TemplateMonad`;
- add simplified extraction to CameLIGO, which should allow for better support for experimenting/extraction tuning;
- fix printing of the pattern-matching on lists and printing of iterated lambdas for CameLIGO;
- fix capitalisation of variables (should start with the lowercase);
- fix capitalisation of constructors;