### PR TITLE
Misc fixes in extraction

### DIFF
--- a/execution/examples/EIP20Token.v
+++ b/execution/examples/EIP20Token.v
@@ -22,7 +22,6 @@ Import RecordSetNotations.
 
 Section EIP20Token.
   Context {BaseTypes : ChainBase}.
-  Set Primitive Projections.
   Set Nonrecursive Elimination Schemes.
 
   Definition TokenValue := N.

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -14,6 +14,7 @@ theories/Annotations.v
 theories/CameLIGOExtract.v
 theories/CameLIGOPretty.v
 theories/Certifying.v
+theories/CertifyingBeta.v
 theories/CertifyingEta.v
 theories/CertifyingInlining.v
 theories/ClosedAux.v

--- a/extraction/examples/ERC20LiquidityExtraction.v
+++ b/extraction/examples/ERC20LiquidityExtraction.v
@@ -98,10 +98,10 @@ Section EIP20TokenExtraction.
     match maybe_msg with
     | Some (transfer to_addr amountt) => without_actions (try_transfer sender to_addr amountt state)
     | Some (transfer_from from to_addr amountt) => without_actions (try_transfer_from sender from to_addr amountt state)
-    (* 'approve' endpoint not included in this test *)
+   | Some (approve delegate amount) => without_actions (try_approve sender delegate amount state)
     | _ => None
     end.
-  
+
   Definition receive_wrapper
              (params : params)
              (st : State) : option (list ActionBody × State) :=
@@ -139,9 +139,11 @@ Section EIP20TokenExtraction.
 
   
   Definition TT_remap_eip20token : list (kername * string) :=
-  TT_remap_default ++ [
+    TT_remap_default ++ [
+    (* FIXME: it seems like the context type is wrong *)
     remap <%% @ContractCallContext %%> "(address * (address * int))"
   ; remap <%% @ctx_from %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% gmap.gmap %%> "map"
   ; remap <%% @AddressMap.add %%> "Map.add"
   ; remap <%% @AddressMap.find %%> "Map.find"
   ; remap <%% @AddressMap.empty %%> "(Map [])"
@@ -169,6 +171,8 @@ Section EIP20TokenExtraction.
     ; <%% @setter_from_getter_State_allowances %%>
     ; <%% @set_State_balances %%>
     ; <%% @set_State_allowances%%>
+
+    ; <%% @Common.AddressMap.AddrMap %%>
     ].
   
   Time MetaCoq Run
@@ -176,7 +180,7 @@ Section EIP20TokenExtraction.
       tmDefinition EIP20Token_MODULE.(lmd_module_name) t).
 
   Print liquidity_eip20token.
-
+  
   (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
   Redirect "./examples/liquidity-extract/liquidity_eip20token.liq" Compute liquidity_eip20token.
 

--- a/extraction/examples/ElmExtractTests.v
+++ b/extraction/examples/ElmExtractTests.v
@@ -437,6 +437,7 @@ Module type_scheme_ex.
 "type alias Triple a b c = Prod (Prod a b) c" $>.
   Proof. vm_compute. reflexivity. Qed.
 
+  Module LetouzeyExample.
   (* An example from Letouzey's thesis, Section 3.3.4 *)
 
   Definition P (b : bool) : Set := if b then nat else bool.
@@ -465,6 +466,11 @@ Module type_scheme_ex.
 "type alias Sch3_applied = Nat -> Bool" $>.
   Proof. vm_compute. reflexivity. Qed.
 
+  End LetouzeyExample.
+
+
+  (* [Vec] is a common example of using a type scheme to abbreviate a type *)
+
   Definition vec (A : Type) (n : nat) := {xs : list A | length xs = n}.
 
   Program Definition singleton_vec (n : nat) : vec nat 1 := [n].
@@ -474,7 +480,6 @@ Module type_scheme_ex.
 
   MetaCoq Run (general_extract_tc singleton_vec_syn [] []).
 
-  (* NOTE: the extracted code is not well-typed in Elm, because Elm's type aliases do not support unused type variables *)
   Example singleton_vec_test:
     general_extract singleton_vec_syn [] [] = Ok <$
 "type Nat";

--- a/extraction/theories/CertifyingBeta.v
+++ b/extraction/theories/CertifyingBeta.v
@@ -1,0 +1,92 @@
+From Coq Require Import List String Bool Basics.
+
+From ConCert.Extraction Require Import Transform.
+From ConCert.Extraction Require Import Optimize.
+From ConCert.Extraction Require Import Common.
+From ConCert.Extraction Require Import ResultMonad.
+From ConCert.Extraction Require Import Utils.
+From ConCert.Extraction Require Import Certifying.
+
+From MetaCoq.Template Require Import All Kernames.
+
+Import ListNotations.
+Import MonadNotation.
+
+Section betared.
+  Context (Σ : global_env).
+
+  Fixpoint decompose_lam (t : term) {struct t} :
+  (list aname × list term) × term :=
+    match t with
+    | tLambda na A B =>
+      let (nAs, B0) := decompose_lam B in
+      let (ns, As) := nAs in (na :: ns, A :: As, B0)
+    | _ => ([], [], t)
+    end.
+
+  Fixpoint betared_aux (args : list term) (t : term) : term :=
+      match t with
+      | tApp hd args0 => betared_aux (map (betared_aux []) args0 ++ args) hd
+      | tCast t0 _ _ => betared_aux args t0
+      | tLambda na ty body =>
+        let b := betared_aux [] body in
+        beta_body (tLambda na ty b) args
+      | t => mkApps (map_subterms (betared_aux []) t) args
+      end.
+
+  Definition betared : term -> term := betared_aux [].
+
+  Definition betared_in_constant_body cst :=
+    {| cst_type := cst_type cst;
+       cst_universes := cst_universes cst;
+       cst_body := option_map betared (cst_body cst) |}.
+
+  Definition betared_in_decl d :=
+    match d with
+    | ConstantDecl cst => ConstantDecl (betared_in_constant_body cst)
+    | _ => d
+    end.
+
+End betared.
+
+Definition betared_in_env (Σ : global_env) : global_env :=
+  fold_right (fun '(kn, decl) Σ => (kn, betared_in_decl decl) :: Σ) [] Σ.
+
+Definition betared_global_env_template
+           (mpath : modpath)
+           (Σ : global_env)
+           (seeds : KernameSet.t)
+  : TemplateMonad global_env :=
+  let suffix := "_after_betared" in
+  Σinlined <- tmEval lazy (betared_in_env Σ);;
+  gen_defs_and_proofs Σ Σinlined mpath suffix seeds;;
+  ret Σinlined.
+
+(* Mainly for testing purposes *)
+Definition betared_def {A}
+           (def : A) : TemplateMonad _ :=
+  mpath <- tmCurrentModPath tt;;
+  p <- tmQuoteRecTransp def false ;;
+  kn <- Common.extract_def_name def ;;
+  betared_global_env_template mpath p.1 (KernameSet.singleton kn).
+
+
+Definition template_betared : TemplateTransform :=
+  fun Σ => Ok (timed "Inlining" (fun _ => betared_in_env Σ)).
+
+Module Ex1.
+
+  Definition foo (n : nat) := (fun x => x) n.
+
+  MetaCoq Run (betared_def foo).
+
+  MetaCoq Quote Recursively Definition foo_after :=
+    ConCert_Extraction_CertifyingBeta_Ex1_foo_after_betared.
+
+  MetaCoq Quote Recursively Definition foo_before := foo.
+
+  Lemma after_not_before :
+    lookup_env foo_after.1 <%% ConCert_Extraction_CertifyingBeta_Ex1_foo_after_betared %%> =
+    lookup_env foo_before.1 <%% foo %%> -> False.
+  Proof. easy. Qed.
+End Ex1.

--- a/extraction/theories/CertifyingEta.v
+++ b/extraction/theories/CertifyingEta.v
@@ -420,8 +420,8 @@ Module Examples.
     MetaCoq Quote Recursively Definition match_ex1__ := match_ex1.
     MetaCoq Run (eta_expand_def
                    (fun _ => None)
-     (* We set the trimmig of masks to true, so the procedure does't not perform full expansion.
-        That way we can test the expansion of branches *)
+    (* We set the trimming of masks to true, so the procedure does't perform full expansion.
+       That way we can test the expansion of branches *)
                    true true
                    match_ex1).
 

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -91,7 +91,7 @@ Section print_term.
   Definition print_type_var (v : name) (i : nat) :=
     match v with
     | nNamed nm => "'" ++ uncapitalize nm
-    | nAnon => "annon_tvar" ++ string_of_nat i
+    | nAnon => "anon_tvar" ++ string_of_nat i
     end.
 
   

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -87,13 +87,20 @@ Section print_term.
     | TApp t1 t2 => get_tapp_hd t1
     | _ => bt
     end.
+  
+  Definition print_type_var (v : name) (i : nat) :=
+    match v with
+    | nNamed nm => "'" ++ uncapitalize nm
+    | nAnon => "annon_tvar" ++ string_of_nat i
+    end.
 
-  Definition print_box_type (prefix : string) (TT : env string)
+  
+  Definition print_box_type (prefix : string) (TT : env string) (vars : list name)
     : box_type -> string :=
     fix go  (bt : box_type) :=
   match bt with
   | TBox => "unit"
-  | TArr dom codom => parens (negb (is_arr dom)) (go dom) ++ " → " ++ go codom
+  | TArr dom codom => parens (negb (is_arr dom)) (go dom) ++ " -> " ++ go codom
   | TApp t1 t2 =>
     let hd := get_tapp_hd t1 in
     let args := map_targs go bt in
@@ -105,7 +112,10 @@ Section print_term.
       else parens false (print_uncurried "" args ++ " " ++ go hd)
     | _ => parens false (print_uncurried "" args ++ " " ++ go hd)
     end
-  | TVar i => "'a" ++ string_of_nat i (* TODO: pass context with type variables *)
+  | TVar i => match nth_error vars i with
+             | Some nm => print_type_var nm i
+             | None => "UnknownTypeVar(" ++ string_of_nat i ++ ")"
+             end
   | TInd s =>
     let full_ind_name := string_of_kername s.(inductive_mind) in
     uncapitalize (from_option (look TT full_ind_name) (prefix ++ s.(inductive_mind).2))
@@ -119,45 +129,48 @@ Section print_term.
   Definition print_ctor
              (prefix : string)
              (TT : env string)
+             (vars : list name)
              (ctor : ident × list (name × box_type)) :=
     let (nm,tys) := ctor in
     let nm := capitalize nm in
     match tys with
     | [] => prefix ++ nm
     | _ => prefix ++ nm ++ " of "
-                  ++ concat " * " (map (print_box_type prefix TT ∘ snd) tys)
+                  ++ concat " * " (map (print_box_type prefix TT vars ∘ snd) tys)
     end.
   
-  Definition print_proj (prefix : string) (TT : env string) (proj : ident × box_type) : string :=
+  Definition print_proj (prefix : string)
+             (TT : env string)
+             (vars : list name)
+             (proj : ident × box_type) : string :=
     let (nm, ty) := proj in
     prefix
       ^ nm
       ^ " : "
-      ^ print_box_type prefix TT ty.
+      ^ print_box_type prefix TT vars ty.
 
   Definition print_inductive (prefix : string) (TT : env string)
              (oib : ExAst.one_inductive_body) :=
     let ind_nm := from_option (lookup TT oib.(ExAst.ind_name))
                               (prefix ++ oib.(ExAst.ind_name)) in
-    let print_type_var (i : nat) :=
-        "'a" ++ string_of_nat i in
+    let vars := map tvar_name oib.(ind_type_vars) in
     let params :=
         if (Nat.eqb #|oib.(ind_type_vars)| 0) then ""
-        else let ps := concat "," (mapi (fun i _ => print_type_var i) oib.(ind_type_vars)) in
-             (parens (Nat.eqb #|oib.(ind_type_vars)| 1) ps) ++ " " in
+        else let ps := concat "," (mapi (fun i v => print_type_var v i) vars) in
+             (parens (Nat.ltb #|oib.(ind_type_vars)| 1) ps) ++ " " in
     (* one-constructor inductives with non-empty ind_projs (projection identifiers) 
        are assumed to be records *)
     match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
     | [build_record_ctor], _::_ =>
       let '(_, ctors) := build_record_ctor in
       let projs_and_ctors := combine oib.(ExAst.ind_projs) ctors in
-      let projs_and_ctors_printed := map (fun '(p, (proj_nm, ty)) => print_proj (capitalize prefix) TT (p.1, ty)) projs_and_ctors in
+      let projs_and_ctors_printed := map (fun '(p, (proj_nm, ty)) => print_proj (capitalize prefix) TT vars (p.1, ty)) projs_and_ctors in
       "type " ++ params ++ uncapitalize ind_nm ++ " = {" ++ nl
               ++ concat (";" ++ nl) projs_and_ctors_printed ++ nl
               ++  "}"
     | _,_ => "type " ++ params ++ uncapitalize ind_nm ++" = "
             ++ nl
-            ++ concat "| " (map (fun p => print_ctor (capitalize prefix) TT p ++ nl) oib.(ExAst.ind_ctors))
+            ++ concat "| " (map (fun p => print_ctor (capitalize prefix) TT vars p ++ nl) oib.(ExAst.ind_ctors))
     end.
 
   Definition is_sort (t : Ast.term) :=
@@ -528,11 +541,11 @@ Definition print_decl (prefix : string)
            (decl_name : string)
            (modifier : option string)
            (wrap : string -> string)
-           (ty : box_type)
+           (ty : list name × box_type)
            (t : term) :=
-  let (tys,_) := decompose_arr ty in
+  let (tys,_) := decompose_arr ty.2 in
   let (args,lam_body) := Edecompose_lam t in
-  let targs := combine args (map (print_box_type prefix TT) tys) in
+  let targs := combine args (map (print_box_type prefix TT ty.1) tys) in
   let printed_targs :=
       map (fun '(x,ty) => parens false (uncapitalize (string_of_name x) ++ " : " ++ ty)) targs in
   let decl := uncapitalize prefix ++ uncapitalize decl_name ++ " " ++ concat " " printed_targs in
@@ -555,7 +568,7 @@ Definition print_init (prefix : string)
   let ty := cst.(ExAst.cst_type) in
   let (tys,_) := decompose_arr ty.2 in
   let (args,lam_body) := Edecompose_lam b in
-  let targs_inner := combine args (map (print_box_type prefix TT) tys) in
+  let targs_inner := combine args (map (print_box_type prefix TT ty.1) tys) in
   let printed_targs_inner :=
       map (fun '(x,ty) => parens false (string_of_name x ++ " : " ++ ty)) targs_inner in
   let decl_inner := "inner " ++ concat " " printed_targs_inner in
@@ -589,7 +602,7 @@ Definition print_cst (prefix : string)
   | Some cst_body =>
     (* NOTE: ignoring the path part *)
     let (_, decl_name) := kn in
-    print_decl prefix TT Σ decl_name None id cst.(ExAst.cst_type).2 cst_body
+    print_decl prefix TT Σ decl_name None id cst.(ExAst.cst_type) cst_body
   | None => ""
   end.
 
@@ -608,9 +621,10 @@ Definition print_global_decl (prefix : string) (TT : MyEnv.env string)
   | TypeAliasDecl (Some (params, ty)) =>
     let ta_nm := from_option (lookup TT (string_of_kername nm))
                              (prefix ++ nm.2) in
-    (nm, "type " ++ uncapitalize ta_nm
-                 ++ concat " " (map (string_of_name ∘ tvar_name) params) ++  " = "
-            ++ print_box_type prefix TT ty)
+    (nm, "type " ++ parens (Nat.ltb #|params| 1) (concat "," (mapi (fun i v => print_type_var v.(tvar_name) i) params))
+                 ++ " " ++ uncapitalize ta_nm
+                 ++  " = "
+            ++ print_box_type prefix TT (map tvar_name params) ty)
   | TypeAliasDecl None => (nm, "")
   end.
 

--- a/extraction/theories/Optimize.v
+++ b/extraction/theories/Optimize.v
@@ -412,6 +412,11 @@ Fixpoint debox_box_type_aux (args : list box_type) (bt : box_type) : box_type :=
   | TApp ty1 ty2 =>
     debox_box_type_aux (debox_box_type_aux [] ty2 :: args) ty1
   | TInd ind => dearg_single_bt (get_inductive_tvars ind) bt args
+  | TConst kn => match lookup_env Σ kn with
+                | Some (TypeAliasDecl (Some (vs, ty))) =>
+                  dearg_single_bt vs bt args
+                | _ => bt
+                end
   | _ => mkTApps bt args
   end.
 
@@ -450,7 +455,8 @@ Definition debox_type_decl (decl : global_decl) : global_decl :=
   | InductiveDecl mib => InductiveDecl (debox_type_mib mib)
   | TypeAliasDecl ta => match ta with
                        | Some (ty_vars, ty) =>
-                         TypeAliasDecl (Some (ty_vars, debox_box_type ty))
+                         TypeAliasDecl (Some (filter keep_tvar ty_vars,
+                                              reindex ty_vars (debox_box_type ty)))
                        | None => TypeAliasDecl None
                        end
   end.


### PR DESCRIPTION
Inlining:
* more beta-reductions;
*  inline definitions in inductive types (we don't generate proofs of convertibility for types of inductives and their constructors, but inlining in inductives does not affect the dynamic semantics.

Pretty-printing:
* fixed printing of parameterised types in Liquidity.

Optimisations:
*  fixed deboxing of type aliases (now type abbreviations extract better).

Extraction examples:
* cleaned up ERC20 extraction to Liqudity and CameLIGO
* note that we can unfold the `AddrMap` type alias and remap `FMap` directly, which gives us extracted code with no extra type alias for `AddrMap`. This is crucial for CameLIGO, because it doesn't support polymorphic definitions and `AddrMap` has a type parameter;
* add tests for type scheme extraction to the Elm extraction.