### PR TITLE
Extraction improvements, cameligo extraction of counter with refinement types

### DIFF
--- a/extraction/examples/CounterCertifiedExtraction.v
+++ b/extraction/examples/CounterCertifiedExtraction.v
@@ -90,19 +90,19 @@ Module Counter.
   Definition counter_init (ch : Chain) (ctx : ContractCallContext) :=
     init_wrapper init ch ctx.
 
-          Definition counter_receive (chain : Chain) (ctx : ContractCallContext)
-                     (st : storage) (msg : option msg) : option (storage * list ActionBody)
-            := match msg with
-               | Some m => match counter m st with
-                          | Some res => Some (res.2,res.1)
-                          | None => None
-                          end
-               | None => None
-               end.
+  Definition counter_receive (chain : Chain) (ctx : ContractCallContext)
+              (st : storage) (msg : option msg) : option (storage * list ActionBody)
+    := match msg with
+        | Some m => match counter m st with
+                  | Some res => Some (res.2,res.1)
+                  | None => None
+                  end
+        | None => None
+        end.
 
-          (** Deriving the [Serializable] instances for the state and for the messages *)
-          Global Instance Msg_serializable : Serializable msg :=
-            Derive Serializable msg_rect<Inc, Dec>.
+  (** Deriving the [Serializable] instances for the state and for the messages *)
+  Global Instance Msg_serializable : Serializable msg :=
+    Derive Serializable msg_rect<Inc, Dec>.
 
   (** A contract instance used by the execution framework *)
   Definition CounterContract :=

--- a/extraction/examples/CounterRefinementTypes.v
+++ b/extraction/examples/CounterRefinementTypes.v
@@ -40,7 +40,7 @@ Module CounterRefinementTypes.
   Definition storage := Z.
 
   Definition init (ctx : SimpleCallCtx) (setup : Z) : option storage :=
-    let ctx' := ctx in (* prevents optimisations from removing unused [ctx]  *)
+    let ctx_ := ctx in (* prevents optimisations from removing unused [ctx]  *)
     Some setup.
 
   Inductive msg := Inc (_ : Z) | Dec (_ : Z).
@@ -63,9 +63,9 @@ Module CounterRefinementTypes.
     Zleb_ltb_to_prop. lia.
   Qed.
 
-  Definition counter (Msg : msg) (st : storage)
+  Definition counter (msg : msg) (st : storage)
     : option (Transaction * storage) :=
-    match Msg with
+    match msg with
     | Inc i =>
       match (bool_dec true (0 <? i)) with
       | left H => Some (Transaction_none, proj1_sig (inc_counter st (exist _ i (eq_sym H))))
@@ -82,68 +82,73 @@ End CounterRefinementTypes.
 
 Import CounterRefinementTypes.
 
-(** [sig] and [exist] becomes just wrappers *)
-Definition sig_def := "type 'a sig_ = 'a".
-Definition exist_def := "let exist_ a = a".
+Section LiquidityExtractionSetup.
 
-(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
-Definition TT_remap : list (kername * string) :=
-  [ remap <%% bool %%> "bool"
-  ; remap <%% list %%> "list"
-  ; remap <%% Amount %%> "tez"
-  ; remap <%% address_coq %%> "address"
-  ; remap <%% time_coq %%> "timestamp"
-  ; remap <%% option %%> "option"
-  ; remap <%% Z.add %%> "addInt"
-  ; remap <%% Z.sub %%> "subInt"
-  ; remap <%% Z.leb %%> "leInt"
-  ; remap <%% Z.ltb %%> "ltInt"
-  ; remap <%% sig %%> "sig_" (* remapping [sig] to the wrapper *)
-  ; remap <%% @proj1_sig %%> "(fun x -> x)" (* this is a safe, but ad-hoc optimisation*)
-  ; remap <%% Z %%> "int"
-  ; remap <%% nat %%> "key_hash" (* type of account addresses*)
-  ; remap <%% Transaction %%> "operation list"
-  ; remap <%% @fst %%> "fst"
-  ; remap <%% @snd %%> "snd" ].
+  (** [sig] and [exist] becomes just wrappers *)
+  Definition sig_def := "type 'a sig_ = 'a".
+  Definition exist_def := "let exist_ a = a".
 
-(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
-Definition TT_rename : list (string * string):=
-  [ ("Some", "Some")
-  ; ("None", "None")
-  ; ("Z0" ,"0")
-  ; ("nil", "[]")
-  ; ("true", "true")
-  ; ("exist", "exist_") (* remapping [exist] to the wrapper *)
-  ; (string_of_kername <%% storage %%>, "storage")  (* we add [storage] so it is printed without the prefix *) ].
+  (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+  Definition TT_remap : list (kername * string) :=
+    [ remap <%% bool %%> "bool"
+    ; remap <%% list %%> "list"
+    ; remap <%% Amount %%> "tez"
+    ; remap <%% address_coq %%> "address"
+    ; remap <%% time_coq %%> "timestamp"
+    ; remap <%% option %%> "option"
+    ; remap <%% Z.add %%> "addInt"
+    ; remap <%% Z.sub %%> "subInt"
+    ; remap <%% Z.leb %%> "leInt"
+    ; remap <%% Z.ltb %%> "ltInt"
+    ; remap <%% sig %%> "sig_" (* remapping [sig] to the wrapper *)
+    ; remap <%% @proj1_sig %%> "(fun x -> x)" (* this is a safe, but ad-hoc optimisation*)
+    ; remap <%% Z %%> "int"
+    ; remap <%% nat %%> "key_hash" (* type of account addresses*)
+    ; remap <%% Transaction %%> "operation list"
+    ; remap <%% @fst %%> "fst"
+    ; remap <%% @snd %%> "snd" ].
 
-Definition COUNTER_MODULE : LiquidityMod msg _ Z storage ActionBody :=
-  {| (* a name for the definition with the extracted code *)
-     lmd_module_name := "liquidity_counter" ;
+  (** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+  Definition TT_rename : list (string * string):=
+    [ ("Some", "Some")
+    ; ("None", "None")
+    ; ("Z0" ,"0")
+    ; ("nil", "[]")
+    ; ("true", "true")
+    ; ("exist", "exist_") (* remapping [exist] to the wrapper *)
+    ; (string_of_kername <%% storage %%>, "storage")  (* we add [storage] so it is printed without the prefix *) ].
 
-     (* definitions of operations on pairs and ints *)
-     lmd_prelude := concat nl [prod_ops;int_ops; sig_def; exist_def];
+  Definition COUNTER_MODULE : LiquidityMod msg _ Z storage ActionBody :=
+    {| (* a name for the definition with the extracted code *)
+      lmd_module_name := "liquidity_counter" ;
 
-     (* initial storage *)
-     lmd_init := init ;
+      (* definitions of operations on pairs and ints *)
+      lmd_prelude := concat nl [prod_ops;int_ops; sig_def; exist_def];
 
-     (* no extra operations in [init] are required *)
-     lmd_init_prelude := "" ;
+      (* initial storage *)
+      lmd_init := init ;
 
-     (* the main functionality *)
-     lmd_receive := counter ;
+      (* no extra operations in [init] are required *)
+      lmd_init_prelude := "" ;
 
-     (* code for the entry point *)
-     lmd_entry_point := printWrapper (PREFIX ++ "counter") ++ nl
-                       ++ printMain |}.
+      (* the main functionality *)
+      lmd_receive := counter ;
 
-(** We run the extraction procedure inside the [TemplateMonad].
-    It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
-    that removes application of boxes to constants and constructors. *)
+      (* code for the entry point *)
+      lmd_entry_point := printWrapper (PREFIX ++ "counter") ++ nl
+                        ++ printMain |}.
 
-Definition to_inline := [<%% bool_rect %%>; <%% bool_rec %%>].
+  (** We run the extraction procedure inside the [TemplateMonad].
+      It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
+      that removes application of boxes to constants and constructors. *)
+
+  Definition to_inline := [<%% bool_rect %%>; <%% bool_rec %%>].
+
+End LiquidityExtractionSetup.
+
 
 Time MetaCoq Run
-     (t <- liquidity_extraction PREFIX  TT_remap TT_rename to_inline COUNTER_MODULE ;;
+     (t <- liquidity_extraction PREFIX TT_remap TT_rename to_inline COUNTER_MODULE ;;
       tmDefinition COUNTER_MODULE.(lmd_module_name) t
      ).
 
@@ -151,3 +156,110 @@ Print liquidity_counter.
 
 (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
 Redirect "examples/liquidity-extract/CounterRefinementTypes.liq" Compute liquidity_counter.
+
+
+
+From ConCert.Extraction Require Import CameLIGOPretty CameLIGOExtract.
+Module CameLIGOExtractionSetup.
+  
+
+  (** [sig] and [exist] becomes just wrappers *)
+  Definition sig_def_ligo := "type sig_ = int".
+  Definition exist_def_ligo := "let exist_ (a:int) = a".
+
+  (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+  Definition TT_remap_ligo : list (kername * string) :=
+    [
+      remap <%% address_coq %%> "address"
+    ; remap <%% time_coq %%> "timestamp"
+    ; remap <%% Z.add %%> "addInt"
+    ; remap <%% Z.sub %%> "subInt"
+    ; remap <%% Z.leb %%> "leInt"
+    ; remap <%% Z.ltb %%> "ltInt"
+    ; remap <%% sig %%> "sig_" (* remapping [sig] to the wrapper *)
+    ; remap <%% @proj1_sig %%> "(fun (x:sig_) -> x)" (* this is a safe because of the way we define sig_, but ad-hoc optimisation*)
+    ; remap <%% Z %%> "int"
+    ; remap <%% Transaction %%> "operation list"
+    ].
+
+  (** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+  Definition TT_rename_ligo : list (string * string):=
+    [ ("Some", "Some")
+    ; ("None", "None")
+    ; ("Z0" ,"0")
+    ; ("nil", "[]")
+    ; ("true", "true")
+    ; ("exist", "exist_") (* remapping [exist] to the wrapper *)
+    ; (string_of_kername <%% storage %%>, "storage")  (* we add [storage] so it is printed without the prefix *)
+    ; (string_of_kername <%% @ActionBody %%>, "operation") (* Same for ActionBody *) 
+    ; (string_of_kername <%% @Chain %%>, "chain") (* Same for Chain *) 
+    ].
+    
+
+  Definition counter_wrapper (c : Chain) 
+                             (ctx : SimpleCallCtx)
+                             (s : storage)
+                             (m : option msg) := 
+    let c_ := c in
+    let ctx_ := ctx in
+    match m with
+    | Some m => counter m s
+    | None => None
+    end.
+  
+Definition dummy_chain :=
+      "type chain = {
+        chain_height     : nat;
+        current_slot     : nat;
+        finalized_height : nat;
+        account_balance  : address -> nat
+      }"
+  ++ nl
+  ++ "let dummy_chain : chain = {
+        chain_height     = 0n;
+        current_slot     = 0n;
+        finalized_height = 0n;
+        account_balance  = fun (a : address) -> 0n
+      }".
+
+  Definition COUNTER_MODULE_LIGO : CameLIGOMod msg _ Z storage ActionBody :=
+    {| (* a name for the definition with the extracted code *)
+      lmd_module_name := "cameligo_counter" ;
+
+      (* definitions of operations on pairs and ints *)
+      lmd_prelude := concat nl [CameLIGOPrelude; sig_def_ligo; exist_def_ligo; dummy_chain];
+
+      (* initial storage *)
+      lmd_init := init ;
+
+      (* no extra operations in [init] are required *)
+      lmd_init_prelude := "" ;
+
+      (* the main functionality *)
+      lmd_receive := counter_wrapper ;
+
+      lmd_receive_prelude := "";
+      (* code for the entry point *)
+      lmd_entry_point := printWrapper (PREFIX ++ "counter_wrapper") 
+                                      (PREFIX ++"msg") 
+                                      "storage" 
+                                      CameLIGO_call_ctx 
+                                      ++ nl
+                                      ++ CameLIGOPretty.printMain |}.
+
+  (** We run the extraction procedure inside the [TemplateMonad].
+      It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
+      that removes application of boxes to constants and constructors. *)
+
+  Definition to_inline_ligo := [<%% bool_rect %%>; <%% bool_rec %%>].
+
+  Time MetaCoq Run
+  (CameLIGO_prepare_extraction PREFIX to_inline_ligo TT_remap_ligo TT_rename_ligo COUNTER_MODULE_LIGO).
+
+  Time Definition cameLIGO_counter := Eval vm_compute in cameligo_counter_prepared.
+
+  MetaCoq Run (tmMsg cameLIGO_counter).
+  
+  Redirect "examples/liquidity-extract/CounterRefinementTypes.mligo" Compute cameLIGO_counter.
+    
+End CameLIGOExtractionSetup.

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -141,7 +141,7 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% Z.eqb %%> "eqTez"
   ; remap <%% Z.gtb %%> "gtbTez"
   ; remap <%% N.add %%> "addInt"
-  ; remap <%% N.sub %%> "subInt"
+  ; remap <%% N.sub %%> "subIntTruncated"
   ; remap <%% N.leb %%> "leInt"
   ; remap <%% N.ltb %%> "ltInt"
   ; remap <%% N.eqb %%> "eqInt"

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -224,7 +224,7 @@ Definition printCameLIGODefs `{ChainBase} {Base : ChainBase} {msg ctx params sto
         let defs : list string :=
           ldef_const_list |> filter (negb ∘ (eq_kername init) ∘ fst)
                           |> map snd
-                          |> List.app [init_prelude] (* append const decls after receive prelude decls *)
+                          |> List.app [prelude] (* append const decls after receive prelude decls *)
                           |> List.app (map snd ldef_ty_list) (* append the above after ty decls*)
                           in
           (* map snd (filter (negb ∘ (eq_kername init) ∘ fst) ldef_list) in *)

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -220,11 +220,11 @@ Definition printCameLIGODefs `{ChainBase} {Base : ChainBase} {msg ctx params sto
       match print_init prefix TT build_call_ctx init_prelude eΣ init_cst annots with
       | Some init_code =>
         (* filtering out the definition of [init] and projecting the code *)
-        (* and place prelude after type decls and before constant decls *)
+        (* and place init prelude after type decls and before constant decls *)
         let defs : list string :=
           ldef_const_list |> filter (negb ∘ (eq_kername init) ∘ fst)
                           |> map snd
-                          |> List.app [prelude] (* append const decls after receive prelude decls *)
+                          |> List.app [init_prelude] (* append const decls after receive prelude decls *)
                           |> List.app (map snd ldef_ty_list) (* append the above after ty decls*)
                           in
           (* map snd (filter (negb ∘ (eq_kername init) ∘ fst) ldef_list) in *)

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -5,18 +5,7 @@
 
 (** Printing covers most constructs of CIC_box (terms after erasure). Usually we have to remove redundant boxes before printing. There are some limitations on what can work after extraction, due to the nature of CameLIGO, or some times, lack of proper support.
 
-CameLIGO allows only tail-recursive calls and recursive functions must have only one argument. So, we pack multiple arguments in a tuple. In order for that to be correct, we assume that all fixpoints are fully applied.
-
-Another issue (mostly solved): constructors accept only one argument, so we have to uncurry (pack in a tuple) applications as well. This transformation is applied to all constructors and the pretty-printing stage. Again, we assume that the constructors are fully applied (e.g. eta-expanded at the previous stage).
-
-TODO: CHECK THIS FOR CAMELIGO
-Pattern-macthing: pattern-matching on pairs is not supported by CameLIGO, so all the programs must use projections.
-
-TODO: RECORDS ARE SUPPORTED IN CAMELIGO
-Records are currently not supported. Should be represented as iterated products.
-
-TODO:REWRITE
-Printing polymoprhic definitions is not supported currently (due to the need of removing redundant types from the type scheme). But the machinery is there, just need to switch to erased types. *)
+CameLIGO allows only tail-recursive calls and recursive functions must have only one argument. So, we pack multiple arguments in a tuple. In order for that to be correct, we assume that all fixpoints are fully applied. *)
 
 From Coq Require Import List Program String Ascii.
 From ConCert.Extraction Require Import Utils ExAst Common.

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -260,6 +260,26 @@ Section print_term.
   Definition print_list_cons (f : term -> string) (t1 : term) (t2 : term) :=
     (f t1) ++ " :: " ++ (f t2).
 
+  Definition is_record_constr (t : term) : option ExAst.one_inductive_body := 
+    match t with
+    | tConstruct (mkInd mind j as ind) i =>
+      match lookup_ind_decl mind i with
+      (* Check if it has only 1 constructor, and projections are specified *)
+      | Some oib => match ExAst.ind_projs oib, Nat.eqb 1 (List.length oib.(ExAst.ind_ctors)) with
+                    | _::_,true => Some oib
+                    | _,_ => None
+                    end
+      | _ => None
+      end
+    | _ => None
+  end.
+
+  Definition is_name_remapped nm TT := 
+    match (look TT nm) with
+    | Some nm' => true
+    | None => false
+    end.
+
   Definition app_args {A} (f : term -> A) :=
     fix go (t : term) := match t with
     | tApp t1 t2 => f t2 :: go t1
@@ -405,24 +425,6 @@ Section print_term.
           else parens (top || inapp) (print_term prefix FT TT ctx false true f fa ++ " " ++ print_term prefix FT TT ctx false false l la)
         | None => "UnboundRel(" ++ string_of_nat i ++ ")"
         end
-      | tProj (mkInd mind i as ind, pars, k) c =>
-        match lookup_ind_decl mind i with
-        | Some oib =>
-          match nth_error oib.(ExAst.ind_projs) k with
-          | Some (na, _) =>
-              if is_not_empty_const l then
-                parens (top || inapp) (print_term prefix FT TT ctx false true f fa ++ " " ++ print_term prefix FT TT ctx false false l la)
-              else (* if term is on the form (tApp t ""), then just print t *)
-                print_term prefix FT TT ctx false true f fa
-            | None =>
-            "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ")"
-                          (* ++ print_term prefix FT TT ctx true false b ba ++ ")" TODO: b should be replaced by c - but need to retrieve annotation first *)
-          end
-          | None =>
-          "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ")"
-                        (* ++ print_term prefix FT TT ctx true false b ba ++ ")" *)
-        end
-
       | tConst c =>
         let cst_name := string_of_kername c in
         let nm := from_option (look TT cst_name) (prefix ++ c.2) in
@@ -432,8 +434,6 @@ Section print_term.
         else if nm =? "snd" then
           (concat " " (map (parens true) apps)) ++ ".1"
         else if (nm =? "constructor") then
-          concat " " apps
-        else if (nm =? "") then
           concat " " apps
         (* ContractCallContext remappings *)
         else if (nm =? "ctx_from") then
@@ -456,20 +456,17 @@ Section print_term.
           print_transfer apps
         else if (nm =? "_") then
           fresh_id_from ctx 10 "a"
-        else
-          (* inductive constructors of 1 arg are treated as records *)
-          let nm' := capitalize <| from_option (look TT nm) ((capitalize prefix) ++ nm) in
-          match lookup_ind_decl mind i with
-          | Some oib =>
-            if Nat.eqb 1 (List.length oib.(ExAst.ind_ctors)) then
-              (* TODO: maybe need to capitalize projs here, to ensure consistency with get_constr_name *)
-              let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in
+        (* inductive constructors of 1 arg are treated as records *)
+        else match is_name_remapped nm TT, is_record_constr b with
+          | false, Some oib => 
+              let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in 
+              (* let nm' := capitalize <| from_option (look TT nm) ((capitalize prefix) ++ nm) in *)
               let field_decls_printed := projs_and_apps |> map (fun '(proj, e) => proj ++ " = " ++ e)
-                                                        |> concat "; " in
+                                                      |> concat "; " in
               "({" ++ field_decls_printed ++ "}: " ++ print_box_type prefix TT bt ++ ")"
-            else parens top (print_uncurried nm' apps)
-          | _ => parens top (print_uncurried nm' apps)
-          end
+              | _,_     => let nm' := from_option (look TT nm) ((capitalize prefix) ++ nm) in
+                           parens top (print_uncurried nm' apps)
+  end
       | _ => if is_not_empty_const l then
               parens (top || inapp) (print_term prefix FT TT ctx false true f fa ++ " " ++ print_term prefix FT TT ctx false false l la)
              else print_term prefix FT TT ctx false true f fa
@@ -480,7 +477,7 @@ Section print_term.
     from_option (look TT cst_name) (prefix ++ c.2)
   | tConstruct ind l => fun bt =>
     let nm := get_constr_name ind l in
-    let nm_tt := from_option (look TT nm) ((capitalize prefix) ++ nm) in
+    let nm_tt := from_option (look TT nm) ((capitalize prefix) ++ (capitalize nm)) in
     (* print annotations for 0-ary constructors of polymorphic types (like [], None, and Map.empty) *)
     if nm_tt =? "[]" then
       "([]:" ++ print_box_type prefix TT bt ++ ")"
@@ -488,7 +485,7 @@ Section print_term.
       "(None:" ++ print_box_type prefix TT bt ++ ")"
     else if nm_tt =? "Map.empty" then
       "(Map.empty: " ++ print_box_type prefix TT bt ++ ")"
-    else capitalize nm_tt
+    else nm_tt
   | tCase (mkInd mind i as ind, nparam) t brs =>
     let fix print_branch ctx arity params (br : term) {struct br} : annots box_type br -> (_ * _) :=
           match arity return annots box_type br -> (_ * _) with

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -795,6 +795,7 @@ Definition int_ops :=
   <$
   "[@inline] let addInt (i : int) (j : int) = i + j" ;
   "[@inline] let subInt (i : int) (j : int) = i - j" ;
+  "[@inline] let subIntTruncated (a : int) (b : int) = let res = a - b in if res < 0 then 0 else res" ;
   "[@inline] let multInt (i : int) (j : int) = i * j" ;
   "[@inline] let divInt (i : int) (j : int) = i / j" ;
   "[@inline] let leInt (i : int) (j : int) = i <= j" ;

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -291,28 +291,12 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
   let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
   let TT :=
       (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
-  s <- printLiquidityDefs prefix Σ TT inline ignore
+  s <- printLiquidityDefs_ prefix Σ TT inline ignore
                          liquidity_call_ctx
                          m.(lmd_init_prelude)
                              init_nm receive_nm ;;
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
-
-Definition liquidity_extraction_test {msg ctx params storage operation : Type}
-           (prefix : string)
-           (TT_defs : list (kername *  string))
-           (TT_ctors : MyEnv.env string)
-           (m : LiquidityMod msg ctx params storage operation) :=
-  '(Σ,_) <- tmQuoteRecTransp m false ;;
-  init_nm <- extract_def_name m.(lmd_init);;
-  receive_nm <- extract_def_name m.(lmd_receive);;
-  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
-  let TT :=
-      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
-  tmEval lazy
-             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
-             | Ok a => a
-             | Err _ => [] end).
 
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -59,7 +59,7 @@ Arguments lmd_entry_point {_ _ _ _ _}.
 Definition overridden_masks (kn : kername) : option bitmask :=
   if eq_kername kn <%% @AddressMap.empty %%> then Some [true]
   else None.
-  
+
 (* Machinery for specializing chain base *)
 Definition extract_template_env_specialize
            (params : extract_template_env_params)
@@ -71,7 +71,6 @@ Definition extract_template_env_specialize
   Σ <- specialize_ChainBase_env Σ ;;
   wfΣ <- check_wf_env_func params Σ;;
   extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
->>>>>>> liq extraction with chainbase
 
 (* Extract an environment with some minimal checks. This assumes the environment
    is well-formed (to make it computable from within Coq) but furthermore checks that the

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -59,6 +59,19 @@ Arguments lmd_entry_point {_ _ _ _ _}.
 Definition overridden_masks (kn : kername) : option bitmask :=
   if eq_kername kn <%% @AddressMap.empty %%> then Some [true]
   else None.
+  
+(* Machinery for specializing chain base *)
+Definition extract_template_env_specialize
+           (params : extract_template_env_params)
+           (Σ : global_env)
+           (seeds : KernameSet.t)
+           (ignore : kername -> bool) : result ExAst.global_env string :=
+  let Σ := SafeTemplateChecker.fix_global_env_universes Σ in
+  let Σ := TemplateToPCUIC.trans_global_decls Σ in
+  Σ <- specialize_ChainBase_env Σ ;;
+  wfΣ <- check_wf_env_func params Σ;;
+  extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
+>>>>>>> liq extraction with chainbase
 
 (* Extract an environment with some minimal checks. This assumes the environment
    is well-formed (to make it computable from within Coq) but furthermore checks that the
@@ -88,6 +101,7 @@ Definition extract_specialize (to_inline :  kername -> bool)
            (extract_ignore : kername -> bool)
            (Σ : global_env) : TemplateMonad ExAst.global_env
   := extract_template_env_certifying_passes specialize_ChainBase_env (extract_liquidity_within_coq to_inline seeds) Σ seeds extract_ignore.
+
 
 Definition printLiquidityDefs_
            (extract_env : (kername -> bool) -> KernameSet.t -> (kername -> bool) -> global_env -> TemplateMonad ExAst.global_env)
@@ -150,7 +164,6 @@ Definition liquidity_ignore_default :=
 ].
 
 
-
 Definition TT_remap_default : list (kername * string) :=
   [
     (* types *)
@@ -174,7 +187,6 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% Nat.sub %%> "subNat"
   ; remap <%% Nat.leb %%> "leNat"
   ; remap <%% Nat.eqb %%> "eqNat"
-
   ; remap <%% Pos.add %%> "addNat"
   ; remap <%% Pos.sub %%> "subNat"
   ; remap <%% Pos.leb %%> "leNat"
@@ -185,11 +197,11 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% Z.ltb %%> "ltTez"
   ; remap <%% Z.eqb %%> "eqTez"
   ; remap <%% Z.gtb %%> "gtbTez"
-  ; remap <%% N.add %%> "addNat"
-  ; remap <%% N.sub %%> "subNat"
-  ; remap <%% N.leb %%> "leNat"
-  ; remap <%% N.ltb %%> "ltNat"
-  ; remap <%% N.eqb %%> "eqNat"
+  ; remap <%% N.add %%> "addInt"
+  ; remap <%% N.sub %%> "subInt"
+  ; remap <%% N.leb %%> "leInt"
+  ; remap <%% N.ltb %%> "ltInt"
+  ; remap <%% N.eqb %%> "eqInt"
   ; remap <%% andb %%> "andb"
   ; remap <%% negb %%> "not"
   ; remap <%% orb %%> "orb"
@@ -261,7 +273,7 @@ Definition wrap_in_delimiters s :=
   String.concat nl ["";"(*START*)"; s; "(*END*)"].
 
 Definition liquidity_extraction_ {msg ctx params storage operation : Type}
-           (printLiquidityDefs : string ->
+           (printLiquidityDefs_ : string ->
                                  global_env ->
                                  env string ->
                                  list kername ->
@@ -275,6 +287,7 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
   '(Σ,_) <- tmQuoteRecTransp m false ;;
   init_nm <- extract_def_name m.(lmd_init);;
   receive_nm <- extract_def_name m.(lmd_receive);;
+  let TT_defs := (TT_defs ++ TT_remap_default)%list in
   let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
   let TT :=
       (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
@@ -284,6 +297,22 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
                              init_nm receive_nm ;;
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
+
+Definition liquidity_extraction_test {msg ctx params storage operation : Type}
+           (prefix : string)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (m : LiquidityMod msg ctx params storage operation) :=
+  '(Σ,_) <- tmQuoteRecTransp m false ;;
+  init_nm <- extract_def_name m.(lmd_init);;
+  receive_nm <- extract_def_name m.(lmd_receive);;
+  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
+  let TT :=
+      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  tmEval lazy
+             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
+             | Ok a => a
+             | Err _ => [] end).
 
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.


### PR DESCRIPTION
- added liquidity extraction with chainbase specialization (cameligo extraction already has this)
- fixed some bugs in record printing so it no longer prints inductives with 1 constructor (that are *not* records) as records
- fixed bug where init prelude was printed twice
- added `truncated_sub_int` for cameligo since `sub` for `nat` has type `nat -> nat -> int` which requires special handling
- added extraction of counterrefinementtypes to cameligo, and made some small fixes to the extraction to liquidity
- fixed other small bugs in the pretty-printers