### PR TITLE
Escrow extraction, extraction improvements, and fixes.

### DIFF
--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -58,6 +58,7 @@ examples/ElmExtractTests.v
 examples/ElmForms.v
 examples/ErasureTests.v
 examples/ERC20LiquidityExtraction.v
+examples/EscrowCameLIGOExtract.v
 examples/MidlangCounterRefTypes.v
 examples/MidlangEscrow.v
 examples/RustCounter.v

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -58,7 +58,7 @@ examples/ElmExtractTests.v
 examples/ElmForms.v
 examples/ErasureTests.v
 examples/ERC20LiquidityExtraction.v
-examples/EscrowCameLIGOExtract.v
+examples/EscrowExtract.v
 examples/MidlangCounterRefTypes.v
 examples/MidlangEscrow.v
 examples/RustCounter.v

--- a/extraction/examples/CameLIGOExtractionTests.v
+++ b/extraction/examples/CameLIGOExtractionTests.v
@@ -175,7 +175,7 @@ Module Counter.
 
         (* code for the entry point *)
         lmd_entry_point := CameLIGOPretty.printWrapper (PREFIX ++ "counter") "msg" "storage" CameLIGO_call_ctx ++ nl
-                          ++ CameLIGOPretty.printMain |}.
+                          ++ CameLIGOPretty.printMain "storage" |}.
 
 End Counter.
 Section CounterExtraction.
@@ -203,7 +203,7 @@ Section CounterExtraction.
       that removes application of boxes to constants and constructors. *)
 
   Time MetaCoq Run
-      (t <- CameLIGO_extract PREFIX [] TT_remap_counter TT_rename LIGO_COUNTER_MODULE ;;
+      (t <- CameLIGO_extract PREFIX [] TT_remap_counter TT_rename CameLIGO_call_ctx LIGO_COUNTER_MODULE ;;
         tmDefinition LIGO_COUNTER_MODULE.(lmd_module_name) t).
 
   (* NOTE: running computations inside [TemplateMonad] is quite slow.
@@ -213,7 +213,7 @@ Section CounterExtraction.
   (** This command adds [cameLIGO_counter_prepared] to the environment,
       which can be evaluated later *)
   Time MetaCoq Run
-       (CameLIGO_prepare_extraction PREFIX [] TT_remap_counter TT_rename LIGO_COUNTER_MODULE).
+       (CameLIGO_prepare_extraction PREFIX [] TT_remap_counter TT_rename CameLIGO_call_ctx LIGO_COUNTER_MODULE).
 
   Time Definition cameLIGO_counter_1 := Eval vm_compute in cameLIGO_counter_prepared.
 
@@ -254,6 +254,7 @@ Module Crowdfunding.
     end.
 
   Open Scope string_scope.
+  Definition simple_ctx := "((timestamp * (address * (tez * tez))) * msg_coq)".
 
   Definition CF_MODULE :
     CameLIGOMod params SimpleCallCtx (time_coq × Z × address_coq) storage SimpleActionBody_coq :=
@@ -287,11 +288,11 @@ Module Crowdfunding.
       (* code for the entry point *)
       lmd_entry_point :=
         CameLIGOPretty.printWrapper (PREFIX ++ "crowdfunding_receive")
-                                    "((timestamp * (address * (tez * tez))) * msg_coq)"
+                                    simple_ctx
                                     "storage"
                                     CameLIGO_call_ctx
                                     ++ nl
-                        ++ CameLIGOPretty.printMain |}.
+                        ++ CameLIGOPretty.printMain simple_ctx |}.
 
   (** We run the extraction procedure inside the [TemplateMonad].
       It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
@@ -331,7 +332,7 @@ Section CrowdfundingExtraction.
     ; ("tt", "()") ].
 
   Time MetaCoq Run
-       (CameLIGO_prepare_extraction PREFIX [] TT_remap_crowdfunding TT_rename_crowdfunding CF_MODULE).
+       (CameLIGO_prepare_extraction PREFIX [] TT_remap_crowdfunding TT_rename_crowdfunding simple_ctx CF_MODULE).
 
   Time Definition cameLIGO_crowdfunding := Eval vm_compute in cameLIGO_crowdfunding_prepared.
 
@@ -388,7 +389,7 @@ Section EIP20TokenExtraction.
 
       (* code for the entry point *)
       lmd_entry_point := CameLIGOPretty.printWrapper (PREFIX ++ "eip20token") "msg" "state" CameLIGO_contractCallContext ++ nl
-                        ++ CameLIGOPretty.printMain |}.
+                        ++ CameLIGOPretty.printMain CameLIGO_contractCallContext|}.
 
   Definition TT_remap_eip20token : list (kername * string) :=
     TT_remap_default ++ [
@@ -431,7 +432,7 @@ Section EIP20TokenExtraction.
     ; ("tt", "()") ].
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction PREFIX TT_inlines_eip20token TT_remap_eip20token TT_rename_eip20token LIGO_EIP20Token_MODULE).
+  (CameLIGO_prepare_extraction PREFIX TT_inlines_eip20token TT_remap_eip20token TT_rename_eip20token CameLIGO_contractCallContext LIGO_EIP20Token_MODULE).
 
   Time Definition cameLIGO_eip20token := Eval vm_compute in cameLIGO_eip20token_prepared.
 
@@ -560,11 +561,11 @@ Section TestExtractionPlayground.
 
       (* code for the entry point *)
       lmd_entry_point := CameLIGOPretty.printWrapper (PREFIX ++ "eip20token") "msg" "state" CameLIGO_contractCallContext ++ nl
-                        ++ CameLIGOPretty.printMain |}.
+                        ++ CameLIGOPretty.printMain CameLIGO_contractCallContext|}.
 
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction PREFIX [] TT_remap_eip20token TT_rename_eip20token playground_module).
+  (CameLIGO_prepare_extraction PREFIX [] TT_remap_eip20token TT_rename_eip20token CameLIGO_contractCallContext playground_module).
 
   Time Definition playground_mod := Eval vm_compute in playground_mod_prepared.
 

--- a/extraction/examples/CounterRefinementTypes.v
+++ b/extraction/examples/CounterRefinementTypes.v
@@ -245,7 +245,7 @@ Definition dummy_chain :=
                                       "storage" 
                                       CameLIGO_call_ctx 
                                       ++ nl
-                                      ++ CameLIGOPretty.printMain |}.
+                                      ++ CameLIGOPretty.printMain CameLIGO_call_ctx |}.
 
   (** We run the extraction procedure inside the [TemplateMonad].
       It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
@@ -254,12 +254,12 @@ Definition dummy_chain :=
   Definition to_inline_ligo := [<%% bool_rect %%>; <%% bool_rec %%>].
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction PREFIX to_inline_ligo TT_remap_ligo TT_rename_ligo COUNTER_MODULE_LIGO).
+  (CameLIGO_prepare_extraction PREFIX to_inline_ligo TT_remap_ligo TT_rename_ligo CameLIGO_call_ctx COUNTER_MODULE_LIGO).
 
   Time Definition cameLIGO_counter := Eval vm_compute in cameligo_counter_prepared.
 
   MetaCoq Run (tmMsg cameLIGO_counter).
   
-  Redirect "examples/liquidity-extract/CounterRefinementTypes.mligo" Compute cameLIGO_counter.
+  Redirect "examples/cameligo-extract/CounterRefinementTypes.mligo" Compute cameLIGO_counter.
     
 End CameLIGOExtractionSetup.

--- a/extraction/examples/EscrowCameLIGOExtract.v
+++ b/extraction/examples/EscrowCameLIGOExtract.v
@@ -1,0 +1,322 @@
+(** * Extraction of Escrow to CameLIGO *)
+
+Section Escrow.
+
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+From Coq Require Import ZArith.
+From Coq Require Import Permutation.
+From Coq Require Import Psatz.
+Require Import Automation.
+Require Import Blockchain.
+Require Import Extras.
+Require Import Monads.
+Require Import ResultMonad.
+Require Import Serializable.
+From ConCert.Utils Require Import RecordUpdate.
+
+Import ListNotations.
+Import RecordSetNotations.
+
+Section Escrow.
+Context `{Base : ChainBase}.
+Set Primitive Projections.
+Set Nonrecursive Elimination Schemes.
+
+Record Setup :=
+  build_setup {
+      setup_buyer : Address;
+    }.
+
+Inductive NextStep :=
+(* Waiting for buyer to commit itemvalue * 2 *)
+| buyer_commit
+(* Waiting for buyer to confirm item received *)
+| buyer_confirm
+(* Waiting for buyer and seller to withdraw their funds. *)
+| withdrawals
+(* No next step, sale is done. *)
+| no_next_step.
+
+Record State :=
+  build_state {
+      last_action : nat;
+      next_step : NextStep;
+      seller : Address;
+      buyer : Address;
+      seller_withdrawable : Amount;
+      buyer_withdrawable : Amount;
+    }.
+
+Inductive Msg :=
+| commit_money
+| confirm_item_received
+| withdraw.
+
+MetaCoq Run (make_setters State).
+
+Global Instance Setup_serializable : Serializable Setup :=
+  Derive Serializable Setup_rect<build_setup>.
+
+Global Instance NextStep_serializable : Serializable NextStep :=
+  Derive Serializable NextStep_rect<buyer_commit, buyer_confirm, withdrawals, no_next_step>.
+
+Global Instance State_serializable : Serializable State :=
+  Derive Serializable State_rect<build_state>.
+
+Global Instance Msg_serializable : Serializable Msg :=
+  Derive Serializable Msg_rect<commit_money, confirm_item_received, withdraw>.
+
+(* workaround for extraction *)
+Definition _50 : nat := 50.
+Definition _4 : Z := 4.
+Definition _3 : Z := 3.
+Definition _2 : Z := 2.
+
+
+Open Scope Z.
+Open Scope bool_scope.
+Definition init (chain : Chain) (ctx : ContractCallContext) (setup : Setup)
+  : option State :=
+  let seller := ctx_from ctx in
+  let buyer := setup_buyer setup in
+  if negb (buyer =? seller)%address && 
+     negb (ctx_amount ctx =? 0) &&
+     Z.even (ctx_amount ctx)
+  then Some (build_state (current_slot chain) buyer_commit seller buyer 0 0)
+  else None.
+
+Definition receive
+           (chain : Chain) (ctx : ContractCallContext)
+           (state : State) (msg : option Msg)
+  : option (State * list ActionBody) :=
+  match msg, next_step state with
+  | Some commit_money, buyer_commit =>
+    let item_price := (ctx_contract_balance ctx - ctx_amount ctx) / _2 in
+    let expected := item_price * _2 in
+    if (ctx_from ctx =? buyer state)%address then 
+      if ctx_amount ctx =? expected then 
+      let new_state := {|
+        last_action := current_slot chain;
+        next_step := buyer_confirm;
+        seller := state.(seller);
+        buyer := state.(buyer);
+        seller_withdrawable := state.(seller_withdrawable);
+        buyer_withdrawable := state.(buyer_withdrawable);
+      |} in
+      Some (new_state, [])
+      else None
+    else None
+  | Some confirm_item_received, buyer_confirm =>
+    let item_price := ctx_contract_balance ctx / _4 in
+    if (ctx_from ctx =? buyer state)%address then
+      if ctx_amount ctx =? 0 then
+      let new_state := {|
+        last_action := state.(last_action);
+        seller := state.(seller);
+        buyer := state.(buyer);
+        seller_withdrawable := item_price * _3;
+        buyer_withdrawable := item_price;
+        next_step := withdrawals;
+      |} in
+      Some (new_state, [])
+      else None
+    else None
+  | Some withdraw, withdrawals =>
+    if ctx_amount ctx =? 0 then
+      let from := ctx_from ctx in
+      do '(to_pay, new_state) <-
+        match from =? buyer state, from =? seller state with
+        | true, _ => Some (buyer_withdrawable state, state<|buyer_withdrawable := 0|>)
+        | _, true => Some (seller_withdrawable state, state<|seller_withdrawable := 0|>)
+        | _, _ => None
+        end%address;
+      if 0 <? to_pay then
+        let new_state := if (buyer_withdrawable new_state =? 0) && (seller_withdrawable new_state =? 0)
+                         then new_state<|next_step := no_next_step|>
+                         else new_state in
+        Some (new_state, [act_transfer (ctx_from ctx) to_pay])
+      else None
+    else None
+  | Some withdraw, buyer_commit =>
+    if (ctx_amount ctx =? 0)
+       && negb (last_action state + _50 <? current_slot chain)%nat
+       && (ctx_from ctx =? seller state)%address then
+      let balance := ctx_contract_balance ctx in
+      Some (state<|next_step := no_next_step|>, [act_transfer (seller state) balance])
+    else None
+  | _, _ => None
+  end.
+
+End Escrow.
+
+
+From Coq Require Import PeanoNat ZArith Notations Bool.
+
+From MetaCoq.Template Require Import Loader.
+From MetaCoq.Erasure Require Import Loader.
+
+From ConCert Require Import MyEnv.
+(* From ConCert.Embedding Require Import Notations CustomTactics. *)
+(* From ConCert.Embedding.Extraction Require Import PreludeExt. *)
+From ConCert.Extraction Require Import CameLIGOPretty CameLIGOExtract Common Extraction.
+From ConCert.Embedding.Extraction Require Import SimpleBlockchainExt.
+(* From ConCert.Embedding.Extraction Require Import PreludeExt. *)
+
+From ConCert.Execution Require Import Blockchain.
+From ConCert.Execution.Examples Require Import Common.
+
+From Coq Require Import List Ascii String.
+Local Open Scope string_scope.
+Require ContractMonads.
+
+From MetaCoq.Template Require Import All.
+
+Import ListNotations.
+Import MonadNotation.
+
+Open Scope Z.
+
+Definition PREFIX := "".
+
+
+Definition contractcallcontextDef := "type cctx = (address * (address * (tez * tez)))".
+
+(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+Definition TT_remap_ligo : list (kername * string) :=
+  [
+    remap <%% Amount %%> "tez"
+  ; remap <%% Nat.add %%> "addN"
+  ; remap <%% Nat.ltb %%> "ltbN"
+  ; remap <%% Nat.mul %%> "multN"
+  ; remap <%% Z.add %%> "addTez"
+  ; remap <%% Z.mul %%> "multTez"
+  ; remap <%% Z.sub %%> "subTez"
+  ; remap <%% Z.leb %%> "leTez"
+  ; remap <%% Z.ltb %%> "ltTez"
+  ; remap <%% Z.div %%> "divTez"
+  ; remap <%% Z.eqb %%> "eqTez"
+  ; remap <%% Z %%> "tez"
+
+  ; remap <%% @ActionBody %%> "operation"
+  ; remap <%% @ContractCallContext %%> "cctx"
+  ; remap <%% @current_slot %%> "current_slot" (* small hack to avoid generating the definition of current_slot *)
+  ; remap <%% @ctx_from %%> "(fun (c : cctx) -> c.0)" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_contract_address %%> "(fun (c : cctx) -> c.1.0)" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_contract_balance %%> "(fun (c : cctx) -> c.1.1.0)" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_amount %%> "(fun (c : cctx) -> c.1.1.1)" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @address_eqb %%> "eq_addr"
+
+  ; remap <%% _2 %%> "2tez"
+  ; remap <%% _3 %%> "3tez"
+  ; remap <%% _4 %%> "4tez"
+  ; remap <%% _50 %%> "50n"
+
+  ; remap <%% @List.fold_left %%> "List.fold"
+  ; remap <%% @List.map %%> "List.map"
+  ; remap <%% @List.find %%> "List.find"
+  ; remap <%% @List.length %%> "List.length"
+  ; remap <%% @List.app %%> "List.append"
+  ].
+(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+Definition TT_rename_ligo : list (string * string):=
+ 
+  [ ("Some", "Some")
+  ; ("None", "None")
+  ; ("Zpos" ,"%int")
+  ; ("Npos" ,"(fun (n:nat) -> n)")
+  ; ("Zneg" ,"-")
+  ; ("Z0" ,"0tez")
+  ; ("N0" ,"0")
+  ; ("xH" ,"0")
+  ; ("1" ,"1")
+  ; ("nil", "[]")
+  ; ("true", "true")
+  ; ("tt", "()")
+  ].
+  
+Definition dummy_chain :=
+      "type chain = {
+        chain_height     : nat;
+        current_slot     : nat;
+        finalized_height : nat;
+      }"
+  ++ nl
+  ++ "let dummy_chain : chain = {
+        chain_height     = Tezos.level;
+        current_slot     = Tezos.level;
+        finalized_height = Tezos.level;
+      }".
+
+  Definition escrow_init_wrapper (cctx : ContractCallContext) (s : Escrow.Setup * Chain) : option Escrow.State := 
+    Escrow.init (snd s) cctx (fst s).
+  
+  Definition escrow_receive (c : Chain) (cctx : ContractCallContext) (s : State) (msg : option Escrow.Msg) : option (list ActionBody * Escrow.State) :=
+    match Escrow.receive c cctx s msg with
+    | Some (s, acts) => Some (acts, s)
+    | None => None
+    end.
+  
+  Definition callctx := "(Tezos.sender, (Tezos.sender, (Tezos.amount, Tezos.balance)))".
+
+  Definition ESCROW_MODULE_LIGO : CameLIGOMod Escrow.Msg ContractCallContext (Escrow.Setup * Chain) Escrow.State ActionBody :=
+    {| (* a name for the definition with the extracted code *)
+      lmd_module_name := "cameligo_escrow" ;
+
+      (* definitions of operations on pairs and ints *)
+      lmd_prelude := concat nl [CameLIGOPrelude; dummy_chain; contractcallcontextDef];
+
+      (* initial storage *)
+      lmd_init := escrow_init_wrapper ;
+
+      (* no extra operations in [init] are required *)
+      lmd_init_prelude := "" ;
+
+      (* the main functionality *)
+      lmd_receive := escrow_receive ;
+
+      lmd_receive_prelude := "";
+      (* code for the entry point *)
+      lmd_entry_point := printWrapper (PREFIX ++ "escrow_receive") 
+                                      (PREFIX ++"msg") 
+                                      "state" 
+                                      callctx 
+                                      ++ nl
+                                      ++ CameLIGOPretty.printMain "state" |}.
+  
+  Definition to_inline : list kername := 
+    [
+      <%% Monads.Monad_option %%>
+    ; <%% @Monads.bind %%>
+    ; <%% @Monads.ret %%>
+    ; <%% @Monads.lift %%>
+    ; <%% bool_rect %%>
+    ; <%% bool_rec %%>
+    ; <%% option_map %%>
+    ; <%% @Extras.with_default %%>
+  
+    ; <%% @Escrow.setter_from_getter_State_last_action %%>
+    ; <%% @Escrow.setter_from_getter_State_next_step %%>
+    ; <%% @Escrow.setter_from_getter_State_seller %%>
+    ; <%% @Escrow.setter_from_getter_State_buyer %%>
+    ; <%% @Escrow.setter_from_getter_State_seller_withdrawable %%>
+    ; <%% @Escrow.setter_from_getter_State_buyer_withdrawable %%>
+
+    ; <%% @Escrow.set_State_last_action %%>
+    ; <%% @Escrow.set_State_next_step %%>
+    ; <%% @Escrow.set_State_seller %%>
+    ; <%% @Escrow.set_State_buyer %%>
+    ; <%% @Escrow.set_State_seller_withdrawable %%>
+    ; <%% @Escrow.set_State_buyer_withdrawable %%>
+
+    ].
+  Time MetaCoq Run
+  (CameLIGO_prepare_extraction PREFIX to_inline TT_remap_ligo TT_rename_ligo callctx ESCROW_MODULE_LIGO).
+
+  Time Definition cameLIGO_escrow := Eval vm_compute in cameligo_escrow_prepared.
+
+  MetaCoq Run (tmMsg cameLIGO_escrow).
+  
+  Redirect "examples/liquidity-extract/EscrowRefinementTypes.mligo" Compute cameLIGO_escrow.
+    
+End CameLIGOExtractionSetup.

--- a/extraction/examples/StackInterpreter.v
+++ b/extraction/examples/StackInterpreter.v
@@ -398,10 +398,10 @@ Module CameLIGOInterp.
        lmd_entry_point :=
               CameLIGOPretty.printWrapper (PREFIX ++ "receive_") "params" "value list" CameLIGO_call_ctx
                           ++ nl
-                          ++ CameLIGOPretty.printMain |}.
+                          ++ CameLIGOPretty.printMain CameLIGO_call_ctx |}.
 
     Time MetaCoq Run
-    (CameLIGO_prepare_extraction PREFIX [] TT_remap_ligo TT_rename LIGO_INTERP_MODULE  ).
+    (CameLIGO_prepare_extraction PREFIX [] TT_remap_ligo TT_rename CameLIGO_call_ctx LIGO_INTERP_MODULE  ).
 
     Time Definition cameligo_interp := Eval vm_compute in cameligo_interp_prepared.
 

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -482,7 +482,8 @@ Section print_term.
                                                       |> concat "; " in
               "({" ++ field_decls_printed ++ "}: " ++ print_box_type prefix TT bt ++ ")"
           | _,_ => 
-              let nm' := from_option (look TT nm) ((capitalize prefix) ++ nm) in
+              (* constructors must be capitalized *)
+              let nm' := from_option (look TT nm) (capitalize (prefix ++ nm)) in
               parens top (print_uncurried nm' apps)
         end
       | _ => if is_not_empty_const l then
@@ -495,7 +496,7 @@ Section print_term.
     from_option (look TT cst_name) (prefix ++ c.2)
   | tConstruct ind l => fun bt =>
     let nm := get_constr_name ind l in
-    let nm_tt := from_option (look TT nm) ((capitalize prefix) ++ (capitalize nm)) in
+    let nm_tt := from_option (look TT nm) (capitalize (prefix ++ nm)) in
     (* print annotations for 0-ary constructors of polymorphic types (like [], None, and Map.empty) *)
     if nm_tt =? "[]" then
       "([]:" ++ print_box_type prefix TT bt ++ ")"

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -831,8 +831,9 @@ Definition tez_ops :=
   "[@inline] let eqTez (a : tez ) (b : tez ) = a = b" ;
   "[@inline] let natural_to_mutez (a: nat): tez = a * 1mutez" ;
   "[@inline] let divTez (a : tez) (b : tez) : tez = natural_to_mutez (a/b)" ;
-  "[@inline] let multTez (n : tez) (m : tez) = (n/1tez) * m"
-    $>.
+  "[@inline] let multTez (n : tez) (m : tez) = (n/1tez) * m";
+  "[@inline] let evenTez (i : tez) = (i mod 2n) = 0tez"
+  $>.
 Definition nat_ops :=
   <$
   "[@inline] let addN (a : nat ) (b : nat ) = a + b" ;

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -421,7 +421,7 @@ Section print_term.
       else if (nm =? "cons") then
         parens top (concat " :: " apps)
       (* is it a transfer *)
-      else if (nm =? "Act_transfer") then print_transfer apps
+      else if (nm =? "act_transfer") then print_transfer apps
       (* is it a record declaration? *)
       else match is_name_remapped nm TT, is_record_constr b with
         | false, Some oib => let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in 

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -149,6 +149,7 @@ Section print_term.
       ^ " : "
       ^ print_box_type prefix TT vars ty.
 
+
   Definition print_inductive (prefix : string) (TT : env string)
              (oib : ExAst.one_inductive_body) :=
     let ind_nm := from_option (lookup TT oib.(ExAst.ind_name))
@@ -158,16 +159,20 @@ Section print_term.
         if (Nat.eqb #|oib.(ind_type_vars)| 0) then ""
         else let ps := concat "," (mapi (fun i v => print_type_var v i) vars) in
              (parens (Nat.ltb #|oib.(ind_type_vars)| 1) ps) ++ " " in
-    (* one-constructor inductives with non-empty ind_projs (projection identifiers) 
+    (* one-constructor inductives with non-empty ind_projs (projection identifiers)
+       and > 1 projections 
        are assumed to be records *)
     match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
-    | [build_record_ctor], _::_ =>
+    | [build_record_ctor], _::_::_ =>
       let '(_, ctors) := build_record_ctor in
       let projs_and_ctors := combine oib.(ExAst.ind_projs) ctors in
       let projs_and_ctors_printed := map (fun '(p, (proj_nm, ty)) => print_proj (capitalize prefix) TT vars (p.1, ty)) projs_and_ctors in
       "type " ++ params ++ uncapitalize ind_nm ++ " = {" ++ nl
               ++ concat (";" ++ nl) projs_and_ctors_printed ++ nl
               ++  "}"
+    (* otherwise, one-constructor inductives are printed as aliases since liquidity doesn't allow inductives with 1 constructor.  *)
+    | [(_,[ctor])], _ => "type " ++ params ++ uncapitalize ind_nm ++" = " ++  print_box_type prefix TT vars ctor.2
+    
     | _,_ => "type " ++ params ++ uncapitalize ind_nm ++" = "
             ++ nl
             ++ concat "| " (map (fun p => print_ctor (capitalize prefix) TT vars p ++ nl) oib.(ExAst.ind_ctors))
@@ -224,7 +229,23 @@ Section print_term.
     | _ => None
     end.
 
+  (* Certain names in Liquidity are reserved (like 'to' and others) so we ensure no fresh names are reserved *)
+  (* Note: for reserved names from the syntax (like 'let', 'in', 'match', etc.) we don't need to add them since
+     they are also reserved names in Coq, hence we can't write coq programs with these names anyways. *)
+  Definition is_reserved_name (id : ident) (reserved : list ident) := 
+    List.existsb (ident_eq id) reserved.
+  
+  Definition liquidity_reserved_names := 
+    [
+        "to"
+      ; "val"
+      ; "balance"
+      ; "continue"
+    ].
+
   Definition is_fresh (Γ : context) (id : ident) :=
+    negb (is_reserved_name id liquidity_reserved_names)
+    &&
     List.forallb
       (fun decl =>
          match decl.(decl_name) with
@@ -294,15 +315,35 @@ Section print_term.
     match t with
     | tConstruct (mkInd mind j as ind) i =>
       match lookup_ind_decl mind i with
-      (* Check if it has only 1 constructor, and projections are specified *)
+      (* Check if it has only 1 constructor, and projections are specified, and > 1 projections *)
       | Some oib => match ExAst.ind_projs oib, Nat.eqb 1 (List.length oib.(ExAst.ind_ctors)) with
-                    | _::_,true => Some oib
+                    | _::_::_,true => Some oib
                     | _,_ => None
                     end
       | _ => None
       end
     | _ => None
   end.
+
+  (* Definition is_one_constructor_inductive_and_not_record (t : term) := 
+    match t with
+    | tConstruct (mkInd mind j as ind) i =>
+      match lookup_ind_decl mind i with
+      | Some oib => match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
+                    | [build_record_ctor], _::_::_ => false (* it is a record *)
+                    | [(_,[_])],_  => true
+                    | _,_ => false
+                    end
+      | None => false
+      end
+    | _ => false
+    end. *)
+  Definition is_one_constructor_inductive_and_not_record (oib : ExAst.one_inductive_body) := 
+    match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
+    | [build_record_ctor], _::_::_ => false (* it is a record *)
+    | [(_,[_])],_  => true
+    | _,_ => false
+    end.  
 
   Definition is_name_remapped nm TT := 
     match (look TT nm) with
@@ -412,7 +453,12 @@ Section print_term.
     | tConst c =>
       let cst_name := string_of_kername c in
       let nm := from_option (look TT cst_name) (uncapitalize prefix ++ uncapitalize c.2) in
-      parens (top || inapp) (nm ++ " " ++ (concat " " (map (parens true) apps)))
+      if nm =? "fst" then
+        (concat " " (map (parens true) apps)) ++ ".(0)"
+      else if nm =? "snd" then
+        (concat " " (map (parens true) apps)) ++ ".(1)"
+      else
+        parens (top || inapp) (nm ++ " " ++ (concat " " (map (parens true) apps)))
     | tConstruct ind i =>
       let nm := get_constr_name ind i in
       (* is it a pair ? *)
@@ -437,8 +483,16 @@ Section print_term.
     let cst_name := string_of_kername c in
     from_option (look TT cst_name) (prefix ++ c.2)
   | tConstruct ind l =>
-    let nm := get_constr_name ind l in
-    from_option (look TT nm) (capitalize prefix ++ capitalize nm)
+    (* if it is a inductive with one constructor, and not a record, then it is an alias, so we don't print the constructor *)
+    match lookup_ind_decl ind.(inductive_mind) ind.(inductive_ind) with
+    (* Check if it has only 1 constructor, and projections are specified, and > 1 projections *)
+    | Some oib => if is_one_constructor_inductive_and_not_record oib then ""
+                  else let nm := get_constr_name ind l in
+                       from_option (look TT nm) (capitalize prefix ++ capitalize nm)
+    | None =>
+      let nm := get_constr_name ind l in
+      from_option (look TT nm) (capitalize prefix ++ capitalize nm)
+    end
   | tCase (mkInd mind i as ind, nparam) t brs =>
     match brs with
     | [] => "failwith () (* absurd case *)"
@@ -453,10 +507,19 @@ Section print_term.
                          ++ " else " ++ print_term prefix FT TT Γ true false (snd b2))
         | _ => "Error (Malformed pattern-mathing on bool: given "
                  ++ string_of_nat (List.length brs) ++ " branches " ++ ")"
-        end
-      else
-      match lookup_ind_decl mind i with
+        end    
+      else match lookup_ind_decl mind i with
       | Some oib =>
+        (* pairs are unfolded directly *)
+        (* if eq_kername mind <%% prod %%> then
+            
+              parens top
+                      ("let "
+                            ++ " = " ++ print_term prefix FT TT Γ true false t
+                            ++ " in " ++ print_term prefix FT TT Γ true false (snd b))
+            | _ => "Error (Malformed pattern-mathing on bool: given "
+                    ++ string_of_nat (List.length brs) ++ " branches " ++ ")"
+          end *)
         let fix print_branch Γ arity params br {struct br} :=
             match arity with
               | 0 => (params, print_term prefix FT TT Γ false false br)
@@ -479,10 +542,16 @@ Section print_term.
                               print_pat prefix TT "::" true b
                             else if (eq_kername mind <%% list %%>) && (na =? "nil") then
                               print_pat "" TT "[]" false b
+                            else if (eq_kername mind <%% prod %%>) then
+                              "let (" ++ concat "," (rev' b.1) ++ ") = " ++ print_term prefix FT TT Γ true false t ++ " in "
+                              ++ b.2
                             else
                             print_pat prefix TT na false b)
                          (nl ++ " | ") brs in
-        parens top
+        (* products are unfolded on the spot because pattern matching on pairs is not allowed in liquidity *)
+        if eq_kername mind <%% prod %%> then
+          parens top brs_printed
+        else parens top
                ("match " ++ print_term prefix FT TT Γ true false t
                          ++ " with " ++ nl
                          ++ brs_printed)
@@ -496,7 +565,10 @@ Section print_term.
     match lookup_ind_decl mind i with
     | Some oib =>
       match nth_error oib.(ExAst.ind_projs) k with
-      | Some (na, _) => print_term prefix FT TT Γ false false c ++ "." ++ na
+      | Some (na, _) => (* if it is a inductive with one constructor, and not a record, then it is an alias, so we don't print the projection *)
+                        if is_one_constructor_inductive_and_not_record oib then
+                          print_term prefix FT TT Γ false false c
+                        else print_term prefix FT TT Γ false false c ++ "." ++ na
       | None =>
         "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ","
                        ++ print_term prefix FT TT Γ true false c ++ ")"
@@ -681,7 +753,14 @@ Definition tez_ops :=
     ++ nl
     ++ "let[@inline] ltTez (a : tez ) (b : tez ) =  a < b"
     ++ nl
-    ++ "let[@inline] eqTez (a : tez ) (b : tez ) = a = b".
+    ++ "let[@inline] eqTez (a : tez ) (b : tez ) = a = b"
+    ++ nl
+    ++ "let[@inline] evenTez (i : tez) = match i/2tz with | Some (_, r) -> r=0tz | None -> false"
+    ++ nl 
+    ++ "let[@inline] divTez (a : tez) (b : nat) : tez = match a/b with Some(d,_) -> d | None -> 0tz"
+    ++ nl 
+    ++ "let[@inline] multTez (n : tez) (m : nat) : tez = n * m".
+
 
 Definition nat_ops :=
       "let[@inline] addNat (i : nat) (j : nat) = i + j"


### PR DESCRIPTION
- added escrow extraction to liquidity and cameligo (both compile out-of-the-box)
- improved record pretty-printing/detection in liquidity and camligo pretty printers
- fixed other small bugs in pretty printers
- improved configurability of contract call context in cameligo extraction 