### PR TITLE
BoardroomVoting Extraction (mainly to cameLIGO)

### DIFF
--- a/execution/_CoqProject
+++ b/execution/_CoqProject
@@ -21,6 +21,7 @@ theories/Serializable.v
 examples/BAT.v
 examples/BoardroomMath.v
 examples/BoardroomVoting.v
+examples/BoardroomVotingZ.v
 examples/BoardroomVotingTest.v
 examples/Common.v
 examples/Congress.v

--- a/execution/examples/BoardroomMath.v
+++ b/execution/examples/BoardroomMath.v
@@ -7,7 +7,6 @@ From Coq Require Import SetoidTactics.
 From Coq Require Import Field.
 From Coq Require Import ZArith.
 From Coq Require Import Znumtheory.
-From Bignums Require Import BigZ.
 Import List.
 
 Require Import Egcd.
@@ -1574,6 +1573,7 @@ Module Zp.
 End Zp.
 
 Module BigZp.
+  From Bignums Require Import BigZ.
   Local Open Scope bigZ.
   Fixpoint mod_pow_pos_aux (a : bigZ) (x : positive) (m : bigZ) (r : bigZ) : bigZ :=
     match x with
@@ -1821,114 +1821,5 @@ Module BigZp.
   
 End BigZp.
 
-Local Open Scope Z.
 
-Definition boardroom_axioms_Z (p : Z) :
-prime p -> BoardroomAxioms Z.
-Proof.
-intros isprime.
-pose proof (prime_ge_2 _ isprime).
-refine
-  {| elmeq a b := a mod p = b mod p;
-     elmeqb a b := a mod p =? b mod p;
-     zero := 0;
-     one := 1;
-     add a a' := (a + a') mod p;
-     mul a a' := (a * a') mod p;
-     opp a := p - a;
-     inv a := Zp.mod_inv a p;
-     pow a e := Zp.mod_pow a e p;
-     order := p;
-  |}.
-- intros x y; apply Z.eqb_spec.
-- lia.
-- constructor; auto.
-  now intros a a' a'' -> ->.
-- intros a a' aeq b b' beq.
-  autorewrite with zsimpl in *.
-  now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
-- intros a a' aeq b b' beq.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
-- intros a a' aeq.
-  autorewrite with zsimpl in *.
-  now rewrite Zminus_mod, aeq, <- Zminus_mod.
-- intros a a' aeq.
-  autorewrite with zsimpl in *.
-  now rewrite <- Zp.mod_inv_mod_idemp, aeq, Zp.mod_inv_mod_idemp.
-- intros a a' aeq e ? <-.
-  autorewrite with zsimpl in *.
-  now rewrite <- Zp.mod_pow_mod_idemp, aeq, Zp.mod_pow_mod_idemp.
-- intros a anp e e' eeq.
-  autorewrite with zsimpl in *.
-  rewrite <- (Zp.mod_pow_exp_mod _ e), <- (Zp.mod_pow_exp_mod _ e') by auto.
-  now rewrite eeq.
-- autorewrite with zsimpl in *.
-  now rewrite Z.mod_1_l, Z.mod_0_l by lia.
-- intros a b.
-  autorewrite with zsimpl in *.
-  now rewrite Z.add_comm.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  rewrite !Z.mod_mod by lia.
-  rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
-  apply f_equal2; lia.
-- intros a b.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_comm.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
-  now rewrite Z.mul_assoc.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mod_mod by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mod_mod by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  rewrite Z.mod_mod by lia.
-  now rewrite Z.mul_1_l.
-- intros a.
-  autorewrite with zsimpl in *.
-  rewrite Z.mod_mod by lia.
-  replace (p - a + a)%Z with p by lia.
-  rewrite Z.mod_same, Z.mod_0_l; lia.
-- intros a anp.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_comm, Zp.mul_mod_inv by auto.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  repeat (try rewrite Z.mul_mod_idemp_l;
-          try rewrite Z.mul_mod_idemp_r;
-          try rewrite Z.add_mod_idemp_l;
-          try rewrite Z.add_mod_idemp_r;
-          try rewrite Z.mod_mod); try lia.
-  apply f_equal2; lia.
-- intros a anp.
-  autorewrite with zsimpl in *.
-  cbn.
-  now rewrite Z.mod_1_l at 1 by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_mod, Zp.mod_pow_1_r.
-- intros a ap0.
-  autorewrite with zsimpl in *.
-  rewrite (Zp.mod_pow_exp_opp _ 1) by auto.
-  rewrite Zp.mod_pow_1_r.
-  now rewrite Zp.mod_inv_mod_idemp.
-- intros a e e' ap0.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_exp_plus by auto.
-- intros a b e ap0.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_exp_mul.
-- intros a e ap0.
-  autorewrite with zsimpl in *.
-  auto.
-- intros a ap0.
-  autorewrite with zsimpl in *.
-  auto.
-Defined.
 

--- a/execution/examples/BoardroomMath.v
+++ b/execution/examples/BoardroomMath.v
@@ -142,15 +142,15 @@ Proof.
   - apply inv_inv_l.
 Qed.
 
-Class Generator {A : Type} (field : BoardroomAxioms A) :=
-  build_generator {
+Class Generator {A : Type} (field : BoardroomAxioms A) := 
+  {
     generator : A;
     generator_nonzero : generator !== 0;
     generator_generates a : a !== 0 -> exists! e, 0 <= e < order - 1 /\ generator^e == a;
   }.
 
-Class DiscreteLog {A : Type} (field : BoardroomAxioms A) (g : Generator field) :=
-  build_log {
+Class DiscreteLog {A : Type} (field : BoardroomAxioms A) (g : Generator field) := 
+  {
     (* This is computationally intractable, but we still require it for ease of specification *)
     log : A -> Z;
     log_proper :> Proper (elmeq ==> expeq) log;
@@ -1822,4 +1822,128 @@ Module BigZp.
 End BigZp.
 
 
+
+Module Type BoardroomAxiomsZParams.
+  Parameter p : Z.
+  Parameter isprime : prime p.
+  Parameter prime_ge_2 : p >= 2.
+End BoardroomAxiomsZParams.
+
+Module BoardroomAxiomsZ (Params : BoardroomAxiomsZParams).
+Import Params.
+Local Open Scope Z_scope.
+Instance boardroom_axioms_Z : BoardroomAxioms Z.
+Proof.
+(* pose proof (prime_ge_2). *)
+(* pose proof (isprime). *)
+refine
+  {| elmeq a b := a mod p = b mod p;
+     elmeqb a b := a mod p =? b mod p;
+     zero := 0;
+     one := 1;
+     add a a' := (a + a') mod p;
+     mul a a' := (a * a') mod p;
+     opp a := p - a;
+     inv a := Zp.mod_inv a p;
+     pow a e := Zp.mod_pow a e p;
+     order := p;
+  |};
+  (* assert (p >= 2); apply prime_ge_2. ;
+  (assert (prime p); apply isprime). *)
+  pose proof (prime_ge_2);
+  pose proof (isprime).
+  
+- intros x y; apply Z.eqb_spec.
+- lia.
+- constructor; auto.
+  now intros a a' a'' -> ->.
+- intros a a' aeq b b' beq.
+  autorewrite with zsimpl in *.
+  now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
+- intros a a' aeq b b' beq.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
+- intros a a' aeq.
+  autorewrite with zsimpl in *.
+  now rewrite Zminus_mod, aeq, <- Zminus_mod.
+- intros a a' aeq.
+  autorewrite with zsimpl in *.
+  now rewrite <- Zp.mod_inv_mod_idemp, aeq, Zp.mod_inv_mod_idemp.
+- intros a a' aeq e ? <-.
+  autorewrite with zsimpl in *.
+  now rewrite <- Zp.mod_pow_mod_idemp, aeq, Zp.mod_pow_mod_idemp.
+- intros a anp e e' eeq.
+  autorewrite with zsimpl in *.
+  rewrite <- (Zp.mod_pow_exp_mod _ e), <- (Zp.mod_pow_exp_mod _ e') by auto.
+  now rewrite eeq.
+- autorewrite with zsimpl in *.
+  now rewrite Z.mod_1_l, Z.mod_0_l by lia.
+- intros a b.
+  autorewrite with zsimpl in *.
+  now rewrite Z.add_comm.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  rewrite !Z.mod_mod by lia.
+  rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
+  apply f_equal2; lia.
+- intros a b.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_comm.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
+  now rewrite Z.mul_assoc.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mod_mod by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mod_mod by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  rewrite Z.mod_mod by lia.
+  now rewrite Z.mul_1_l.
+- intros a.
+  autorewrite with zsimpl in *.
+  rewrite Z.mod_mod by lia.
+  replace (p - a + a)%Z with p by lia.
+  rewrite Z.mod_same, Z.mod_0_l; lia.
+- intros a anp.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_comm, Zp.mul_mod_inv by auto.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  repeat (try rewrite Z.mul_mod_idemp_l;
+          try rewrite Z.mul_mod_idemp_r;
+          try rewrite Z.add_mod_idemp_l;
+          try rewrite Z.add_mod_idemp_r;
+          try rewrite Z.mod_mod); try lia.
+  apply f_equal2; lia.
+- intros a anp.
+  autorewrite with zsimpl in *.
+  cbn.
+  now rewrite Z.mod_1_l at 1 by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_mod, Zp.mod_pow_1_r.
+- intros a ap0.
+  autorewrite with zsimpl in *.
+  rewrite (Zp.mod_pow_exp_opp _ 1) by auto.
+  rewrite Zp.mod_pow_1_r.
+  now rewrite Zp.mod_inv_mod_idemp.
+- intros a e e' ap0.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_exp_plus by auto.
+- intros a b e ap0.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_exp_mul.
+- intros a e ap0.
+  autorewrite with zsimpl in *.
+  auto.
+- intros a ap0.
+  autorewrite with zsimpl in *.
+  auto.
+Defined.
+
+End BoardroomAxiomsZ.
 

--- a/execution/examples/BoardroomMath.v
+++ b/execution/examples/BoardroomMath.v
@@ -1818,4 +1818,117 @@ Module BigZp.
       autorewrite with zsimpl in *.
       auto.
   Defined.
+  
 End BigZp.
+
+Local Open Scope Z.
+
+Definition boardroom_axioms_Z (p : Z) :
+prime p -> BoardroomAxioms Z.
+Proof.
+intros isprime.
+pose proof (prime_ge_2 _ isprime).
+refine
+  {| elmeq a b := a mod p = b mod p;
+     elmeqb a b := a mod p =? b mod p;
+     zero := 0;
+     one := 1;
+     add a a' := (a + a') mod p;
+     mul a a' := (a * a') mod p;
+     opp a := p - a;
+     inv a := Zp.mod_inv a p;
+     pow a e := Zp.mod_pow a e p;
+     order := p;
+  |}.
+- intros x y; apply Z.eqb_spec.
+- lia.
+- constructor; auto.
+  now intros a a' a'' -> ->.
+- intros a a' aeq b b' beq.
+  autorewrite with zsimpl in *.
+  now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
+- intros a a' aeq b b' beq.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
+- intros a a' aeq.
+  autorewrite with zsimpl in *.
+  now rewrite Zminus_mod, aeq, <- Zminus_mod.
+- intros a a' aeq.
+  autorewrite with zsimpl in *.
+  now rewrite <- Zp.mod_inv_mod_idemp, aeq, Zp.mod_inv_mod_idemp.
+- intros a a' aeq e ? <-.
+  autorewrite with zsimpl in *.
+  now rewrite <- Zp.mod_pow_mod_idemp, aeq, Zp.mod_pow_mod_idemp.
+- intros a anp e e' eeq.
+  autorewrite with zsimpl in *.
+  rewrite <- (Zp.mod_pow_exp_mod _ e), <- (Zp.mod_pow_exp_mod _ e') by auto.
+  now rewrite eeq.
+- autorewrite with zsimpl in *.
+  now rewrite Z.mod_1_l, Z.mod_0_l by lia.
+- intros a b.
+  autorewrite with zsimpl in *.
+  now rewrite Z.add_comm.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  rewrite !Z.mod_mod by lia.
+  rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
+  apply f_equal2; lia.
+- intros a b.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_comm.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
+  now rewrite Z.mul_assoc.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mod_mod by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mod_mod by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  rewrite Z.mod_mod by lia.
+  now rewrite Z.mul_1_l.
+- intros a.
+  autorewrite with zsimpl in *.
+  rewrite Z.mod_mod by lia.
+  replace (p - a + a)%Z with p by lia.
+  rewrite Z.mod_same, Z.mod_0_l; lia.
+- intros a anp.
+  autorewrite with zsimpl in *.
+  now rewrite Z.mul_comm, Zp.mul_mod_inv by auto.
+- intros a b c.
+  autorewrite with zsimpl in *.
+  repeat (try rewrite Z.mul_mod_idemp_l;
+          try rewrite Z.mul_mod_idemp_r;
+          try rewrite Z.add_mod_idemp_l;
+          try rewrite Z.add_mod_idemp_r;
+          try rewrite Z.mod_mod); try lia.
+  apply f_equal2; lia.
+- intros a anp.
+  autorewrite with zsimpl in *.
+  cbn.
+  now rewrite Z.mod_1_l at 1 by lia.
+- intros a.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_mod, Zp.mod_pow_1_r.
+- intros a ap0.
+  autorewrite with zsimpl in *.
+  rewrite (Zp.mod_pow_exp_opp _ 1) by auto.
+  rewrite Zp.mod_pow_1_r.
+  now rewrite Zp.mod_inv_mod_idemp.
+- intros a e e' ap0.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_exp_plus by auto.
+- intros a b e ap0.
+  autorewrite with zsimpl in *.
+  now rewrite Zp.mod_pow_exp_mul.
+- intros a e ap0.
+  autorewrite with zsimpl in *.
+  auto.
+- intros a ap0.
+  autorewrite with zsimpl in *.
+  auto.
+Defined.
+

--- a/execution/examples/BoardroomVoting.v
+++ b/execution/examples/BoardroomVoting.v
@@ -179,7 +179,7 @@ Definition init : ContractIniterSetupState :=
 
 Definition ContractReceiverStateMsgState := ContractReceiver State Msg State.
 
-Definition handle_signup pk prf state caller cur_slot : ContractReceiver State Msg State := 
+Definition handle_signup pk prf state caller cur_slot : ContractReceiverStateMsgState := 
   do lift (if finish_registration_by (setup state) <? cur_slot then None else Some tt)%nat;
   do lift (if AddressMap.find caller (eligible_voters (setup state)) then Some tt else None);
   do lift (if AddressMap.find caller (registered_voters state) then None else Some tt);

--- a/execution/examples/BoardroomVoting.v
+++ b/execution/examples/BoardroomVoting.v
@@ -99,8 +99,12 @@ Import ContractMonads.
 
 Local Open Scope broom.
 
+Definition encodeA : A -> positive := countable.encode.
+Definition encodeNat : nat -> positive := countable.encode.
+
+
 Definition hash_sk_data (gv pk : A) (i : nat) : positive :=
-  H [countable.encode (generator : A); countable.encode gv; countable.encode pk; countable.encode i].
+  H [encodeA (generator : A); encodeA gv; encodeA pk; encodeNat i].
 
 (* This follows the original open vote protocol paper. It is a schnorr signature
      with the fiat-shamir heuristic applied. *)
@@ -117,7 +121,7 @@ Definition verify_secret_key_proof (pk : A) (i : nat) (proof : A * Z) : bool :=
   elmeqb gv (generator^r * (pk^z)).
 
 Definition hash_sv_data (i : nat) (pk rk a1 b1 a2 b2 : A) : positive :=
-  H (countable.encode i :: map countable.encode [pk; rk; a1; b1; a2; b2]).
+  H (encodeNat i :: map encodeA [pk; rk; a1; b1; a2; b2]).
 
 Definition secret_vote_proof (sk : Z) (rk : A) (sv : bool) (i : nat) (w r d : Z) : VoteProof :=
   let pk : A := compute_public_key sk in
@@ -156,7 +160,7 @@ Definition make_signup_msg (sk : Z) (v : Z) (i : nat) : Msg :=
 
 Definition make_commit_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) : Msg :=
   let pv := compute_public_vote (reconstructed_key pks my_index) sk sv in
-  commit_to_vote (H [countable.encode pv]).
+  commit_to_vote (H [encodeA pv]).
 
 Definition make_vote_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) (w r d : Z) : Msg :=
   let rk := reconstructed_key pks my_index in
@@ -207,7 +211,7 @@ Definition handle_submit_vote v proof state caller cur_slot : ContractReceiverSt
   do lift (if finish_vote_by (setup state) <? cur_slot then None else Some tt)%nat;
   do inf <- lift (AddressMap.find caller (registered_voters state));
   do lift (if finish_commit_by (setup state) then
-             if (H [countable.encode v] =? vote_hash inf)%positive then Some tt else None
+             if (H [encodeA v] =? vote_hash inf)%positive then Some tt else None
            else
              Some tt);
   do lift (if verify_secret_vote_proof

--- a/execution/examples/BoardroomVotingTest.v
+++ b/execution/examples/BoardroomVotingTest.v
@@ -11,12 +11,15 @@ Require Import LocalBlockchain.
 Require Import Monads.
 Require Import ResultMonad.
 Require Import Serializable.
+Require Import Common. Import AddressMap.
 
 Import ListNotations.
 Import BoardroomMathNotations.
 
+
 Local Open Scope Z.
 Local Open Scope broom.
+
 (*
 Definition modulus : bigZ := 1552518092300708935130918131258481755631334049434514313202351194902966239949102107258669453876591642442910007680288864229150803718918046342632727613031282983744380820890196288509170691316593175367469551763119843371637221007210577919.
 Definition generator : bigZ := 2.
@@ -69,10 +72,27 @@ Definition rks : list Z :=
 Definition hash_func (l : list positive) : positive :=
   N.succ_pos (fold_right (fun p a => N.lxor (Npos p) a) 1%N l).
 
+Definition AddrSize := (2^128)%N.
+Instance Base : ChainBase := LocalChainBase AddrSize.
+Instance ChainBuilder : ChainBuilderType := LocalChainBuilderDepthFirst AddrSize.
+
+Module Params <: BoardroomParams.
+  Definition A : Type := Z.
+  Definition H : list positive -> positive := hash_func.
+  Definition ser : Serializable A := _.
+  Definition axioms : BoardroomAxioms A := _.
+  Definition gen : Generator axioms := _.
+  Axiom d : DiscreteLog axioms gen.
+  Definition discr_log : DiscreteLog axioms gen := d.
+  Definition Base := Base .
+End Params.
+
+Module BV := BoardroomVoting Params. Import BV.
+
 (* Compute the signup messages that would be sent by each party.
    We just use the public key as the chosen randomness here. *)
 Definition signups : list Msg :=
-  Eval native_compute in map (fun '(sk, pk, i) => make_signup_msg hash_func sk 5 i)
+  Eval native_compute in map (fun '(sk, pk, i) => make_signup_msg sk 5 i)
                              (zip (zip sks pks) (seq 0 (length sks))).
 
 (* Compute the submit_vote messages that would be sent by each party *)
@@ -80,12 +100,8 @@ Definition signups : list Msg :=
    using the make_vote_msg function provided by the contract.
    In this example we just use the secret key as the random parameters. *)
 Definition votes : list Msg :=
-  Eval native_compute in map (fun '(i, sk, sv, rk) => make_vote_msg hash_func pks i sk sv sk sk sk)
+  Eval native_compute in map (fun '(i, sk, sv, rk) => make_vote_msg pks i sk sv sk sk sk)
                              (zip (zip (zip (seq 0 (length pks)) sks) svs) rks).
-
-Definition AddrSize := (2^128)%N.
-Instance Base : ChainBase := LocalChainBase AddrSize.
-Instance ChainBuilder : ChainBuilderType := LocalChainBuilderDepthFirst AddrSize.
 
 Definition A a :=
   BoundedN.of_Z_const AddrSize a.
@@ -105,8 +121,11 @@ Proof.
   exact tm.
 Defined.
 
+Definition voters_map : AddrMap unit := FMap.of_list (map (fun a => (a, tt)) addrs).
+
+
 Definition deploy_setup :=
-  {| eligible_voters := FMap.of_list (map (fun a => (a, tt)) addrs);
+  {| eligible_voters := voters_map;
      finish_registration_by := 3;
      finish_commit_by := None;
      finish_vote_by := 5;
@@ -125,7 +144,7 @@ Definition boardroom_example : option nat :=
              block_reward := 50; |} in
       option_of_result (builder_add_block chain next_header acts) in
   do chain <- add_block chain [];
-  let dep := build_act creator (create_deployment 0 (boardroom_voting hash_func) deploy_setup) in
+  let dep := build_act creator (create_deployment 0 boardroom_voting deploy_setup) in
   do chain <- add_block chain [dep];
   do caddr <- hd_error (FMap.keys (lc_contracts (lcb_lc chain)));
   let send addr m := build_act addr (act_call caddr 0 (serialize m)) in
@@ -135,7 +154,7 @@ Definition boardroom_example : option nat :=
   do chain <- add_block chain votes;
   let tally := build_act creator (act_call caddr 0 (serialize tally_votes)) in
   do chain <- add_block chain [tally];
-  do state <- @contract_state _ (@State _ Z) _ (lcb_lc chain) caddr;
-  BoardroomVoting.tally state.
+  do state <- contract_state (lcb_lc chain) caddr;
+  BV.tally state.
 
 Check (@eq_refl (option nat) (Some votes_for)) <<: boardroom_example = Some votes_for.

--- a/execution/examples/BoardroomVotingTest.v
+++ b/execution/examples/BoardroomVotingTest.v
@@ -24,126 +24,28 @@ Local Open Scope broom.
 Definition modulus : bigZ := 1552518092300708935130918131258481755631334049434514313202351194902966239949102107258669453876591642442910007680288864229150803718918046342632727613031282983744380820890196288509170691316593175367469551763119843371637221007210577919.
 Definition generator : bigZ := 2.
 *)
-(* Definition modulus : Z := 201697267445741585806196628073. *)
-Definition modulus : Z := 13.
+Definition modulus : Z := 201697267445741585806196628073.
+Definition four := 4%nat.
+Definition seven := 7%nat.
+Definition _1234583932 := 1234583932.
+Definition _23241 := 23241.
+Definition _159338231 := 159338231.
+
+
+(* Definition modulus : Z := 13. *)
 Definition generator : Z := 3.
 
 Axiom modulus_prime : prime modulus.
+Import Lia.
+Module ZAxiomParams <: BoardroomAxiomsZParams.
+  Definition p := modulus.
+  Definition isprime := modulus_prime.
+  Program Definition prime_ge_2 : p >= 2.
+  Proof. easy. Defined.
+End ZAxiomParams.
+Module BVZAxioms := BoardroomAxiomsZ ZAxiomParams. Import BVZAxioms.
 
-Local Open Scope Z.
-Require Import Lia.
-Definition boardroom_axioms_Z : BoardroomAxioms Z.
-Proof.
-(* pose proof (prime_ge_2 _ modulus_prime).
-pose proof (modulus_prime). *)
-refine
-  {| elmeq a b := a mod modulus = b mod modulus;
-     elmeqb a b := a mod modulus =? b mod modulus;
-     zero := 0;
-     one := 1;
-     BoardroomMath.add a a' := (a + a') mod modulus;
-     mul a a' := (a * a') mod modulus;
-     opp a := modulus - a;
-     inv a := Zp.mod_inv a modulus;
-     pow a e := Zp.mod_pow a e modulus;
-     order := modulus;
-  |}; 
-  pose proof (prime_ge_2 _ modulus_prime);
-  pose proof (modulus_prime).
-  
-- intros x y; apply Z.eqb_spec.
-- lia.
-- constructor; auto.
-  now intros a a' a'' -> ->.
-- intros a a' aeq b b' beq.
-  autorewrite with zsimpl in *.
-  now rewrite Z.add_mod, aeq, beq, <- Z.add_mod by lia.
-- intros a a' aeq b b' beq.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_mod, aeq, beq, <- Z.mul_mod by lia.
-- intros a a' aeq.
-  autorewrite with zsimpl in *.
-  now rewrite Zminus_mod, aeq, <- Zminus_mod.
-- intros a a' aeq.
-  autorewrite with zsimpl in *.
-  now rewrite <- Zp.mod_inv_mod_idemp, aeq, Zp.mod_inv_mod_idemp.
-- intros a a' aeq e ? <-.
-  autorewrite with zsimpl in *.
-  now rewrite <- Zp.mod_pow_mod_idemp, aeq, Zp.mod_pow_mod_idemp.
-- intros a anp e e' eeq.
-  autorewrite with zsimpl in *.
-  rewrite <- (Zp.mod_pow_exp_mod _ e), <- (Zp.mod_pow_exp_mod _ e') by auto.
-  now rewrite eeq.
-- autorewrite with zsimpl in *.
-  now rewrite Z.mod_1_l, Z.mod_0_l by lia.
-- intros a b.
-  autorewrite with zsimpl in *.
-  now rewrite Z.add_comm.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  rewrite !Z.mod_mod by lia.
-  rewrite Z.add_mod_idemp_l, Z.add_mod_idemp_r by lia.
-  apply f_equal2; lia.
-- intros a b.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_comm.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  repeat (try rewrite Z.mul_mod_idemp_l; try rewrite Z.mul_mod_idemp_r); try lia.
-  now rewrite Z.mul_assoc.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mod_mod by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mod_mod by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  rewrite Z.mod_mod by lia.
-  now rewrite Z.mul_1_l.
-- intros a.
-  autorewrite with zsimpl in *.
-  rewrite Z.mod_mod by lia.
-  replace (modulus - a + a)%Z with modulus by lia.
-  rewrite Z.mod_same, Z.mod_0_l; lia.
-- intros a anp.
-  autorewrite with zsimpl in *.
-  now rewrite Z.mul_comm, Zp.mul_mod_inv by auto.
-- intros a b c.
-  autorewrite with zsimpl in *.
-  repeat (try rewrite Z.mul_mod_idemp_l;
-          try rewrite Z.mul_mod_idemp_r;
-          try rewrite Z.add_mod_idemp_l;
-          try rewrite Z.add_mod_idemp_r;
-          try rewrite Z.mod_mod); try lia.
-  apply f_equal2; lia.
-- intros a anp.
-  autorewrite with zsimpl in *.
-  cbn.
-  now rewrite Z.mod_1_l at 1 by lia.
-- intros a.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_mod, Zp.mod_pow_1_r.
-- intros a ap0.
-  autorewrite with zsimpl in *.
-  rewrite (Zp.mod_pow_exp_opp _ 1) by auto.
-  rewrite Zp.mod_pow_1_r.
-  now rewrite Zp.mod_inv_mod_idemp.
-- intros a e e' ap0.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_exp_plus by auto.
-- intros a b e ap0.
-  autorewrite with zsimpl in *.
-  now rewrite Zp.mod_pow_exp_mul.
-- intros a e ap0.
-  autorewrite with zsimpl in *.
-  auto.
-- intros a ap0.
-  autorewrite with zsimpl in *.
-  auto.
-Defined.
-
-Instance axioms_instance : BoardroomAxioms Z := boardroom_axioms_Z.
+Existing Instance boardroom_axioms_Z.
 
 Lemma generator_nonzero : generator !== 0.
 Proof. discriminate. Qed.
@@ -153,19 +55,19 @@ Axiom generator_is_generator :
     ~(z == 0) ->
     exists! (e : Z), (0 <= e < order - 1)%Z /\ pow generator e == z.
 
-Instance generator_instance : Generator axioms_instance :=
+Instance generator_instance : Generator boardroom_axioms_Z :=
   {| BoardroomMath.generator := generator;
      BoardroomMath.generator_nonzero := generator_nonzero;
      generator_generates := generator_is_generator; |}.
 
-Definition num_parties : nat := 7.
-Definition votes_for : nat := 4.
+Definition num_parties : nat := seven.
+Definition votes_for : nat := four.
 
 (* a pseudo-random generator for secret keys *)
-Definition sk n := (Z.of_nat n + 1234583932) * (modulus - 23241)^159338231.
+Definition sk n := (Z.of_nat n + _1234583932) * (modulus - _23241)^_159338231.
 
 (* Make a list of secret keys, here starting at i=7 *)
-Definition sks : list Z := map sk (seq 7 num_parties).
+Definition sks : list Z := map sk (seq seven num_parties).
 
 (* Make a list of votes for each party *)
 Definition svs : list bool :=
@@ -183,8 +85,10 @@ Definition rks : list Z :=
 
 (* In this example we just use xor for the hash function, which is
    obviously not cryptographically secure. *)
+Definition oneN : N := 1%N.
+
 Definition hash_func (l : list positive) : positive :=
-  N.succ_pos (fold_right (fun p a => N.lxor (Npos p) a) 1%N l).
+  N.succ_pos (fold_left (fun a p => N.lxor (Npos p) a) l oneN).
 
   
 Definition AddrSize := (2^128)%N.
@@ -206,8 +110,12 @@ Module BV := BoardroomVoting Params. Import BV.
 
 (* Compute the signup messages that would be sent by each party.
    We just use the public key as the chosen randomness here. *)
-Definition signups : list Msg :=
-  Eval vm_compute in map (fun '(sk, pk, i) => make_signup_msg sk 5 i)
+Definition _3 := 3%nat.
+Definition _5 := 5.
+Definition _11 := 11.
+
+Time Definition signups : list Msg :=
+  Eval vm_compute in map (fun '(sk, pk, i) => make_signup_msg sk _5 i)
                              (zip (zip sks pks) (seq 0 (length sks))).
 
 (* Compute the submit_vote messages that would be sent by each party *)
@@ -231,19 +139,20 @@ Proof.
               constr:(cons (A z) tail)
     end in
   let num := eval compute in num_parties in
-  let tm := add_addr 11%Z num in
+  let tm := add_addr _11%Z num in
   let tm := eval vm_compute in tm in
   exact tm.
 Defined.
 
 Definition voters_map : AddrMap unit := AddressMap.of_list (map (fun a => (a, tt)) addrs).
 
+Definition five := 5%nat.
 
 Definition deploy_setup :=
   {| eligible_voters := voters_map;
-     finish_registration_by := 3;
+     finish_registration_by := _3;
      finish_commit_by := None;
-     finish_vote_by := 5;
+     finish_vote_by := five;
      registration_deposit := 0; |}.
 
 Local Open Scope list.

--- a/execution/examples/BoardroomVotingZ.v
+++ b/execution/examples/BoardroomVotingZ.v
@@ -1,0 +1,923 @@
+From Coq Require Import List.
+From Coq Require Import Morphisms.
+From Coq Require Import Orders.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+From Coq Require Import Permutation.
+From Coq Require Import Psatz.
+From Coq Require Import Mergesort.
+From Coq Require Program.
+From ConCert.Utils Require Import RecordUpdate.
+Require Import Automation.
+Require Import Blockchain.
+Require Import BoundedN.
+Require Import Containers.
+From stdpp Require countable.
+Require ContractMonads.
+Require Import Extras Egcd Euler.
+Require Import Monads.
+Require Import Serializable.
+Require Import Common. Import AddressMap.
+
+Import ListNotations.
+Import RecordSetNotations.
+
+
+Module Type BoardroomParams.
+  Parameter H : list positive -> positive.
+  Parameter prime : Z.
+  Parameter generator : Z.
+  Parameter Base : ChainBase.
+End BoardroomParams.
+
+Module BoardroomVoting (Params : BoardroomParams).
+Import Params.
+(* Existing Instance ser. *)
+(* Existing Instance axioms. *)
+(* Existing Instance gen. *)
+(* Existing Instance discr_log. *)
+Existing Instance Base.
+
+Definition A := Z.
+Definition elmeqb (a b : A) := a mod prime =? b mod prime.
+Definition mod_inv (a : Z) (p : Z) : Z :=
+  fst (egcd a p) mod p.
+
+Fixpoint mod_pow_pos_aux (a : Z) (x : positive) (m : Z) (r : Z) : Z :=
+  match x with
+  | x~0%positive => mod_pow_pos_aux (a * a mod m) x m r
+  | x~1%positive => mod_pow_pos_aux (a * a mod m) x m (r * a mod m)
+  | _ => r * a mod m
+  end.
+
+Definition mod_pow_pos (a : Z) (x : positive) (m : Z) : Z :=
+  mod_pow_pos_aux a x m 1.
+
+Definition mod_pow (a x p : Z) : Z :=
+  match x with
+  | Z0 => a ^ 0 mod p
+  | Zpos x => mod_pow_pos a x p
+  | Zneg x => mod_inv (mod_pow_pos a x p) p
+  end.
+
+Definition add_p a a' := (a + a') mod prime.
+Definition mul_p a a' := (a * a') mod prime.
+Definition opp_p a := prime - a.
+Definition inv_p a := mod_inv a prime.
+Definition pow_p a e := mod_pow a e prime.
+Definition order := prime.
+Delimit Scope broom_scope with broom.
+
+Module BoardroomMathNotations.
+
+  Infix "=?" := elmeqb (at level 70) : broom.
+  Notation "0" := 0%Z : broom.
+  Notation "1" := 1%Z : broom.
+  Infix "+" := add_p : broom.
+  Infix "*" := mul_p : broom.
+  Infix "^" := pow_p : broom.
+  (* Notation "a 'exp=' b" := (expeq a b) (at level 70) : broom. *)
+  (* Notation "a 'exp<>' b" := (~(expeq a b)) (at level 70) : broom. *)
+End BoardroomMathNotations.
+
+Import BoardroomMathNotations.
+Local Open Scope broom.
+
+
+(* Allow us to automatically derive Serializable instances *)
+Set Nonrecursive Elimination Schemes.
+Set Primitive Projections.
+
+Record Setup :=
+  build_setup {
+    eligible_voters : AddrMap unit;
+    finish_registration_by : nat;
+    finish_commit_by : option nat;
+    finish_vote_by : nat;
+    registration_deposit : Amount;
+  }.
+
+Record VoterInfo :=
+  build_voter_info {
+    voter_index : nat;
+    vote_hash : positive;
+    public_vote : A;
+}.
+
+Record State :=
+  build_state {
+    owner : Address;
+    registered_voters : AddrMap VoterInfo;
+    public_keys : list A;
+    setup : Setup;
+    tally : option nat;
+  }.
+
+(* w, a1, b1, a2, b2, d1, d2 *)
+Definition VoteProof := (Z * A * A * A * A * Z * Z * Z * Z)%type.
+
+Inductive Msg :=
+| signup (pk : A) (proof : A * Z)
+| commit_to_vote (hash : positive)
+| submit_vote (v : A) (proof : VoteProof)
+| tally_votes.
+
+MetaCoq Run (make_setters VoterInfo).
+MetaCoq Run (make_setters State).
+
+Global Instance Setup_serializable : Serializable Setup :=
+  Derive Serializable Setup_rect<build_setup>.
+
+Global Instance VoterInfo_serializable : Serializable VoterInfo :=
+  Derive Serializable VoterInfo_rect<build_voter_info>.
+
+Global Instance State_serializable : Serializable State :=
+  Derive Serializable State_rect<build_state>.
+
+Global Instance Msg_serializable : Serializable Msg :=
+  Derive Serializable Msg_rect<signup, commit_to_vote, submit_vote, tally_votes>.
+
+Import ContractMonads.
+
+
+Definition encodeA : A -> positive := countable.encode.
+Definition encodeNat : nat -> positive := countable.encode.
+
+
+Definition hash_sk_data (gv pk : A) (i : nat) : positive :=
+  H [encodeA (generator : A); encodeA gv; encodeA pk; encodeNat i].
+
+Definition compute_public_key (sk : Z) : A :=
+  pow_p generator sk.
+
+(* This follows the original open vote protocol paper. It is a schnorr signature
+     with the fiat-shamir heuristic applied. *)
+Definition secret_key_proof (sk : Z) (v : Z) (i : nat) : A * Z :=
+  let gv : A := pow_p generator v in
+  let pk := compute_public_key sk in
+  let z := Zpos (hash_sk_data gv pk i) in
+  let r := (v - sk * z)%Z in
+  (gv, r).
+
+
+Definition verify_secret_key_proof (pk : A) (i : nat) (proof : A * Z) : bool :=
+  let (gv, r) := proof in
+  let z := Zpos (hash_sk_data gv pk i) in
+  elmeqb gv ((pow_p generator r) * (pow_p pk z)).
+
+Definition hash_sv_data (i : nat) (pk rk a1 b1 a2 b2 : A) : positive :=
+  H (encodeNat i :: map encodeA [pk; rk; a1; b1; a2; b2]).
+Definition compute_public_vote (rk : A) (sk : Z) (sv : bool) : A :=
+  pow_p rk sk * if sv then generator else 1.
+
+Definition secret_vote_proof (sk : Z) (rk : A) (sv : bool) (i : nat) (w r d : Z) : VoteProof :=
+  let pk : A := compute_public_key sk in
+  let pv : A := compute_public_vote rk sk sv in
+  if sv then
+    let a1 : A := pow_p generator r * pow_p pk d in
+    let b1 : A := pow_p rk r * pow_p pv d in
+    let a2 : A := pow_p generator w in
+    let b2 : A := pow_p rk w in
+    let c := Zpos (hash_sv_data i pk rk a1 b1 a2 b2) in
+    let d2 := c - d in
+    let r2 := w - sk*d2 in
+    (w, a1, b1, a2, b2, d, d2, r, r2)
+  else
+    let a1 := pow_p generator w in
+    let b1 := pow_p rk w in
+    let a2 := pow_p generator r * pow_p pk d in
+    let b2 := pow_p rk r * (pow_p (pv * inv_p generator) d) in
+    let c := Zpos (hash_sv_data i pk rk a1 b1 a2 b2) in
+    let d1 := c - d in
+    let r1 := w - sk*d1 in
+    (w, a1, b1, a2, b2, d1, d, r1, r).
+
+Local Open Scope bool.
+Definition verify_secret_vote_proof (pk rk pv : A) (i : nat) (proof : VoteProof) : bool :=
+  let '(w, a1, b1, a2, b2, d1, d2, r1, r2) := proof in
+  let c := hash_sv_data i pk rk a1 b1 a2 b2 in
+  (Zpos c =? d1 + d2)%Z &&
+  (a1 =? pow_p generator r1 * pow_p pk d1)%broom &&
+  (b1 =? pow_p rk r1 * pow_p pv d1)%broom &&
+  (a2 =? pow_p generator r2 * pow_p pk d2)%broom &&
+  (b2 =? pow_p rk r2 * pow_p (pv * inv_p generator) d2)%broom.
+
+Definition make_signup_msg (sk : Z) (v : Z) (i : nat) : Msg :=
+  signup (compute_public_key sk) (secret_key_proof sk v i).
+
+Definition reconstructed_key (pks : list A) (n : nat) : A :=
+  let lprod := prod (firstn n pks) in
+  let rprod := inv_p (prod (skipn (S n) pks)) in
+  lprod * rprod.
+
+Definition make_commit_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) : Msg :=
+  let pv := compute_public_vote (reconstructed_key pks my_index) sk sv in
+  commit_to_vote (H [encodeA pv]).
+
+Definition make_vote_msg (pks : list A) (my_index : nat) (sk : Z) (sv : bool) (w r d : Z) : Msg :=
+  let rk := reconstructed_key pks my_index in
+  submit_vote (compute_public_vote rk sk sv)
+              (secret_vote_proof sk rk sv my_index w r d).
+
+(* A necessary aliasing to make extraction work *)
+Definition ContractIniterSetupState := ContractIniter Setup State.
+
+Definition init : ContractIniterSetupState :=
+  do owner <- lift caller_addr;
+  do setup <- deployment_setup;
+  do lift (if finish_registration_by setup <? finish_vote_by setup then Some tt else None)%nat;
+  accept_deployment
+    {| owner := owner;
+       registered_voters := AddressMap.empty;
+       public_keys := [];
+       setup := setup;
+       tally := None; |}.
+
+Definition ContractReceiverStateMsgState := ContractReceiver State Msg State.
+
+Definition handle_signup pk prf state caller cur_slot : ContractReceiverStateMsgState := 
+  do lift (if finish_registration_by (setup state) <? cur_slot then None else Some tt)%nat;
+  do lift (if AddressMap.find caller (eligible_voters (setup state)) then Some tt else None);
+  do lift (if AddressMap.find caller (registered_voters state) then None else Some tt);
+  do amt <- lift call_amount;
+  do lift (if (amt =? (registration_deposit (setup state)))%Z then Some tt else None);
+  do lift (if Z.of_nat (length (public_keys state)) <? order - 2 then Some tt else None);
+  let index := length (public_keys state) in
+  do lift (if verify_secret_key_proof pk index prf then Some tt else None);
+  let inf := {| voter_index := index;
+                vote_hash := 1%positive;
+                public_vote := 0; |} in
+  let new_state := state<|registered_voters ::= AddressMap.add caller inf|>
+                        <|public_keys ::= fun l => l ++ [pk]|> in
+  accept_call new_state.
+
+
+Definition handle_commit_to_vote hash state caller cur_slot : ContractReceiverStateMsgState := 
+  do commit_by <- lift (finish_commit_by (setup state));
+  do lift (if commit_by <? cur_slot then None else Some tt)%nat;
+  do inf <- lift (AddressMap.find caller (registered_voters state));
+  let inf := inf<|vote_hash := hash|> in
+  accept_call (state<|registered_voters ::= AddressMap.add caller inf|>).
+
+Definition handle_submit_vote v proof state caller cur_slot : ContractReceiverStateMsgState :=
+  do lift (if finish_vote_by (setup state) <? cur_slot then None else Some tt)%nat;
+  do inf <- lift (AddressMap.find caller (registered_voters state));
+  do lift (if finish_commit_by (setup state) then
+             if (H [encodeA v] =? vote_hash inf)%positive then Some tt else None
+           else
+             Some tt);
+  do lift (if verify_secret_vote_proof
+                (nth (voter_index inf) (public_keys state) 0)
+                (reconstructed_key (public_keys state) (voter_index inf))
+                v
+                (voter_index inf)
+                proof then Some tt else None);
+  let inf := inf<|public_vote := v|> in
+  accept_call (state<|registered_voters ::= AddressMap.add caller inf|>).
+
+Fixpoint bruteforce_tally_aux
+          (n : nat)
+          (votes_product : A) : option nat :=
+  if pow_p generator (Z.of_nat n) =? votes_product then
+    Some n
+  else
+    if (n =? 0)%nat then None
+    else bruteforce_tally_aux (pred n) votes_product
+    %nat.
+
+Definition bruteforce_tally (votes : list A) : option nat :=
+  bruteforce_tally_aux (length votes) (prod votes).
+
+Definition handle_tally_votes state cur_slot : ContractReceiverStateMsgState :=
+  do lift (if cur_slot <? finish_vote_by (setup state) then None else Some tt)%nat;
+  do lift (match tally state with | Some _ => None | None => Some tt end);
+  let voters := AddressMap.values (registered_voters state) in
+  do lift (if existsb
+                (fun vi => if elmeqb (public_vote vi) 0 then true else false)
+                voters then None else Some tt);
+  let votes := map public_vote voters in
+  do res <- lift (bruteforce_tally votes);
+  accept_call (state<|tally := Some res|>).
+
+Definition receive : ContractReceiverStateMsgState :=
+  do state <- my_state;
+  do caller <- lift caller_addr;
+  do cur_slot <- lift current_slot;
+  do msg <- call_msg >>= lift;
+  match msg with
+  | signup pk prf => handle_signup pk prf state caller cur_slot
+  | commit_to_vote hash => handle_commit_to_vote hash state caller cur_slot
+  | submit_vote v proof => handle_submit_vote v proof state caller cur_slot
+  | tally_votes => handle_tally_votes state cur_slot
+  end.
+
+Definition boardroom_voting : Contract Setup Msg State :=
+  build_contract init receive.
+
+Section Theories.
+
+Record SecretVoterInfo :=
+  build_secret_voter_info {
+    svi_index : nat;
+    (* Secret key *)
+    svi_sk : Z;
+    (* Chosen randomness for knowledge of secret key proof *)
+    svi_sk_r : Z;
+    (* Secret vot e*)
+    svi_sv : bool;
+    (* Chosen random w for vote proof *)
+    svi_sv_w : Z;
+    (* Chosen random r for vote proof *)
+    svi_sv_r : Z;
+    (* Chosen random d for vote proof *)
+    svi_sv_d : Z;
+  }.
+
+MetaCoq Run (make_setters SecretVoterInfo).
+
+(* For correctness we assume that all signups and vote messages were
+   created using the make_signup_msg and make_vote_msg functions from
+   the contract *)
+Fixpoint MsgAssumption
+         (pks : list A)
+         (parties : Address -> SecretVoterInfo)
+         (calls : list (ContractCallInfo Msg)) : Prop :=
+  match calls with
+  | call :: calls =>
+    let party := parties (Blockchain.call_from call) in
+    match Blockchain.call_msg call with
+    | Some (signup pk prf as m) => m = make_signup_msg (svi_sk party) (svi_sk_r party)
+                                                       (svi_index party)
+    | Some (submit_vote _ _ as m) =>
+      m = make_vote_msg
+            pks
+            (svi_index party)
+            (svi_sk party)
+            (svi_sv party)
+            (svi_sv_w party)
+            (svi_sv_r party)
+            (svi_sv_d party)
+    | _ => True
+    end /\ MsgAssumption pks parties calls
+  | [] => True
+  end.
+
+Definition signups (calls : list (ContractCallInfo Msg)) : list (Address * A) :=
+  (* reverse the signups since the calls will have the last one at the head *)
+  rev (map_option (fun call => match Blockchain.call_msg call with
+                               | Some (signup pk prf) => Some (Blockchain.call_from call, pk)
+                               | _ => None
+                               end) calls).
+
+(* The index map and public keys list provided also needs to match the
+   order in which parties signed up in the contract. *)
+Definition SignupOrderAssumption
+           (pks : list A)
+           (parties : Address -> SecretVoterInfo)
+           (calls : list (ContractCallInfo Msg)) : Prop :=
+  All (fun '((addr, pk), i) => svi_index (parties addr) = i /\ nth_error pks i = Some pk)
+      (zip (signups calls) (seq 0 (length (signups calls)))).
+
+Local Open Scope nat.
+
+Lemma no_outgoing bstate caddr :
+  reachable bstate ->
+  env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+  outgoing_acts bstate caddr = [].
+Proof.
+  intros.
+  apply (lift_outgoing_acts_nil boardroom_voting); try easy.
+  intros.
+  destruct msg as [msg|]; cbn -[Nat.ltb] in *; try congruence.
+  destruct msg.
+  - destruct (_ <? _); cbn in *; try congruence.
+    destruct (AddressMap.find _ _); cbn in *; try congruence.
+    destruct (AddressMap.find _ _); cbn in *; try congruence.
+    destruct (_ =? _)%Z; cbn in *; try congruence.
+    destruct (_ <? _)%Z; cbn in *; try congruence.
+    destruct (verify_secret_key_proof _ _ _); cbn in *; congruence.
+  - destruct (finish_commit_by _); cbn -[Nat.ltb] in *; try congruence.
+    destruct (_ <? _); cbn in *; try congruence.
+    destruct (AddressMap.find _ _); cbn in *; congruence.
+  - destruct (_ <? _); cbn in *; try congruence.
+    destruct (AddressMap.find _ _); cbn in *; try congruence.
+    destruct (if finish_commit_by _ then _ else _); cbn in *; try congruence.
+    destruct (verify_secret_vote_proof _ _ _ _); cbn in *; congruence.
+  - destruct (_ <? _); cbn in *; try congruence.
+    destruct (tally _); cbn in *; try congruence.
+    destruct (existsb _ _); cbn in *; try congruence.
+    destruct (bruteforce_tally _); cbn in *; congruence.
+Qed.
+
+Lemma Permutation_modify k vold vnew (m : AddrMap VoterInfo) :
+  FMap.find k m = Some vold ->
+  voter_index vold = voter_index vnew ->
+  Permutation (map (fun '(_, v) => voter_index v)
+                   (FMap.elements m))
+              (seq 0 (FMap.size m)) ->
+  Permutation
+    (map (fun '(_, v0) => voter_index v0)
+         (FMap.elements (FMap.add k vnew m)))
+    (seq 0 (FMap.size m)).
+Proof.
+  intros find_some index old_perm.
+  unfold AddrMap in *.
+  rewrite <- old_perm.
+  rewrite <- (FMap.add_id _ _ _ find_some) at 2.
+  rewrite <- (FMap.add_remove k vold).
+  rewrite (FMap.elements_add_existing k vold vnew) by auto.
+  rewrite FMap.elements_add by auto.
+  cbn.
+  now rewrite index.
+Qed.
+
+Lemma all_signups pks parties calls :
+  SignupOrderAssumption pks parties calls ->
+  length (signups calls) = length pks ->
+  map snd (signups calls) = pks.
+Proof.
+  intros order len_signups.
+  unfold SignupOrderAssumption in order.
+  revert parties pks len_signups order.
+  induction (signups calls) as [|[addr pk] xs IH]; intros parties pks len_signups order.
+  - destruct pks; cbn in *; congruence.
+  - cbn in *.
+    destruct pks as [|pk' pks]; cbn in *; try lia.
+    destruct order as [[index_eq nth_eq] all].
+    f_equal; try congruence.
+    apply (IH (fun addr => (parties addr)<|svi_index ::= fun i => i - 1|>));
+      [lia|].
+    clear -all.
+    rewrite <- (map_id xs) in all at 1.
+    rewrite <- seq_shift in all.
+    rewrite zip_map in all.
+    apply All_map in all.
+    apply (All_ext_in _ _ _ all).
+    intros.
+    destruct a, p.
+    cbn in *.
+    split; [|tauto].
+    destruct H1; lia.
+Qed.
+
+Local Open Scope broom.
+(* Lemma elmeqb_eq (a a' : A) :
+  (a =? a') = true <-> a == a'.
+Proof.
+  destruct (elmeqb_spec a a'); [tauto|].
+  split; congruence.
+Qed.
+
+Hint Resolve
+     pow_nonzero generator_nonzero int_domain generator_nonzero compute_public_key_unit
+     reconstructed_key_unit
+  : broom.
+Lemma verify_secret_key_proof_spec sk v i :
+  verify_secret_key_proof (compute_public_key sk) i (secret_key_proof sk v i) = true.
+Proof with auto with broom.
+  cbn.
+  apply elmeqb_eq.
+  apply log_both...
+  rewrite log_pow...
+  rewrite log_mul...
+  unfold "exp=".
+  assert (order - 1 <> 0)%Z by (pose proof order_ge_2; lia).
+  rewrite Z.add_mod...
+  rewrite !log_pow...
+  rewrite log_generator.
+  rewrite !Z.mul_1_r.
+  unfold compute_public_key.
+  rewrite <- Z.mul_mod_idemp_r...
+  rewrite log_pow...
+  rewrite log_generator.
+  rewrite Z.mul_1_r.
+  rewrite Z.mul_mod_idemp_r...
+  rewrite <- Z.add_mod...
+  f_equal.
+  lia.
+Qed.
+
+Lemma verify_secret_vote_proof_spec sk pks sv i w r d :
+  All (fun pk => pk !== 0) pks ->
+  verify_secret_vote_proof
+    (compute_public_key sk)
+    (reconstructed_key pks i)
+    (compute_public_vote (reconstructed_key pks i) sk sv)
+    i
+    (secret_vote_proof sk (reconstructed_key pks i) sv i w r d) = true.
+Proof.
+  intros all_units.
+  set (rk := reconstructed_key pks i).
+  unfold verify_secret_vote_proof, secret_vote_proof.
+  cbn.
+  destruct sv.
+  - set (h := hash_sv_data _ _ _ _ _ _ _).
+    rewrite Zplus_minus.
+    rewrite Pos.eqb_refl, !elmeqb_refl.
+    cbn.
+    unfold compute_public_key.
+    rewrite pow_pow by (auto with broom).
+    rewrite <- pow_plus by (auto with broom).
+    rewrite Z.sub_add.
+    rewrite elmeqb_refl.
+    cbn.
+    unfold compute_public_vote.
+    rewrite <- (mul_assoc (rk^sk)).
+    rewrite (mul_comm generator).
+    rewrite inv_inv_l by (auto with broom).
+    rewrite (mul_comm (rk^sk)), mul_1_l.
+    rewrite pow_pow by (subst rk; auto with broom).
+    rewrite <- pow_plus by (subst rk; auto with broom).
+    rewrite Z.sub_add.
+    now rewrite elmeqb_refl.
+  - set (h := hash_sv_data _ _ _ _ _ _ _).
+    rewrite Z.sub_add.
+    rewrite Pos.eqb_refl, !elmeqb_refl.
+    cbn.
+    unfold compute_public_key.
+    rewrite pow_pow by (auto with broom).
+    rewrite <- pow_plus by (auto with broom).
+    rewrite Z.sub_add.
+    rewrite elmeqb_refl.
+    cbn.
+    unfold compute_public_vote.
+    rewrite (mul_comm (rk^sk)), mul_1_l.
+    rewrite pow_pow by (subst rk; auto with broom).
+    rewrite <- pow_plus by (subst rk; auto with broom).
+    rewrite Z.sub_add.
+    now rewrite elmeqb_refl.
+Qed.
+
+Definition has_tallied (calls : list (ContractCallInfo Msg)) : bool :=
+  existsb (fun c => match Blockchain.call_msg c with
+                    | Some tally_votes => true
+                    | _ => false
+                    end) calls.
+
+Theorem boardroom_voting_correct_strong
+        (bstate : ChainState)
+        (caddr : Address)
+        (trace : ChainTrace empty_state bstate)
+        (parties : Address -> SecretVoterInfo)
+        (pks : list A) :
+    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+    exists (cstate : State)
+           (depinfo : DeploymentInfo Setup)
+           (inc_calls : list (ContractCallInfo Msg)),
+      deployment_info Setup trace caddr = Some depinfo /\
+      contract_state bstate caddr = Some cstate /\
+      incoming_calls Msg trace caddr = Some inc_calls /\
+
+      finish_registration_by (setup cstate) < finish_vote_by (setup cstate) /\
+
+      (Blockchain.current_slot bstate < finish_vote_by (setup cstate) ->
+       has_tallied inc_calls = false) /\
+
+      length (public_keys cstate) = FMap.size (registered_voters cstate) /\
+      public_keys cstate = map snd (signups inc_calls) /\
+
+      (Z.of_nat (length (public_keys cstate)) < order - 1)%Z /\
+
+      (MsgAssumption pks parties inc_calls ->
+       SignupOrderAssumption pks parties inc_calls ->
+       (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
+        length pks = length (signups inc_calls)) ->
+
+       Permutation (map (fun '(_, v) => voter_index v)
+                        (FMap.elements (registered_voters cstate)))
+                   (seq 0 (length (public_keys cstate))) /\
+
+       Permutation (FMap.keys (registered_voters cstate))
+                   (map fst (signups inc_calls)) /\
+
+       (forall addr inf,
+           FMap.find addr (registered_voters cstate) = Some inf ->
+           voter_index inf < length (public_keys cstate) /\
+           voter_index inf = svi_index (parties addr) /\
+           nth_error (public_keys cstate) (voter_index inf) =
+           Some (compute_public_key (svi_sk (parties addr))) /\
+           (public_vote inf == zero \/
+            public_vote inf = compute_public_vote
+                                (reconstructed_key pks (voter_index inf))
+                                (svi_sk (parties addr))
+                                (svi_sv (parties addr)))) /\
+       ((has_tallied inc_calls = false ->
+         tally cstate = None) /\
+        (has_tallied inc_calls = true ->
+         tally cstate = Some (sumnat (fun party => if svi_sv (parties party) then 1 else 0)%nat
+                                     (map fst (signups inc_calls)))))).
+Proof.
+  contract_induction; intros; unfold AddrMap in *.
+  - [AddBlockFacts]: exact (fun _ old_slot _ _ new_slot _ => old_slot < new_slot).
+    subst AddBlockFacts.
+    cbn in facts.
+    destruct_and_split; try tauto.
+    + eauto with lia.
+    + intros; eauto with lia.
+  - cbn -[Nat.ltb] in *.
+    destruct (_ <? _) eqn:ltb; [|congruence].
+    apply Nat.ltb_lt in ltb.
+    inversion_clear init_some.
+    cbn.
+    split; auto.
+    split; auto.
+    split; [symmetry; apply FMap.size_empty|].
+    split; [auto|].
+    pose proof order_ge_2.
+    split; [lia|].
+    intros _ _ _.
+    unfold FMap.keys.
+    unfold AddrMap in *.
+    unfold AddressMap.empty in *.
+    rewrite @FMap.elements_empty.
+    split; [auto|].
+    split; [auto|].
+    split; [|easy].
+    intros ? ? find.
+    now rewrite @FMap.find_empty in find.
+  - auto.
+  - cbn -[Nat.ltb] in receive_some.
+    destruct msg as [msg|]; cbn -[Nat.ltb] in *; [|congruence].
+    destruct msg.
+    unfold AddressMap.add in *. unfold AddressMap.find in *.
+    + (* signup *)
+      destruct (_ <? _)%nat eqn:intime in receive_some; cbn -[Nat.ltb] in *; [congruence|].
+      apply Nat.ltb_ge in intime.
+      destruct (FMap.find _ _) in receive_some; cbn in *; [|congruence].
+      destruct (FMap.find _ _) eqn:new in receive_some; cbn in *; [congruence|].
+      destruct (_ =? _)%Z in receive_some; cbn in *; [|congruence].
+      destruct (_ <? _)%Z eqn:lt in receive_some; cbn in *; [|congruence].
+      destruct (verify_secret_key_proof _ _ _) eqn:verify_zkp in receive_some;
+        cbn in *; [|congruence].
+      inversion_clear receive_some.
+      cbn.
+      split; [lia|].
+      split; [tauto|].
+      split.
+      unfold AddrMap in *.
+      { rewrite app_length, FMap.size_add_new by auto; cbn; lia. }
+      apply Z.ltb_lt in lt.
+      rewrite app_length in *.
+      cbn.
+      fold (has_tallied prev_inc_calls).
+      fold (signups prev_inc_calls).
+      rewrite app_length, map_app; cbn.
+      split; [destruct_and_split; congruence|].
+      split; [lia|].
+      intros [signup_assum msg_assum] order_assum num_signups_assum.
+      destruct IH as (reg_lt & cur_lt & _ & pks_signups & _ & IH).
+      unshelve epose proof (IH _ _ _) as IH.
+      * auto.
+      * rewrite seq_app in order_assum.
+        rewrite zip_app in order_assum by (now rewrite seq_length).
+        apply All_app in order_assum.
+        tauto.
+      * intros.
+        lia.
+      * split.
+        { destruct IH as (perm & _).
+          cbn.
+          unfold AddrMap in *.
+          rewrite FMap.elements_add by auto.
+          cbn.
+          rewrite seq_app.
+          cbn.
+          perm_simplify. }
+        split.
+        { destruct IH as (_ & perm & _).
+          rewrite map_app.
+          unfold FMap.keys.
+          rewrite FMap.elements_add by auto.
+          cbn.
+          perm_simplify. }
+
+        split; cycle 1.
+        {
+          split; [easy|].
+          intros tallied.
+          specialize (cur_lt ltac:(lia)).
+          congruence.
+        }
+        intros addr inf find_add.
+        destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+        unfold AddrMap in *.
+        -- rewrite (FMap.find_add (ctx_from ctx)) in find_add.
+           inversion_clear find_add.
+           cbn.
+           unfold make_signup_msg in signup_assum.
+           rewrite nth_error_snoc.
+           rewrite seq_app, zip_app in order_assum by (now rewrite seq_length).
+           apply All_app in order_assum.
+           cbn in order_assum.
+           destruct order_assum as [_ []].
+           split; [lia|].
+           rewrite pks_signups, map_length.
+           split; [symmetry; tauto|].
+           split; [congruence|].
+           left; easy.
+        -- unfold AddrMap in *.
+           rewrite FMap.find_add_ne in find_add by auto.
+           destruct IH as (_ & _ & IH & _).
+           specialize (IH _ _ find_add).
+           split; [lia|].
+           now rewrite nth_error_app1 by lia.
+    + (* commit_to_vote *)
+      destruct (finish_commit_by _); cbn -[Nat.ltb] in *; [|congruence].
+      destruct (_ <? _); cbn in *; [congruence|].
+      unfold AddressMap.find in *.
+      destruct (FMap.find _ _) eqn:found; cbn in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      split; [lia|].
+      split; [tauto|].
+      split.
+      unfold AddressMap.add.
+      unfold AddrMap in *.
+      {  rewrite FMap.size_add_existing by congruence; tauto. }
+      split; [tauto|].
+      split; [tauto|].
+      intros [_ msg_assum] order_assum num_signups_assum.
+      destruct IH as (_ & _ & len_pks & _ & _ & IH).
+      specialize (IH msg_assum order_assum num_signups_assum).
+      setoid_rewrite (FMap.keys_already _ _ _ _ found).
+      split.
+      {
+        destruct IH as (perm & _).
+        rewrite len_pks in *.
+        apply Permutation_modify with (vold := v); auto.
+      }
+      split; [tauto|].
+      split; [|tauto].
+      intros addr inf find_add.
+      unfold AddressMap.add in *.
+      destruct IH as (_ & _ & IH & _).
+      destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+      * unfold AddrMap in *.  rewrite FMap.find_add in find_add.
+        inversion_clear find_add; cbn.
+        auto.
+      * unfold AddrMap in *; rewrite FMap.find_add_ne in find_add by auto.
+        auto.
+    + (* submit_vote *)
+      destruct (_ <? _); cbn -[Nat.ltb] in *; [congruence|].
+      unfold AddressMap.find in *. 
+      destruct (FMap.find _ _) eqn:found; cbn in *; [|congruence].
+      destruct (if finish_commit_by _ then _ else _); cbn in *; [|congruence].
+      destruct (verify_secret_vote_proof _ _ _ _); cbn in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      split; [lia|].
+      split; [tauto|].
+      unfold AddressMap.add in *.
+      unfold AddrMap in *; rewrite FMap.size_add_existing by congruence.
+      split; [tauto|].
+      split; [tauto|].
+      split; [tauto|].
+      intros [vote_assum msg_assum] order_assum num_signups_assum.
+      destruct IH as (_ & _ & len_pks & _ & _ & IH).
+      specialize (IH msg_assum order_assum num_signups_assum).
+      setoid_rewrite (FMap.keys_already _ _ _ _ found).
+      split.
+      { destruct IH as (perm & _).
+        rewrite len_pks in *.
+        apply Permutation_modify with (vold := v0); auto. }
+      split; [tauto|].
+      split; [|tauto].
+      intros addr inf find_add.
+      destruct IH as (_ & _ & IH & _).
+      destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
+      * rewrite FMap.find_add in find_add.
+        inversion_clear find_add; cbn.
+        specialize (IH _ _ found).
+        repeat split; try tauto.
+        right.
+        unfold make_vote_msg in *.
+        inversion vote_assum.
+        destruct_hyps.
+        replace (svi_index (parties (ctx_from ctx))) with (voter_index v0) by congruence.
+        easy.
+      * rewrite FMap.find_add_ne in find_add by auto.
+        auto.
+    + (* tally_votes *)
+      destruct (_ <? _) eqn:intime; cbn in *; [congruence|].
+      destruct (tally prev_state); cbn in *; [congruence|].
+      destruct (existsb _ _) eqn:all_voted; cbn in *; [congruence|].
+      destruct (bruteforce_tally _) eqn:bruteforce; cbn -[Nat.ltb] in *; [|congruence].
+      inversion_clear receive_some; cbn.
+      apply Nat.ltb_ge in intime.
+      split; [lia|].
+      split; [intros; lia|].
+      split; [tauto|].
+      split; [tauto|].
+      split; [tauto|].
+      intros (_ & msg_assum) order_assum num_signups_assum.
+      split; [tauto|].
+      split; [tauto|].
+      split; [tauto|].
+      split; [easy|].
+      intros _.
+      apply f_equal.
+      destruct IH as (finish_before_vote & _ & len_pks & pks_signups & party_count & IH).
+      specialize (IH msg_assum order_assum num_signups_assum).
+      destruct IH as (perm & perm' & addrs & _).
+      unfold AddressMap.values in *. 
+      unfold FMap.values in bruteforce.
+      rewrite map_map in bruteforce.
+      rewrite (map_ext_in _ (fun '(_, v) => public_vote v)) in bruteforce
+        by (now intros []).
+      rewrite (bruteforce_tally_correct
+                    (FMap.elements (registered_voters prev_state))
+                    (fun '(_, v) => voter_index v)
+                    (fun '(addr, _) => svi_sk (parties addr))
+                    (public_keys prev_state)
+                    (fun kvp => svi_sv (parties (fst kvp)))
+                    (fun '(_, v) => public_vote v)) in bruteforce.
+      * inversion bruteforce.
+        rewrite <- (sumnat_map fst (fun a => if svi_sv (parties a) then 1 else 0))%nat.
+        now rewrite perm'.
+      * unfold AddrMap in *; now rewrite FMap.length_elements, <- len_pks.
+      * unfold AddrMap in *; now rewrite FMap.length_elements, <- len_pks.
+      * auto.
+      * intros [k v] kvpin.
+        apply FMap.In_elements in kvpin.
+        specialize (addrs _ _ kvpin).
+        tauto.
+      * intros [k v] kvpin.
+        rewrite existsb_forallb in all_voted.
+        apply Bool.negb_false_iff in all_voted.
+        rewrite forallb_forall in all_voted.
+        unshelve epose proof (all_voted v _) as all_voted.
+        {
+          apply in_map_iff.
+          exists (k, v).
+          tauto.
+        }
+        apply Bool.negb_true_iff in all_voted.
+        destruct (elmeqb_spec (public_vote v) zero); [congruence|].
+        apply FMap.In_elements in kvpin.
+        specialize (addrs _ _ kvpin).
+        cbn.
+        destruct addrs as (_ & _ & _ & []); [easy|].
+        fold (signups prev_inc_calls) (SignupOrderAssumption pks parties prev_inc_calls) in *.
+        rewrite pks_signups.
+        specialize (num_signups_assum ltac:(lia)).
+        now rewrite (all_signups pks parties) by auto.
+  - [CallFacts]: exact (fun _ ctx _ => ctx_from ctx <> ctx_contract_address ctx).
+    subst CallFacts; cbn in *; congruence.
+  - auto.
+  - [DeployFacts]: exact (fun _ _ => True).
+    unset_all; subst; cbn in *.
+    destruct_chain_step; auto.
+    + destruct valid_header; auto.
+    + destruct_action_eval; auto.
+      intros.
+      pose proof (no_outgoing _ _ from_reachable H0).
+      unfold outgoing_acts in H2.
+      rewrite queue_prev in H2.
+      cbn in H2.
+      destruct (address_eqb_spec (act_from act) to_addr); cbn in *; try congruence.
+      subst act; cbn in *; congruence.
+Qed.
+
+Theorem boardroom_voting_correct
+        (bstate : ChainState)
+        (caddr : Address)
+        (trace : ChainTrace empty_state bstate)
+        (* list of all public keys, in the order of signups *)
+        (pks : list A)
+        (* function mapping a party to information about him *)
+        (parties : Address -> SecretVoterInfo) :
+    env_contracts bstate caddr = Some (boardroom_voting : WeakContract) ->
+    exists (cstate : State)
+           (depinfo : DeploymentInfo Setup)
+           (inc_calls : list (ContractCallInfo Msg)),
+      deployment_info Setup trace caddr = Some depinfo /\
+      contract_state bstate caddr = Some cstate /\
+      incoming_calls Msg trace caddr = Some inc_calls /\
+
+      (* assuming that the message sent were created with the
+          functions provided by this smart contract *)
+      MsgAssumption pks parties inc_calls ->
+
+      (* ..and that people signed up in the order given by 'index'
+          and 'pks' *)
+      SignupOrderAssumption pks parties inc_calls ->
+
+      (* ..and that the correct number of people register *)
+      (finish_registration_by (setup cstate) < Blockchain.current_slot bstate ->
+       length pks = length (signups inc_calls)) ->
+
+      (* then if we have not tallied yet, the tally is none *)
+      ((has_tallied inc_calls = false -> tally cstate = None) /\
+       (* or if we have tallied yet, the tally is correct *)
+       (has_tallied inc_calls = true ->
+        tally cstate = Some (sumnat (fun party => if svi_sv (parties party) then 1 else 0)%nat
+                                    (map fst (signups inc_calls))))).
+Proof.
+  intros deployed.
+  destruct (boardroom_voting_correct_strong bstate caddr trace parties pks deployed)
+    as (cstate & depinfo & inc_calls & P).
+  exists cstate, depinfo, inc_calls.
+  tauto.
+Qed.
+*)
+End Theories.
+
+End BoardroomVoting.

--- a/execution/examples/Common.v
+++ b/execution/examples/Common.v
@@ -17,6 +17,15 @@ Module AddressMap.
   Definition add  `{ChainBase} {V : Type} (addr : Address) (val : V) (m : AddrMap V) : AddrMap V :=
     FMap.add addr val m.
 
+  Definition values  `{ChainBase} {V : Type} (m : AddrMap V) : list V :=
+    FMap.values m.
+
+  Definition keys  `{ChainBase} {V : Type} (m : AddrMap V) : list Address :=
+    FMap.keys m.
+      
+  Definition of_list  `{ChainBase} {V : Type} (l : list (Address * V)) : AddrMap V :=
+    FMap.of_list l.
+
   Definition empty  `{ChainBase} {V : Type} : AddrMap V := FMap.empty.
 
 End AddressMap.

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -48,6 +48,8 @@ theories/WcbvEvalAux.v
 
 -Q examples ConCert.Extraction.Examples
 examples/Ack.v
+examples/BoardroomVotingExtractionCameLIGO.v
+examples/BoardroomVotingExtractionLiquidity.v
 examples/CameLIGOExtractionTests.v
 examples/CounterCertifiedExtraction.v
 examples/CounterDepCertifiedExtraction.v

--- a/extraction/examples/BoardroomVotingExtraction.v
+++ b/extraction/examples/BoardroomVotingExtraction.v
@@ -21,6 +21,7 @@ Open Scope Z.
 Definition PREFIX := "".
 
 From ConCert.Execution.Examples Require Import BoardroomVotingTest.
+Import Params.
 (* Get string representation of modulus, and remap it. This way we avoid having the extraction compute the number. *)
 Definition modulus_ := StringExtra.string_of_Z BoardroomVotingTest.modulus.
 
@@ -40,23 +41,50 @@ Print BoardroomMath.BoardroomAxioms.
     expeq := fun e e' : Z => e mod (order - 1) = e' mod (order - 
     order_ge_2 : order >
   ] *)
+Print Params.
+  Definition eqlemeqb_Z := @BoardroomMath.elmeqb _ Params.axioms.
+  
+  (* elmeq a b := a mod p = b mod p;
+     elmeqb a b := a mod p =? b mod p;
+     zero := 0;
+     one := 1;
+     add a a' := (a + a') mod p;
+     mul a a' := (a * a') mod p;
+     opp a := p - a;
+     inv a := Zp.mod_inv a p;
+     pow a e := Zp.mod_pow a e p;
+     order := p; *)
 
 (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
 Definition TT_remap : list (kername * string) :=
   TT_remap_default ++ [
-      remap <%% Amount %%> "tez"
-    ; remap <%% Z %%> "int"
-    ; remap <%% Z.add %%> "addInt"
-    ; remap <%% Z.sub %%> "subInt"
-    ; remap <%% Z.leb %%> "leInt"
-    ; remap <%% Z.ltb %%> "ltInt"
-    ; remap <%% Z.add %%> "addInt"
-    ; remap <%% Z.eqb %%> "eqInt"
-    ; remap <%% Z.gtb %%> "gtbInt"
-    ; remap <%% Nat.ltb %%> "ltbNat"
-    ; remap <%% Z.modulo %%> "modInt"
-    ; remap <%% Z.mul %%> "mulInt"
+    remap <%% Amount %%> "tez"
+  ;  remap <%% positive %%> "nat"
+  ; remap <%% Z %%> "int"
+  ; remap <%% Z.of_nat %%> "%int"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.eqb %%> "eqInt"
+  ; remap <%% Z.gtb %%> "gtbInt"
+  ; remap <%% Nat.ltb %%> "ltbNat"
+  ; remap <%% Z.modulo %%> "modInt"
+  ; remap <%% Z.mul %%> "mulInt"
+  ; remap <%% N.lxor %%> "xor"
+  ; remap <%% N.succ_pos %%> "(addNat 1)"
 
+  ; remap <%% BoardroomVotingTest.oneN %%> "1"
+  ; remap <%% BoardroomVotingTest.four %%> "4"
+  ; remap <%% BoardroomVotingTest.seven %%> "7"
+  ; remap <%% BoardroomVotingTest._1234583932 %%> "1234583932"
+  ; remap <%% BoardroomVotingTest._23241 %%> "23241"
+  ; remap <%% BoardroomVotingTest._159338231 %%> "159338231"
+  ; remap <%% BoardroomVotingTest._5 %%> "5"
+  ; remap <%% BoardroomVotingTest._3 %%> "3"
+  ; remap <%% BoardroomVotingTest._11 %%> "11"
+  ; remap <%% BoardroomVotingTest.five %%> "5"
   ; remap <%% @ContractCallContext %%> "(address * (address * int))"
   ; remap <%% @Chain %%> "(address * (address * address))" (* chain_height, current_slot, finalized_height *)
   ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
@@ -71,6 +99,18 @@ Definition TT_remap : list (kername * string) :=
 
   ; remap <%% BoardroomMath.Zp.mod_pow %%> "mod_powInt"
   ; remap <%% BoardroomMath.Zp.mod_inv %%> "mod_invInt"
+  (*; remap <%% @BoardroomMath.add%%> "addInt"
+  ; remap <%% @BoardroomMath.elmeq%%> "eqInt"
+  ; remap <%% @BoardroomMath.expeq%%> "expeq"
+  ; remap <%% @BoardroomMath.elmeqb%%> "eqInt"
+  ; remap <%% @BoardroomMath.zero%%> "0"
+  ; remap <%% @BoardroomMath.one%%> "1"
+  ; remap <%% @BoardroomMath.mul%%> "mulInt"
+  ; remap <%% @BoardroomMath.opp%%> "-"
+  ; remap <%% @BoardroomMath.inv%%> "inv"
+  ; remap <%% @BoardroomMath.pow%%> "pow"
+  ; remap <%% @BoardroomMath.order%%> "order"
+  ; remap <%% @BoardroomVotingTest.axioms%%> "" *)
 
   (* ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof" *)
   (* ; remap <%% @BV.make_signup_msg %%> "make_signup_msg" *)
@@ -79,26 +119,25 @@ Definition TT_remap : list (kername * string) :=
   (* ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof" *)
   (* ; remap <%% @BV.secret_key_proof %%> "secret_key_proof" *)
   (* ; remap <%% @BV.hash_sk_data %%> "hash_sk_data" *)
-  ; remap <%% @BV.hash_sv_data %%> "hash_sv_data"
+  (* ; remap <%% @BV.hash_sv_data %%> "hash_sv_data" *)
 
-  ; remap <%% @BV.handle_signup %%> "handle_signup"
+  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
   ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote"
-  (* ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote" *)
-  (* ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes" *)
+  ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote"
+  ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes"
 
 
   ; remap <%% BoardroomVotingTest.modulus %%> modulus_
-
-  (* ; remap <%% @modulus_prime %%> "modulus_prime" *)
-  (* ; remap <%% @generator_is_generator %%> "generator_is_generator" *)
-  (* ; remap <%% @BoardroomMath.boardroom_axioms_Z %%> "BoardroomMath.boardroom_axioms_Z" *)
-  (* ; remap <%% @BoardroomMath.Generator %%> "BoardroomAxioms" *)
-  (* ; remap <%% @BoardroomMath.DiscreteLog %%> "BoardroomAxioms" *)
+  ; remap <%% @modulus_prime %%> "modulus_prime"
+  ; remap <%% BV.encodeA %%> "%nat"
+  ; remap <%% BV.encodeNat %%> "%nat"
   
 
-  ; remap <%% @List.map %%> "map"
-  ; remap <%% @List.find %%> "find"
-  ; remap <%% @countable.encode %%> "TODO_encode"
+  ; remap <%% @List.fold_left %%> "List.fold"
+  ; remap <%% @List.map %%> "List.map"
+  ; remap <%% @List.find %%> "List.find"
+  ; remap <%% @List.length %%> "List.length"
+  ; remap <%% @List.app %%> "List.append"
   ; remap <%% @Serializable.serialize %%> "TODO_serialize"
   ; remap <%% @Serializable.deserialize %%> "TODO_deserialize"
   ].
@@ -106,10 +145,17 @@ Definition TT_remap : list (kername * string) :=
 Definition TT_rename : list (string * string):=
   [ ("Some", "Some")
   ; ("None", "None")
+  ; ("Zpos" ,"%int")
+  ; ("Npos" ,"(fun (n:nat) -> n)")
+  ; ("Zneg" ,"-")
   ; ("Z0" ,"0")
+  ; ("N0" ,"0")
+  ; ("xH" ,"0")
+  ; ("1" ,"1")
   ; ("nil", "[]")
   ; ("true", "true")
   ; (string_of_kername <%% BV.State %%>, "State")  (* we add [storage] so it is printed without the prefix *) 
+  ; ("tt", "()")
   ].
 Require Import ContractMonads.
 
@@ -130,7 +176,7 @@ Definition receive_wrapper (msg : msg)
 Definition dummy_init : init_ctx -> BV.Setup -> option BV.State := fun _ _ => None .
 Definition dummy_receive : msg -> BV.State -> option (list ActionBody × BV.State) := 
   fun _ _  => 
-    let x := BoardroomMath.add 1 2 in
+    let x := BV.secret_key_proof 0 _5 five in
     None.
 
 Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
@@ -163,16 +209,27 @@ Definition inline_boardroom_params : list kername :=
       <%% Params.A %%>
     ; <%% Params.H %%>
     ; <%% Params.ser %%>
-    ; <%% Params.axioms %%>
+    (* ; <%% Params.axioms %%> *)
     ; <%% Params.gen %%>
     ; <%% Params.discr_log %%>
-    ; <%% BoardroomVotingTest.axioms_instance %%>
-    (* this *)
-    ; <%% BoardroomMath.boardroom_axioms_Z %%>
+    (* ; <%% BoardroomVotingTest.axioms_instance %%> *)
+    (* ; <%% BVZAxioms.boardroom_axioms_Z %%> *)
+
+    (* ; <%% @BoardroomMath.oeq_equivalence %%> *)
+    (* ; <%% @BoardroomMath.generator_instance %%> *)
+    (* ; <%% @BoardroomMath.generator %%> *)
+    (* ; <%% @BoardroomMath.generator_nonzero %%> *)
+    (* ; <%% @BoardroomMath.generator_generates %%> *)
+    (* ; <%% @BoardroomMath.log %%>
+    ; <%% @BoardroomMath.log_proper %%>
+    ; <%% @BoardroomMath.log_1_l %%>
+    ; <%% @BoardroomMath.log_generator %%> *)
 
     (* BoardroomAxioms *)
+    (* ; <%% @BoardroomMath.BoardroomAxioms%%>
     ; <%% @BoardroomMath.add%%>
-    (* ; <%% @BoardroomMath.elmeq%%> *)
+    ; <%% @BoardroomMath.elmeq%%>
+    ; <%% @BoardroomMath.expeq%%>
     ; <%% @BoardroomMath.elmeqb%%>
     ; <%% @BoardroomMath.zero%%>
     ; <%% @BoardroomMath.one%%>
@@ -180,8 +237,45 @@ Definition inline_boardroom_params : list kername :=
     ; <%% @BoardroomMath.opp%%>
     ; <%% @BoardroomMath.inv%%>
     ; <%% @BoardroomMath.pow%%>
-    ; <%% @BoardroomMath.order%%>
+    ; <%% @BoardroomMath.order%%> *)
 
+    (* ; <%% @BoardroomMath.plus_expeq_proper%%>
+    ; <%% @BoardroomMath.mul_expeq_proper%%>
+    ; <%% @BoardroomMath.sub_expeq_proper%%>
+    ; <%% @BoardroomMath.opp_expeq_proper%%>
+    ; <%% @BoardroomMath.pow_generator_proper%%>
+    ; <%% @BoardroomMath.prod_perm_proper%%>
+    ; <%% @BoardroomMath.bruteforce_tally_aux_proper%%>
+    ; <%% @BoardroomMath.bruteforce_tally_proper%%>
+    ; <%% @BoardroomMath.elmeqb_elmeq_proper%%>
+
+    ; <%% @BoardroomMath.elmeqb_spec%%>
+    ; <%% @BoardroomMath.order_ge_2%%>
+    ; <%% @BoardroomMath.elmeq_equiv%%>
+    ; <%% @BoardroomMath.add_proper%%>
+    ; <%% @BoardroomMath.mul_proper%%>
+    ; <%% @BoardroomMath.opp_proper%%>
+    ; <%% @BoardroomMath.inv_proper%%>
+    ; <%% @BoardroomMath.pow_base_proper%%>
+    ; <%% @BoardroomMath.pow_exp_proper%%>
+    ; <%% @BoardroomMath.one_neq_zero%%>
+    ; <%% @BoardroomMath.add_comm %%>
+    ; <%% @BoardroomMath.add_assoc %%>
+    ; <%% @BoardroomMath.mul_comm %%>
+    ; <%% @BoardroomMath.mul_assoc %%>
+    ; <%% @BoardroomMath.add_0_l %%>
+    ; <%% @BoardroomMath.mul_0_l %%>
+    ; <%% @BoardroomMath.mul_1_l %%>
+    ; <%% @BoardroomMath.opp_inv_l %%>
+    ; <%% @BoardroomMath.inv_inv_l %%>
+    ; <%% @BoardroomMath.mul_add %%>
+    ; <%% @BoardroomMath.pow_0_r %%>
+    ; <%% @BoardroomMath.pow_1_r %%>
+    ; <%% @BoardroomMath.pow_opp_1 %%>
+    ; <%% @BoardroomMath.pow_plus %%>
+    ; <%% @BoardroomMath.pow_pow %%>
+    ; <%% @BoardroomMath.pow_nonzero %%>
+    ; <%% @BoardroomMath.inv_nonzero %%> *)
   ].
 
 
@@ -253,7 +347,7 @@ Definition to_inline : list kername :=
   ; <%% @BV.set_VoterInfo_vote_hash %%>
   ; <%% @BV.set_VoterInfo_public_vote %%>
 
-
+  (* ; <%% @countable.encode %%> *)
   ].
 
 (* Definition asd := (BoardroomMath.add 1 2).
@@ -262,6 +356,11 @@ Time MetaCoq Quote Recursively Definition ex1 := asd.
 Check ex1.
 Definition r1 := Eval vm_compute in (liquidity_extract_single TT_remap TT_rename true BV_MODULE.(lmd_prelude) "harness?" ex1).
 Print r1. *)
+(* r1 = 
+inr
+  "Erased environment is not expanded enough for dearging to be provably correct"
+  : string + string
+*)
 
 Time MetaCoq Run
      (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;
@@ -271,4 +370,4 @@ Time MetaCoq Run
 Print liquidity_boardroomvoting.
 
 (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
-Redirect "examples/liquidity-extract/CounterRefinementTypes.liq" Compute liquidity_counter.
+Redirect "examples/liquidity-extract/BoardroomVoting.liq" Compute liquidity_boardroomvoting.

--- a/extraction/examples/BoardroomVotingExtraction.v
+++ b/extraction/examples/BoardroomVotingExtraction.v
@@ -5,7 +5,7 @@
 From Coq Require Import PeanoNat ZArith.
 
 From ConCert.Extraction Require Import LPretty LiquidityExtract Common.
-From ConCert.Execution Require Import Blockchain Common.
+From ConCert.Execution Require Import Blockchain Common LocalBlockchain.
 
 From Coq Require Import List String.
 Local Open Scope string_scope.
@@ -20,143 +20,109 @@ Open Scope Z.
 
 Definition PREFIX := "".
 
-From ConCert.Execution.Examples Require Import BoardroomVotingTest.
-Import Params.
+From ConCert.Execution.Examples Require Import BoardroomVotingZ.
+
+(* In this example we just use xor for the hash function, which is
+   obviously not cryptographically secure. *)
+Definition modulus : Z := 201697267445741585806196628073.
+Definition four := 4%nat.
+Definition seven := 7%nat.
+Definition _1234583932 := 1234583932.
+Definition _23241 := 23241.
+Definition _159338231 := 159338231.
+Definition oneN : N := 1%N.
+Definition Z3 : Z := 3.
+Definition generator : Z := Z3.
+
+Definition hash_func (l : list positive) : positive :=
+  N.succ_pos (fold_left (fun a p => N.lxor (Npos p) a) l oneN).
+
+  (* Instance Base : ChainBase := LocalChainBase AddrSize. *)
+Definition AddrSize := (2^128)%N.
+Instance Base : ChainBase := LocalBlockchain.LocalChainBase AddrSize.
+
+Module Params <: BoardroomParams.
+  Definition H : list positive -> positive := hash_func.
+  Definition Base := Base .
+  Definition prime := modulus.
+  Definition generator := generator.
+End Params.  
+Module BV := BoardroomVoting Params. Import BV.
+
+(* Compute the signup messages that would be sent by each party.
+   We just use the public key as the chosen randomness here. *)
+Definition _3 := 3%nat.
+Definition _5 := 5.
+Definition _11 := 11.
+
+Definition num_parties : nat := seven.
+Definition votes_for : nat := four.
+
+(* a pseudo-random generator for secret keys *)
+Definition sk n := (Z.of_nat n + _1234583932) * (modulus - _23241)^_159338231.
+
+(* Make a list of secret keys, here starting at i=7 *)
+Definition sks : list Z := map sk (seq seven num_parties).
+
+(* Make a list of votes for each party *)
+Definition svs : list bool :=
+  Eval compute in map (fun _ => true)
+                      (seq 0 votes_for)
+                  ++ map (fun _ => false)
+                         (seq 0 (num_parties - votes_for)).
+
+(* Compute the public keys for each party *)
+(* 
+Time Definition pks : list Z :=
+  Eval vm_compute in map compute_public_key sks.
+
+Definition rks : list Z :=
+  Eval vm_compute in map (reconstructed_key pks) (seq 0 (length pks)).
+
+Time Definition signups : list Msg :=
+  Eval vm_compute in map (fun '(sk, pk, i) => make_signup_msg sk _5 i)
+                             (Extras.zip (zip sks pks) (seq 0 (length sks))).
+
+(* Compute the submit_vote messages that would be sent by each party *)
+(* Our functional correctness proof assumes that the votes were computed
+   using the make_vote_msg function provided by the contract.
+   In this example we just use the secret key as the random parameters. *)
+Definition votes : list Msg :=
+  Eval vm_compute in map (fun '(i, sk, sv, rk) => make_vote_msg pks i sk sv sk sk sk)
+                             (zip (zip (zip (seq 0 (length pks)) sks) svs) rks).
+
+Definition A a :=
+  BoundedN.of_Z_const AddrSize a.
+
+Local Open Scope nat.
+Definition addrs : list Address.
+Proof.
+  let rec add_addr z n :=
+    match n with
+    | O => constr:(@nil Address)
+    | S ?n => let tail := add_addr (z + 1)%Z n in
+              constr:(cons (A z) tail)
+    end in
+  let num := eval compute in num_parties in
+  let tm := add_addr _11%Z num in
+  let tm := eval vm_compute in tm in
+  exact tm.
+Defined.
+
+Definition voters_map : AddrMap unit := AddressMap.of_list (map (fun a => (a, tt)) addrs).
+
+Definition five := 5%nat.
+
+Definition deploy_setup :=
+  {| eligible_voters := voters_map;
+     finish_registration_by := _3;
+     finish_commit_by := None;
+     finish_vote_by := five;
+     registration_deposit := 0; |}. *)
+
 (* Get string representation of modulus, and remap it. This way we avoid having the extraction compute the number. *)
-Definition modulus_ := StringExtra.string_of_Z BoardroomVotingTest.modulus.
+Definition modulus_ := StringExtra.string_of_Z modulus.
 
-Print BoardroomMath.BoardroomAxioms.
-(* TODO: remap all definition in boardroomaxioms *)
-(* Definition TT_boardroomaxioms : list (kername * string) :=
-  [
-    elmeqb_spec : 
-    zero 
-    one 
-    add : A -> A -
-    mul : A -> A -
-    opp : A -
-    inv : A -
-    pow : A -> Z -
-    order 
-    expeq := fun e e' : Z => e mod (order - 1) = e' mod (order - 
-    order_ge_2 : order >
-  ] *)
-Print Params.
-  Definition eqlemeqb_Z := @BoardroomMath.elmeqb _ Params.axioms.
-  
-  (* elmeq a b := a mod p = b mod p;
-     elmeqb a b := a mod p =? b mod p;
-     zero := 0;
-     one := 1;
-     add a a' := (a + a') mod p;
-     mul a a' := (a * a') mod p;
-     opp a := p - a;
-     inv a := Zp.mod_inv a p;
-     pow a e := Zp.mod_pow a e p;
-     order := p; *)
-
-(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
-Definition TT_remap : list (kername * string) :=
-  TT_remap_default ++ [
-    remap <%% Amount %%> "tez"
-  ;  remap <%% positive %%> "nat"
-  ; remap <%% Z %%> "int"
-  ; remap <%% Z.of_nat %%> "%int"
-  ; remap <%% Z.add %%> "addInt"
-  ; remap <%% Z.sub %%> "subInt"
-  ; remap <%% Z.leb %%> "leInt"
-  ; remap <%% Z.ltb %%> "ltInt"
-  ; remap <%% Z.add %%> "addInt"
-  ; remap <%% Z.eqb %%> "eqInt"
-  ; remap <%% Z.gtb %%> "gtbInt"
-  ; remap <%% Nat.ltb %%> "ltbNat"
-  ; remap <%% Z.modulo %%> "modInt"
-  ; remap <%% Z.mul %%> "mulInt"
-  ; remap <%% N.lxor %%> "xor"
-  ; remap <%% N.succ_pos %%> "(addNat 1)"
-
-  ; remap <%% BoardroomVotingTest.oneN %%> "1"
-  ; remap <%% BoardroomVotingTest.four %%> "4"
-  ; remap <%% BoardroomVotingTest.seven %%> "7"
-  ; remap <%% BoardroomVotingTest._1234583932 %%> "1234583932"
-  ; remap <%% BoardroomVotingTest._23241 %%> "23241"
-  ; remap <%% BoardroomVotingTest._159338231 %%> "159338231"
-  ; remap <%% BoardroomVotingTest._5 %%> "5"
-  ; remap <%% BoardroomVotingTest._3 %%> "3"
-  ; remap <%% BoardroomVotingTest._11 %%> "11"
-  ; remap <%% BoardroomVotingTest.five %%> "5"
-  ; remap <%% @ContractCallContext %%> "(address * (address * int))"
-  ; remap <%% @Chain %%> "(address * (address * address))" (* chain_height, current_slot, finalized_height *)
-  ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
-  ; remap <%% @current_slot %%> "(fun c -> fst (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
-  ; remap <%% @finalized_height %%> "(fun c -> snd (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
-  ; remap <%% @ctx_from %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
-  ; remap <%% @AddressMap.AddrMap %%> "addrMap"
-  ; remap <%% @AddressMap.add %%> "Map.add"
-  ; remap <%% @AddressMap.find %%> "Map.find"
-  ; remap <%% @AddressMap.values %%> "Map.to_list"
-  ; remap <%% @AddressMap.empty %%> "(Map [])"
-
-  ; remap <%% BoardroomMath.Zp.mod_pow %%> "mod_powInt"
-  ; remap <%% BoardroomMath.Zp.mod_inv %%> "mod_invInt"
-  (*; remap <%% @BoardroomMath.add%%> "addInt"
-  ; remap <%% @BoardroomMath.elmeq%%> "eqInt"
-  ; remap <%% @BoardroomMath.expeq%%> "expeq"
-  ; remap <%% @BoardroomMath.elmeqb%%> "eqInt"
-  ; remap <%% @BoardroomMath.zero%%> "0"
-  ; remap <%% @BoardroomMath.one%%> "1"
-  ; remap <%% @BoardroomMath.mul%%> "mulInt"
-  ; remap <%% @BoardroomMath.opp%%> "-"
-  ; remap <%% @BoardroomMath.inv%%> "inv"
-  ; remap <%% @BoardroomMath.pow%%> "pow"
-  ; remap <%% @BoardroomMath.order%%> "order"
-  ; remap <%% @BoardroomVotingTest.axioms%%> "" *)
-
-  (* ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof" *)
-  (* ; remap <%% @BV.make_signup_msg %%> "make_signup_msg" *)
-  (* ; remap <%% @BV.make_commit_msg %%> "make_commit_msg" *)
-  (* ; remap <%% @BV.make_vote_msg %%> "make_vote_msg" *)
-  (* ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof" *)
-  (* ; remap <%% @BV.secret_key_proof %%> "secret_key_proof" *)
-  (* ; remap <%% @BV.hash_sk_data %%> "hash_sk_data" *)
-  (* ; remap <%% @BV.hash_sv_data %%> "hash_sv_data" *)
-
-  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
-  ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote"
-  ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote"
-  ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes"
-
-
-  ; remap <%% BoardroomVotingTest.modulus %%> modulus_
-  ; remap <%% @modulus_prime %%> "modulus_prime"
-  ; remap <%% BV.encodeA %%> "%nat"
-  ; remap <%% BV.encodeNat %%> "%nat"
-  
-
-  ; remap <%% @List.fold_left %%> "List.fold"
-  ; remap <%% @List.map %%> "List.map"
-  ; remap <%% @List.find %%> "List.find"
-  ; remap <%% @List.length %%> "List.length"
-  ; remap <%% @List.app %%> "List.append"
-  ; remap <%% @Serializable.serialize %%> "TODO_serialize"
-  ; remap <%% @Serializable.deserialize %%> "TODO_deserialize"
-  ].
-(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
-Definition TT_rename : list (string * string):=
-  [ ("Some", "Some")
-  ; ("None", "None")
-  ; ("Zpos" ,"%int")
-  ; ("Npos" ,"(fun (n:nat) -> n)")
-  ; ("Zneg" ,"-")
-  ; ("Z0" ,"0")
-  ; ("N0" ,"0")
-  ; ("xH" ,"0")
-  ; ("1" ,"1")
-  ; ("nil", "[]")
-  ; ("true", "true")
-  ; (string_of_kername <%% BV.State %%>, "State")  (* we add [storage] so it is printed without the prefix *) 
-  ; ("tt", "()")
-  ].
 Require Import ContractMonads.
 
 Definition init_ctx := (Chain × ContractCallContext).
@@ -174,9 +140,10 @@ Definition receive_wrapper (msg : msg)
   end.
 
 Definition dummy_init : init_ctx -> BV.Setup -> option BV.State := fun _ _ => None .
+
 Definition dummy_receive : msg -> BV.State -> option (list ActionBody × BV.State) := 
   fun _ _  => 
-    let x := BV.secret_key_proof 0 _5 five in
+    let x := add_p 0 _5 in
     None.
 
 Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
@@ -184,16 +151,16 @@ Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
     lmd_module_name := "liquidity_boardroomvoting" ;
 
     (* definitions of operations on pairs and ints *)
-    lmd_prelude := concat nl [prod_ops;int_ops];
+    lmd_prelude := LiquidityPrelude;
 
     (* initial storage *)
-    lmd_init := dummy_init ;
+    lmd_init := init_wrapper;
 
     (* no extra operations in [init] are required *)
     lmd_init_prelude := "" ;
 
     (* the main functionality *)
-    lmd_receive := dummy_receive;
+    lmd_receive := receive_wrapper;
 
     (* code for the entry point *)
     lmd_entry_point := printWrapper (PREFIX ++ "receive_wrapper") ++ nl
@@ -203,79 +170,11 @@ Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
     It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
     that removes application of boxes to constants and constructors. *)
 (* Require Import RecordSet. *)
-Print Params.
+
 Definition inline_boardroom_params : list kername :=
   [
-      <%% Params.A %%>
-    ; <%% Params.H %%>
-    ; <%% Params.ser %%>
-    (* ; <%% Params.axioms %%> *)
-    ; <%% Params.gen %%>
-    ; <%% Params.discr_log %%>
-    (* ; <%% BoardroomVotingTest.axioms_instance %%> *)
-    (* ; <%% BVZAxioms.boardroom_axioms_Z %%> *)
-
-    (* ; <%% @BoardroomMath.oeq_equivalence %%> *)
-    (* ; <%% @BoardroomMath.generator_instance %%> *)
-    (* ; <%% @BoardroomMath.generator %%> *)
-    (* ; <%% @BoardroomMath.generator_nonzero %%> *)
-    (* ; <%% @BoardroomMath.generator_generates %%> *)
-    (* ; <%% @BoardroomMath.log %%>
-    ; <%% @BoardroomMath.log_proper %%>
-    ; <%% @BoardroomMath.log_1_l %%>
-    ; <%% @BoardroomMath.log_generator %%> *)
-
-    (* BoardroomAxioms *)
-    (* ; <%% @BoardroomMath.BoardroomAxioms%%>
-    ; <%% @BoardroomMath.add%%>
-    ; <%% @BoardroomMath.elmeq%%>
-    ; <%% @BoardroomMath.expeq%%>
-    ; <%% @BoardroomMath.elmeqb%%>
-    ; <%% @BoardroomMath.zero%%>
-    ; <%% @BoardroomMath.one%%>
-    ; <%% @BoardroomMath.mul%%>
-    ; <%% @BoardroomMath.opp%%>
-    ; <%% @BoardroomMath.inv%%>
-    ; <%% @BoardroomMath.pow%%>
-    ; <%% @BoardroomMath.order%%> *)
-
-    (* ; <%% @BoardroomMath.plus_expeq_proper%%>
-    ; <%% @BoardroomMath.mul_expeq_proper%%>
-    ; <%% @BoardroomMath.sub_expeq_proper%%>
-    ; <%% @BoardroomMath.opp_expeq_proper%%>
-    ; <%% @BoardroomMath.pow_generator_proper%%>
-    ; <%% @BoardroomMath.prod_perm_proper%%>
-    ; <%% @BoardroomMath.bruteforce_tally_aux_proper%%>
-    ; <%% @BoardroomMath.bruteforce_tally_proper%%>
-    ; <%% @BoardroomMath.elmeqb_elmeq_proper%%>
-
-    ; <%% @BoardroomMath.elmeqb_spec%%>
-    ; <%% @BoardroomMath.order_ge_2%%>
-    ; <%% @BoardroomMath.elmeq_equiv%%>
-    ; <%% @BoardroomMath.add_proper%%>
-    ; <%% @BoardroomMath.mul_proper%%>
-    ; <%% @BoardroomMath.opp_proper%%>
-    ; <%% @BoardroomMath.inv_proper%%>
-    ; <%% @BoardroomMath.pow_base_proper%%>
-    ; <%% @BoardroomMath.pow_exp_proper%%>
-    ; <%% @BoardroomMath.one_neq_zero%%>
-    ; <%% @BoardroomMath.add_comm %%>
-    ; <%% @BoardroomMath.add_assoc %%>
-    ; <%% @BoardroomMath.mul_comm %%>
-    ; <%% @BoardroomMath.mul_assoc %%>
-    ; <%% @BoardroomMath.add_0_l %%>
-    ; <%% @BoardroomMath.mul_0_l %%>
-    ; <%% @BoardroomMath.mul_1_l %%>
-    ; <%% @BoardroomMath.opp_inv_l %%>
-    ; <%% @BoardroomMath.inv_inv_l %%>
-    ; <%% @BoardroomMath.mul_add %%>
-    ; <%% @BoardroomMath.pow_0_r %%>
-    ; <%% @BoardroomMath.pow_1_r %%>
-    ; <%% @BoardroomMath.pow_opp_1 %%>
-    ; <%% @BoardroomMath.pow_plus %%>
-    ; <%% @BoardroomMath.pow_pow %%>
-    ; <%% @BoardroomMath.pow_nonzero %%>
-    ; <%% @BoardroomMath.inv_nonzero %%> *)
+      <%% Params.H %%>
+    ; <%% Params.generator %%>
   ].
 
 
@@ -306,6 +205,9 @@ Definition to_inline : list kername :=
   ++ [
     <%% Monads.Monad_option %%>
   (* ; <%% @Monads.MonadTrans %%> *)
+  
+  ; <%% ContractIniterSetupState %%>
+  ; <%% ContractReceiverStateMsgState %%>
   ; <%% @contract_initer_monad %%>
   ; <%% @run_contract_initer %%>
   ; <%% @contract_receiver_monad %%>
@@ -361,6 +263,115 @@ inr
   "Erased environment is not expanded enough for dearging to be provably correct"
   : string + string
 *)
+
+(* Time MetaCoq Run ('(env, init_nm, receive_nm) <- quote_and_preprocess to_inline BV_MODULE ;;
+                  tmDefinition "bv_env" env ;;
+                  tmDefinition "bv_init_nm" init_nm ;;
+                  tmDefinition "bv_receive_nm" receive_nm). *)
+
+
+(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+Definition TT_remap : list (kername * string) :=
+  (* TT_remap_default ++  *)
+  [
+    remap <%% Amount %%> "tez"
+  ; remap <%% positive %%> "nat"
+  ; remap <%% Z %%> "int"
+  ; remap <%% Z.of_nat %%> "int"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.eqb %%> "eqInt"
+  ; remap <%% Z.gtb %%> "gtbInt"
+  ; remap <%% Nat.ltb %%> "ltbNat"
+  ; remap <%% Z.modulo %%> "modInt"
+  ; remap <%% Z.mul %%> "mulInt"
+  (* ; remap <%% Z.pow %%> "powInt" *)
+  ; remap <%% N.lxor %%> "lxorNat"
+  ; remap <%% N.succ_pos %%> "(addNat 1)"
+  ; remap <%% mod_pow %%> "mod_pow"
+  ; remap <%% Egcd.egcd %%> "egcd"
+  (* ; remap <%% List.nth %%> "List.nth" *)
+  (* ; remap <%% List.firstn %%> "List.firstn" *)
+  (* ; remap <%% List.skipn %%> "List.skipn" *)
+
+  ; remap <%% oneN %%> "1"
+  ; remap <%% four %%> "4"
+  ; remap <%% seven %%> "7"
+  ; remap <%% _1234583932 %%> "1234583932"
+  ; remap <%% _23241 %%> "23241"
+  ; remap <%% _159338231 %%> "159338231"
+  ; remap <%% _5 %%> "5"
+  ; remap <%% _3 %%> "3"
+  ; remap <%% Z3 %%> "3"
+  ; remap <%% _11 %%> "11"
+  (* ; remap <%% five %%> "5" *)
+  ; remap <%% @ContractCallContext %%> "(address * (address * int))"
+  ; remap <%% @Chain %%> "(address * (address * address))" (* chain_height, current_slot, finalized_height *)
+  ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @current_slot %%> "(fun c -> fst (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
+  ; remap <%% @finalized_height %%> "(fun c -> snd (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
+  ; remap <%% @ctx_from %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @AddressMap.AddrMap %%> "addrMap"
+  ; remap <%% @AddressMap.add %%> "Map.add"
+  ; remap <%% @AddressMap.find %%> "Map.find"
+  ; remap <%% @AddressMap.values %%> "Map.to_list"
+  ; remap <%% @AddressMap.empty %%> "(Map [])"
+
+  (* ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof" *)
+  (* ; remap <%% @BV.make_signup_msg %%> "make_signup_msg" *)
+  (* ; remap <%% @BV.make_commit_msg %%> "make_commit_msg" *)
+  (* ; remap <%% @BV.make_vote_msg %%> "make_vote_msg" *)
+  (* ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof" *)
+  (* ; remap <%% @BV.secret_key_proof %%> "secret_key_proof" *)
+  (* ; remap <%% @BV.hash_sk_data %%> "hash_sk_data" *)
+  (* ; remap <%% @BV.hash_sv_data %%> "hash_sv_data" *)
+
+  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
+  (* ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote" *)
+  (* ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote" *)
+  (* ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes" *)
+
+
+  ; remap <%% modulus %%> modulus_
+  ; remap <%% BV.encodeA %%> "nat"
+  ; remap <%% BV.encodeNat %%> "nat"
+  
+
+  ; remap <%% @List.fold_left %%> "List.fold"
+  ; remap <%% @List.map %%> "List.map"
+  ; remap <%% @List.find %%> "List.find"
+  ; remap <%% @List.length %%> "List.length"
+  ; remap <%% @List.app %%> "List.append"
+  ; remap <%% @Serializable.serialize %%> "TODO_serialize"
+  ; remap <%% @Serializable.deserialize %%> "TODO_deserialize"
+  ].
+(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+Definition TT_rename : list (string * string):=
+  [ ("Some", "Some")
+  ; ("None", "None")
+  ; ("Zpos" ,"int")
+  ; ("Npos" ,"(fun (n:nat) -> n)")
+  ; ("Zneg" ,"-")
+  ; ("Z0" ,"0")
+  ; ("N0" ,"0")
+  ; ("xH" ,"0")
+  ; ("1" ,"1")
+  ; ("nil", "[]")
+  ; ("true", "true")
+  ; ("false", "false")
+  ; (string_of_kername <%% BV.State %%>, "State")  (* we add [storage] so it is printed without the prefix *) 
+  ; ("tt", "()")
+  ].
+
+(* Time MetaCoq Run (
+  t <- liquidity_prepare_extraction PREFIX TT_remap TT_rename to_inline BV_MODULE bv_env bv_init_nm bv_receive_nm ;;
+  tmDefinition BV_MODULE.(lmd_module_name) t
+  ).
+
+Print liquidity_boardroomvoting.  *)
 
 Time MetaCoq Run
      (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;

--- a/extraction/examples/BoardroomVotingExtraction.v
+++ b/extraction/examples/BoardroomVotingExtraction.v
@@ -1,0 +1,156 @@
+
+
+(** * Extraction of a counter contract with refinement types to Liquidity *)
+
+(** The contract uses refinement types to specify some functional correctness properties *)
+
+From Coq Require Import PeanoNat ZArith Notations Bool.
+
+From MetaCoq.Template Require Import Loader.
+From MetaCoq.Erasure Require Import Loader.
+
+From ConCert Require Import MyEnv.
+From ConCert.Extraction Require Import LPretty LiquidityExtract Common Extraction.
+From ConCert.Execution Require Import Blockchain Common.
+
+From Coq Require Import List Ascii String.
+Local Open Scope string_scope.
+
+From MetaCoq.Template Require Import All.
+
+Import ListNotations.
+Import MonadNotation.
+Import AddressMap.
+
+Open Scope Z.
+
+
+Definition PREFIX := "".
+
+From ConCert.Execution.Examples Require Import BoardroomVotingTest.
+
+(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+Definition TT_remap : list (kername * string) :=
+  (* [ remap <%% bool %%> "bool"
+  ; remap <%% list %%> "list"
+  ; remap <%% Amount %%> "tez"
+  ; remap <%% option %%> "option"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z %%> "int"
+  ; remap <%% nat %%> "key_hash" (* type of account addresses*)
+  ; remap <%% @fst %%> "fst"
+  ; remap <%% @snd %%> "snd" ]. *)
+  TT_remap_default ++ [
+    remap <%% @ContractCallContext %%> "(address * (address * int))"
+  ; remap <%% @ctx_from %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @AddressMap.add %%> "Map.add"
+  ; remap <%% @AddressMap.find %%> "Map.find"
+  ; remap <%% @AddressMap.empty %%> "(Map [])"
+
+  ; remap <%% Nat.ltb %%> "ltbNat"
+  ].
+(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+Definition TT_rename : list (string * string):=
+  [ ("Some", "Some")
+  ; ("None", "None")
+  ; ("Z0" ,"0")
+  ; ("nil", "[]")
+  ; ("true", "true")
+  ; (string_of_kername <%% BV.State %%>, "State")  (* we add [storage] so it is printed without the prefix *) 
+  ].
+Require Import ContractMonads.
+
+Definition init_ctx := (Chain × ContractCallContext).
+
+Definition init_wrapper (cctx : init_ctx) := (run_contract_initer BV.init) cctx.1 cctx.2.
+
+Notation msg := (Chain × ContractCallContext × option BV.Msg).
+
+Definition receive_wrapper (msg : msg)
+                           (st : BV.State) : option (list ActionBody * BV.State):= 
+  None.                           
+  (* match BV.boardroom_voting.(receive) msg.1 msg.2.1 st msg.2.2 with
+  | Some (st, acts) => Some (acts, st)
+  | None => None
+  end. *)
+
+
+Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
+  {| (* a name for the definition with the extracted code *)
+    lmd_module_name := "liquidity_boardroomvoting" ;
+
+    (* definitions of operations on pairs and ints *)
+    lmd_prelude := concat nl [prod_ops;int_ops];
+
+    (* initial storage *)
+    lmd_init := init_wrapper ;
+
+    (* no extra operations in [init] are required *)
+    lmd_init_prelude := "" ;
+
+    (* the main functionality *)
+    lmd_receive := receive_wrapper;
+
+    (* code for the entry point *)
+    lmd_entry_point := printWrapper (PREFIX ++ "receive_wrapper") ++ nl
+                      ++ printMain |}.
+
+(** We run the extraction procedure inside the [TemplateMonad].
+    It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
+    that removes application of boxes to constants and constructors. *)
+Require Import RecordSet.
+Definition to_inline : list kername := 
+  [
+    <%% Monads.Monad_option %%>
+  ; <%% @contract_initer_monad %%>
+  ; <%% @contract_receiver_monad %%>
+  ; <%% @contract_reader_to_contract_initer %%>
+  ; <%% @option_to_contract_initer %%>
+  ; <%% @contract_reader_to_receiver %%>
+  ; <%% @option_to_contract_receiver %%>
+  ; <%% @run_contract_initer %%>
+  ; <%% @ContractIniter %%>
+  ; <%% @ContractReader %%>
+  
+  ; <%% @Monads.bind %%>
+  ; <%% @Monads.ret %%>
+  ; <%% @Monads.lift %%>
+  ; <%% bool_rect %%>
+  ; <%% bool_rec %%>
+  ; <%% option_map %%>
+  ; <%% @Extras.with_default %%>
+
+  ; <%% @BV.setter_from_getter_State_owner %%>
+  ; <%% @BV.setter_from_getter_State_registered_voters %%>
+  ; <%% @BV.setter_from_getter_State_public_keys %%>
+  ; <%% @BV.setter_from_getter_State_setup %%>
+  ; <%% @BV.setter_from_getter_State_tally %%>
+
+  ; <%% @BV.setter_from_getter_VoterInfo_voter_index %%>
+  ; <%% @BV.setter_from_getter_VoterInfo_vote_hash %%>
+  ; <%% @BV.setter_from_getter_VoterInfo_public_vote %%>
+
+  ; <%% @BV.set_State_owner %%>
+  ; <%% @BV.set_State_registered_voters %%>
+  ; <%% @BV.set_State_public_keys %%>
+  ; <%% @BV.set_State_setup %%>
+  ; <%% @BV.set_State_tally %%>
+
+  ; <%% @BV.set_VoterInfo_voter_index %%>
+  ; <%% @BV.set_VoterInfo_vote_hash %%>
+  ; <%% @BV.set_VoterInfo_public_vote %%>
+  ].
+
+
+Time MetaCoq Run
+     (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;
+      tmDefinition BV_MODULE.(lmd_module_name) t
+     ).
+
+Print liquidity_boardroomvoting.
+
+(** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
+Redirect "examples/liquidity-extract/CounterRefinementTypes.liq" Compute liquidity_counter.

--- a/extraction/examples/BoardroomVotingExtraction.v
+++ b/extraction/examples/BoardroomVotingExtraction.v
@@ -21,23 +21,43 @@ Open Scope Z.
 Definition PREFIX := "".
 
 From ConCert.Execution.Examples Require Import BoardroomVotingTest.
+(* Get string representation of modulus, and remap it. This way we avoid having the extraction compute the number. *)
+Definition modulus_ := StringExtra.string_of_Z BoardroomVotingTest.modulus.
+
+Print BoardroomMath.BoardroomAxioms.
+(* TODO: remap all definition in boardroomaxioms *)
+(* Definition TT_boardroomaxioms : list (kername * string) :=
+  [
+    elmeqb_spec : 
+    zero 
+    one 
+    add : A -> A -
+    mul : A -> A -
+    opp : A -
+    inv : A -
+    pow : A -> Z -
+    order 
+    expeq := fun e e' : Z => e mod (order - 1) = e' mod (order - 
+    order_ge_2 : order >
+  ] *)
 
 (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
 Definition TT_remap : list (kername * string) :=
-  (* [ remap <%% bool %%> "bool"
-  ; remap <%% list %%> "list"
-  ; remap <%% Amount %%> "tez"
-  ; remap <%% option %%> "option"
-  ; remap <%% Z.add %%> "addInt"
-  ; remap <%% Z.sub %%> "subInt"
-  ; remap <%% Z.leb %%> "leInt"
-  ; remap <%% Z.ltb %%> "ltInt"
-  ; remap <%% Z %%> "int"
-  ; remap <%% nat %%> "key_hash" (* type of account addresses*)
-  ; remap <%% @fst %%> "fst"
-  ; remap <%% @snd %%> "snd" ]. *)
   TT_remap_default ++ [
-    remap <%% @ContractCallContext %%> "(address * (address * int))"
+      remap <%% Amount %%> "tez"
+    ; remap <%% Z %%> "int"
+    ; remap <%% Z.add %%> "addInt"
+    ; remap <%% Z.sub %%> "subInt"
+    ; remap <%% Z.leb %%> "leInt"
+    ; remap <%% Z.ltb %%> "ltInt"
+    ; remap <%% Z.add %%> "addInt"
+    ; remap <%% Z.eqb %%> "eqInt"
+    ; remap <%% Z.gtb %%> "gtbInt"
+    ; remap <%% Nat.ltb %%> "ltbNat"
+    ; remap <%% Z.modulo %%> "modInt"
+    ; remap <%% Z.mul %%> "mulInt"
+
+  ; remap <%% @ContractCallContext %%> "(address * (address * int))"
   ; remap <%% @Chain %%> "(address * (address * address))" (* chain_height, current_slot, finalized_height *)
   ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
   ; remap <%% @current_slot %%> "(fun c -> fst (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
@@ -49,29 +69,33 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% @AddressMap.values %%> "Map.to_list"
   ; remap <%% @AddressMap.empty %%> "(Map [])"
 
-  ; remap <%% Nat.ltb %%> "ltbNat"
+  ; remap <%% BoardroomMath.Zp.mod_pow %%> "mod_powInt"
+  ; remap <%% BoardroomMath.Zp.mod_inv %%> "mod_invInt"
 
-  ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof"
-  ; remap <%% @BV.make_signup_msg %%> "make_signup_msg"
-  ; remap <%% @BV.make_commit_msg %%> "make_commit_msg"
-  ; remap <%% @BV.make_vote_msg %%> "make_vote_msg"
-  ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof"
-  ; remap <%% @BV.secret_key_proof %%> "secret_key_proof"
-  ; remap <%% @BV.hash_sk_data %%> "hash_sk_data"
+  (* ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof" *)
+  (* ; remap <%% @BV.make_signup_msg %%> "make_signup_msg" *)
+  (* ; remap <%% @BV.make_commit_msg %%> "make_commit_msg" *)
+  (* ; remap <%% @BV.make_vote_msg %%> "make_vote_msg" *)
+  (* ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof" *)
+  (* ; remap <%% @BV.secret_key_proof %%> "secret_key_proof" *)
+  (* ; remap <%% @BV.hash_sk_data %%> "hash_sk_data" *)
   ; remap <%% @BV.hash_sv_data %%> "hash_sv_data"
 
-  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
-  (* ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote" *)
+  ; remap <%% @BV.handle_signup %%> "handle_signup"
+  ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote"
   (* ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote" *)
   (* ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes" *)
 
 
-  ; remap <%% BoardroomVotingTest.modulus %%> "13"
+  ; remap <%% BoardroomVotingTest.modulus %%> modulus_
 
-  ; remap <%% @BoardroomMath.BoardroomAxioms %%> "BoardroomAxioms"
-  ; remap <%% @BoardroomMath.Generator %%> "BoardroomAxioms"
-  ; remap <%% @BoardroomMath.DiscreteLog %%> "BoardroomAxioms"
+  (* ; remap <%% @modulus_prime %%> "modulus_prime" *)
+  (* ; remap <%% @generator_is_generator %%> "generator_is_generator" *)
+  (* ; remap <%% @BoardroomMath.boardroom_axioms_Z %%> "BoardroomMath.boardroom_axioms_Z" *)
+  (* ; remap <%% @BoardroomMath.Generator %%> "BoardroomAxioms" *)
+  (* ; remap <%% @BoardroomMath.DiscreteLog %%> "BoardroomAxioms" *)
   
+
   ; remap <%% @List.map %%> "map"
   ; remap <%% @List.find %%> "find"
   ; remap <%% @countable.encode %%> "TODO_encode"
@@ -103,6 +127,11 @@ Definition receive_wrapper (msg : msg)
   | None => None
   end.
 
+Definition dummy_init : init_ctx -> BV.Setup -> option BV.State := fun _ _ => None .
+Definition dummy_receive : msg -> BV.State -> option (list ActionBody × BV.State) := 
+  fun _ _  => 
+    let x := BoardroomMath.add 1 2 in
+    None.
 
 Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
   {| (* a name for the definition with the extracted code *)
@@ -112,13 +141,13 @@ Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
     lmd_prelude := concat nl [prod_ops;int_ops];
 
     (* initial storage *)
-    lmd_init := init_wrapper ;
+    lmd_init := dummy_init ;
 
     (* no extra operations in [init] are required *)
     lmd_init_prelude := "" ;
 
     (* the main functionality *)
-    lmd_receive := receive_wrapper;
+    lmd_receive := dummy_receive;
 
     (* code for the entry point *)
     lmd_entry_point := printWrapper (PREFIX ++ "receive_wrapper") ++ nl
@@ -127,7 +156,34 @@ Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
 (** We run the extraction procedure inside the [TemplateMonad].
     It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
     that removes application of boxes to constants and constructors. *)
-Require Import RecordSet.
+(* Require Import RecordSet. *)
+Print Params.
+Definition inline_boardroom_params : list kername :=
+  [
+      <%% Params.A %%>
+    ; <%% Params.H %%>
+    ; <%% Params.ser %%>
+    ; <%% Params.axioms %%>
+    ; <%% Params.gen %%>
+    ; <%% Params.discr_log %%>
+    ; <%% BoardroomVotingTest.axioms_instance %%>
+    (* this *)
+    ; <%% BoardroomMath.boardroom_axioms_Z %%>
+
+    (* BoardroomAxioms *)
+    ; <%% @BoardroomMath.add%%>
+    (* ; <%% @BoardroomMath.elmeq%%> *)
+    ; <%% @BoardroomMath.elmeqb%%>
+    ; <%% @BoardroomMath.zero%%>
+    ; <%% @BoardroomMath.one%%>
+    ; <%% @BoardroomMath.mul%%>
+    ; <%% @BoardroomMath.opp%%>
+    ; <%% @BoardroomMath.inv%%>
+    ; <%% @BoardroomMath.pow%%>
+    ; <%% @BoardroomMath.order%%>
+
+  ].
+
 
 Definition inline_contract_monad_projection : list kername := 
   [
@@ -151,9 +207,9 @@ Definition inline_contract_monad_projection : list kername :=
 
 
 Definition to_inline : list kername := 
-  inline_contract_monad_projection
-  ++
-  [
+     inline_contract_monad_projection
+  ++ inline_boardroom_params
+  ++ [
     <%% Monads.Monad_option %%>
   (* ; <%% @Monads.MonadTrans %%> *)
   ; <%% @contract_initer_monad %%>
@@ -196,12 +252,21 @@ Definition to_inline : list kername :=
   ; <%% @BV.set_VoterInfo_voter_index %%>
   ; <%% @BV.set_VoterInfo_vote_hash %%>
   ; <%% @BV.set_VoterInfo_public_vote %%>
+
+
   ].
 
-(* Time MetaCoq Run
+(* Definition asd := (BoardroomMath.add 1 2).
+
+Time MetaCoq Quote Recursively Definition ex1 := asd.
+Check ex1.
+Definition r1 := Eval vm_compute in (liquidity_extract_single TT_remap TT_rename true BV_MODULE.(lmd_prelude) "harness?" ex1).
+Print r1. *)
+
+Time MetaCoq Run
      (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;
       tmDefinition BV_MODULE.(lmd_module_name) t
-     ). *)
+     ).
 
 Print liquidity_boardroomvoting.
 

--- a/extraction/examples/BoardroomVotingExtraction.v
+++ b/extraction/examples/BoardroomVotingExtraction.v
@@ -60,10 +60,10 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% @BV.hash_sk_data %%> "hash_sk_data"
   ; remap <%% @BV.hash_sv_data %%> "hash_sv_data"
 
-  ; remap <%% @BV.handle_signup %%> "handle_signup"
-  ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote"
-  ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote"
-  ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes"
+  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
+  (* ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote" *)
+  (* ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote" *)
+  (* ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes" *)
 
 
   ; remap <%% BoardroomVotingTest.modulus %%> "13"
@@ -163,9 +163,10 @@ Definition to_inline : list kername :=
   ; <%% @option_to_contract_initer %%>
   ; <%% @contract_reader_to_receiver %%>
   ; <%% @option_to_contract_receiver %%>
-
+  
+  ; <%% @ContractReceiver %%>
+  ; <%% @ContractIniter %%>
   (* Dont work *)
-  (* ; <%% @ContractIniter %%> *)
   (* ; <%% @ContractReader %%> *)
   
   ; <%% @Monads.bind %%>
@@ -196,7 +197,6 @@ Definition to_inline : list kername :=
   ; <%% @BV.set_VoterInfo_vote_hash %%>
   ; <%% @BV.set_VoterInfo_public_vote %%>
   ].
-
 
 (* Time MetaCoq Run
      (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;

--- a/extraction/examples/BoardroomVotingExtractionCameLIGO.v
+++ b/extraction/examples/BoardroomVotingExtractionCameLIGO.v
@@ -1,0 +1,364 @@
+(** * Extraction of a counter contract with refinement types to Liquidity *)
+
+(** The contract uses refinement types to specify some functional correctness properties *)
+
+From Coq Require Import PeanoNat ZArith.
+
+From ConCert.Extraction Require Import LPretty CameLIGOExtract Common.
+From ConCert.Execution Require Import Blockchain Common LocalBlockchain.
+
+From Coq Require Import List String.
+Local Open Scope string_scope.
+
+From MetaCoq.Template Require Import All.
+
+Import ListNotations.
+Import MonadNotation.
+Import AddressMap.
+
+Open Scope Z.
+
+Definition PREFIX := "".
+
+From ConCert.Execution.Examples Require Import BoardroomVotingZ.
+
+(* In this example we just use xor for the hash function, which is
+   obviously not cryptographically secure. *)
+Definition modulus : Z := 201697267445741585806196628073.
+Definition four := 4%nat.
+Definition seven := 7%nat.
+Definition _1234583932 := 1234583932.
+Definition _23241 := 23241.
+Definition _159338231 := 159338231.
+Definition oneN : N := 1%N.
+Definition Z3 : Z := 3.
+Definition generator : Z := Z3.
+
+Definition hash_func (l : list positive) : positive :=
+  N.succ_pos (fold_left (fun a p => N.lxor (Npos p) a) l oneN).
+
+  (* Instance Base : ChainBase := LocalChainBase AddrSize. *)
+Definition AddrSize := (2^128)%N.
+Instance Base : ChainBase := LocalBlockchain.LocalChainBase AddrSize.
+
+Module Params <: BoardroomParams.
+  Definition H : list positive -> positive := hash_func.
+  Definition Base := Base .
+  Definition prime := modulus.
+  Definition generator := generator.
+End Params.  
+Module BV := BoardroomVoting Params. Import BV.
+
+(* Compute the signup messages that would be sent by each party.
+   We just use the public key as the chosen randomness here. *)
+Definition _3 := 3%nat.
+Definition _5 := 5.
+Definition _11 := 11.
+
+Definition num_parties : nat := seven.
+Definition votes_for : nat := four.
+
+(* a pseudo-random generator for secret keys *)
+Definition sk n := (Z.of_nat n + _1234583932) * (modulus - _23241)^_159338231.
+
+(* Make a list of secret keys, here starting at i=7 *)
+Definition sks : list Z := map sk (seq seven num_parties).
+
+(* Make a list of votes for each party *)
+Definition svs : list bool :=
+  Eval compute in map (fun _ => true)
+                      (seq 0 votes_for)
+                  ++ map (fun _ => false)
+                         (seq 0 (num_parties - votes_for)).
+
+(* Get string representation of modulus, and remap it. This way we avoid having the extraction compute the number. *)
+Definition modulus_ := StringExtra.string_of_Z modulus.
+
+Require Import ContractMonads.
+
+Definition setupWchain := (BV.Setup × Chain).
+
+Definition init_wrapper (cctx : ContractCallContext) (s : setupWchain) := (run_contract_initer BV.init) s.2 cctx s.1.
+
+Definition receive_wrapper (c : Chain)
+                           (ctx : ContractCallContext)
+                           (st : BV.State) 
+                           (msg : option BV.Msg)
+                           : option (list ActionBody * BV.State):= 
+                           (* None. *)
+  match (run_contract_receiver BV.receive) c ctx st msg with
+  | Some (st, acts) => Some (acts, st)
+  | None => None
+  end.
+
+Definition storage_alias := "type storage = state".
+Definition bruteforce_tally_def := 
+ "(fun (votes :  (a) list) -> 
+  let rec bruteforce_tally_aux  (n, votes_product : nat * a) : nat option = 
+    if elmeqb (pow_p generator (int n)) votes_product then 
+        Some (n) 
+    else if n = 0n then 
+      None
+    else
+      let n0 = n - 1n in
+        (bruteforce_tally_aux (unsafe_int_to_nat n0, votes_product))
+  in bruteforce_tally_aux ((List.length votes), (prod votes)))".
+
+Definition extra_ops := 
+ "let unsafe_int_to_nat (n : int) = abs(n)
+  let predN (n : nat) = unsafe_int_to_nat (n - 1n)
+  let mod_pow (a : int) (e : int) (p : int) : int = failwith (""unimplemented"")
+  let egcd (a : int) (p : int) : int * int = failwith (""unimplemented"")
+  
+  let nth  = let rec nth  (n, l, default : nat * int list * int) : int = 
+  if n = 0n then (match l with 
+  []  -> default
+   | x :: r -> x)
+  else let m = predN n in (match l with 
+  []  -> default
+   | x :: t -> (nth (m, t, default)))
+   in fun (n:nat) (l:int list) (default:int) -> nth (n, l, default)
+   
+   
+  let prod (l : int list) =
+    List.fold (fun (a, b: int*int) -> multInt a b) l 1
+  
+  let firstn (n : nat) (l : int list) : int list =
+    let (_,r) = List.fold_left (fun ((n, a),b : (nat * int list) * int) ->
+        if n = 0n then (0n, a)
+        else (predN n, b :: a)) (n,([] : int list)) l in
+   r
+  
+  let skipn  = let rec skipn  (n, l : nat * int list) : int list = 
+   if n = 0n then l
+    else let n0 = predN n in (match l with 
+    | []  -> ([]:int list)
+    | a :: l0 -> (skipn (n0, l0 : nat * int list)))
+    in fun (n : nat) (l : int list) -> skipn (n, l : nat * int list)".
+
+
+Definition existsb_def := 
+  "(let existsb (f : voterInfo -> bool) = let rec existsb  (l: voterInfo list) : bool = 
+  match l with 
+  []  -> false
+  | a :: l0 -> (if (f a) then true else (existsb (l0)))
+  in fun (l: voterInfo list) -> existsb (l) in existsb)".
+
+Definition dummy_chain :=
+"let dummy_chain : (nat * (nat * nat)) = (Tezos.level, (Tezos.level, Tezos.level))".
+
+Definition hash_func_def := "let hash_func (l :  (nat) list) = addN 1n (List.fold_left (fun (a, p : nat * nat) -> Bitwise.xor p a) 1n l)".
+
+Definition callctx := "(Tezos.sender,(Tezos.self_address,(Tezos.amount,Tezos.balance)))".
+
+
+Definition BV_MODULE : CameLIGOMod BV.Msg ContractCallContext setupWchain BV.State ActionBody :=
+  {| (* a name for the definition with the extracted code *)
+    lmd_module_name := "cameligo_boardroomvoting" ;
+
+    (* definitions of operations on pairs and ints *)
+    lmd_prelude := concat nl [CameLIGOPretty.CameLIGOPrelude; extra_ops; dummy_chain; hash_func_def];
+
+    (* initial storage *)
+    lmd_init := init_wrapper;
+
+    (* no extra operations in [init] are required *)
+    lmd_init_prelude := "";
+
+    lmd_receive_prelude := "";
+    (* the main functionality *)
+    lmd_receive := receive_wrapper;
+
+    (* code for the entry point *)
+    lmd_entry_point := CameLIGOPretty.printWrapper (PREFIX ++ "receive_wrapper")
+                        "msg"
+                        "state"
+                        callctx
+                        ++ nl
+                        ++ CameLIGOPretty.printMain "state" |}.
+
+Definition inline_boardroom_params : list kername :=
+  [
+      <%% Params.H %%>
+    ; <%% Params.generator %%>
+  ].
+
+
+Definition inline_contract_monad_projection : list kername := 
+  [
+      <%% @ContractMonads.chain_height %%>
+    ; <%% @ContractMonads.current_slot %%>
+    ; <%% @ContractMonads.finalized_height %%>
+    ; <%% @ContractMonads.caller_addr %%>
+    ; <%% @ContractMonads.my_addr %%>
+    ; <%% @ContractMonads.my_balance %%>
+    ; <%% @ContractMonads.call_amount %%>
+    ; <%% @ContractMonads.deployment_setup %%>
+    ; <%% @ContractMonads.reject_deployment %%>
+    ; <%% @ContractMonads.accept_deployment %%>
+    ; <%% @ContractMonads.call_msg %%>
+    ; <%% @ContractMonads.my_state %%>
+    ; <%% @ContractMonads.queue %%>
+    ; <%% @ContractMonads.reject_call %%>
+    ; <%% @ContractMonads.accept_call %%>
+    ; <%% @ContractMonads.build_contract %%>
+  ].
+
+
+Definition to_inline : list kername := 
+     inline_contract_monad_projection
+  ++ inline_boardroom_params
+  ++ [
+    <%% Monads.Monad_option %%>
+  ; <%% ContractIniterSetupState %%>
+  ; <%% ContractReceiverStateMsgState %%>
+  ; <%% @contract_initer_monad %%>
+  ; <%% @run_contract_initer %%>
+  ; <%% @run_contract_receiver %%>
+  ; <%% @contract_receiver_monad %%>
+  ; <%% @contract_reader_to_contract_initer %%>
+  ; <%% @option_to_contract_initer %%>
+  ; <%% @contract_reader_to_receiver %%>
+  ; <%% @option_to_contract_receiver %%>
+  
+  ; <%% @ContractReceiver %%>
+  ; <%% @ContractIniter %%>
+  
+  ; <%% @Monads.bind %%>
+  ; <%% @Monads.ret %%>
+  ; <%% @Monads.lift %%>
+  ; <%% bool_rect %%>
+  ; <%% bool_rec %%>
+  ; <%% option_map %%>
+  ; <%% @BV.isSome %%>
+  ; <%% @isNone %%>
+  ; <%% @Extras.with_default %%>
+
+  ; <%% @BV.setter_from_getter_State_owner %%>
+  ; <%% @BV.setter_from_getter_State_registered_voters %%>
+  ; <%% @BV.setter_from_getter_State_public_keys %%>
+  ; <%% @BV.setter_from_getter_State_setup %%>
+  ; <%% @BV.setter_from_getter_State_tally %%>
+
+  ; <%% @BV.setter_from_getter_VoterInfo_voter_index %%>
+  ; <%% @BV.setter_from_getter_VoterInfo_vote_hash %%>
+  ; <%% @BV.setter_from_getter_VoterInfo_public_vote %%>
+
+  ; <%% @BV.set_State_owner %%>
+  ; <%% @BV.set_State_registered_voters %%>
+  ; <%% @BV.set_State_public_keys %%>
+  ; <%% @BV.set_State_setup %%>
+  ; <%% @BV.set_State_tally %%>
+
+  ; <%% @BV.set_VoterInfo_voter_index %%>
+  ; <%% @BV.set_VoterInfo_vote_hash %%>
+  ; <%% @BV.set_VoterInfo_public_vote %%>
+
+  ; <%% @Common.AddressMap.AddrMap %%>
+  ].
+
+(** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
+Definition TT_remap : list (kername * string) :=
+  [
+    remap <%% Amount %%> "tez"
+  ; remap <%% BV.amount_eqb %%> "eqTez"
+  ; remap <%% positive %%> "nat"
+  ; remap <%% Z %%> "int"
+  ; remap <%% Z.of_nat %%> "int"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.eqb %%> "eqInt"
+  ; remap <%% Z.gtb %%> "gtbInt"
+  ; remap <%% Nat.ltb %%> "ltbN"
+  ; remap <%% Z.modulo %%> "modInt"
+  ; remap <%% Z.mul %%> "multInt"
+  ; remap <%% N.lxor %%> "Bitwise.xor"
+  ; remap <%% N.succ_pos %%> "addN 1n"
+  ; remap <%% mod_pow %%> "mod_pow"
+  ; remap <%% hash_func %%> "hash_func"
+  ; remap <%% Egcd.egcd %%> "egcd"
+  ; remap <%% bruteforce_tally %%> bruteforce_tally_def (* inlined definition *)
+  ; remap <%% @List.existsb %%> existsb_def (* inlined definition *)
+  ; remap <%% @List.nth %%> "nth"
+  ; remap <%% @List.firstn %%> "firstn"
+  ; remap <%% @List.skipn %%> "skipn"
+  ; remap <%% Euler.prod %%> "prod"
+
+  ; remap <%% oneN %%> "1n"
+  ; remap <%% onePos %%> "1n"
+  ; remap <%% Z3 %%> "3"
+  ; remap <%% four %%> "4n"
+  ; remap <%% seven %%> "7n"
+  ; remap <%% _1234583932 %%> "1234583932"
+  ; remap <%% _23241 %%> "23241"
+  ; remap <%% _159338231 %%> "159338231"
+  ; remap <%% _5 %%> "5"
+  ; remap <%% _3 %%> "3n"
+  ; remap <%% _11 %%> "11"
+  ; remap <%% twoZ %%> "2"
+  ; remap <%% @ActionBody %%> "operation"
+  ; remap <%% @ContractCallContext %%> "(address * (address * (tez * tez)))"
+  ; remap <%% @Chain %%> "(nat * (nat * nat))" (* chain_height, current_slot, finalized_height *)
+  ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @Blockchain.current_slot %%> "(fun (c:(nat * (nat * nat))) -> c.1.0)" (* small hack, but valid since Chain is mapped to a tuple *)
+  ; remap <%% @finalized_height %%> "(fun (c:(nat * (nat * nat))) -> snd (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
+  ; remap <%% @ctx_from %%> "(fun (c:(address * (address * (tez * tez)))) -> c.0)" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_amount %%> "(fun (c:(address * (address * (tez * tez)))) -> c.1.1.1)" 
+  ; remap <%% @ctx_contract_address %%> "(fun (c:(address * (address * (tez * tez)))) -> c.1.0)" 
+  ; remap <%% @ctx_contract_balance %%> "(fun (c:(address * (address * (tez * tez)))) -> c.1.1.0)" 
+  ; remap <%% @AddressMap.add %%> "Map.add"
+  ; remap <%% @AddressMap.find %%> "Map.find_opt"
+  ; remap <%% @AddressMap.of_list %%> "Map.of_list"
+  ; remap <%% @AddressMap.values %%> (* only way to obtain values is via fold - specialized to voterInfo*)
+  "(fun (v:(address, voterInfo) map) -> 
+    Map.fold (fun (acc, (_,info) : voterInfo list * (address * voterInfo)) -> info :: acc) 
+    v ([]: voterInfo list))"
+  ; remap <%% @AddressMap.keys %%> "Map.keys"
+  ; remap <%% @AddressMap.empty %%> "Map.empty"
+
+  ; remap <%% modulus %%> modulus_
+  ; remap <%% BV.encodeA %%> "unsafe_int_to_nat"
+  ; remap <%% BV.encodeNat %%> ""
+  
+
+  ; remap <%% @List.fold_left %%> "List.fold_left"
+  ; remap <%% @List.map %%> "List.map"
+  ; remap <%% @List.find %%> "List.find"
+  ; remap <%% @List.length %%> "List.length"
+  ; remap <%% @List.app %%> "List.fold_left (fun (acc, e : (int list) * int) -> e :: acc)" (* small hack since ligo doesn't have append on lists *)
+  ].
+(** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
+Definition TT_rename : list (string * string):=
+  [ ("Some", "Some")
+  ; ("None", "None")
+  ; ("Zpos" ,"int")
+  ; ("Npos" ,"")
+  ; ("Zneg" ,"-")
+  ; ("Z0" ,"0")
+  ; ("0" ,"0n")
+  ; ("N0" ,"0n")
+  ; ("xH" ,"0")
+  ; ("1" ,"1")
+  ; ("2" ,"2n")
+  ; ("S" ,"1n +")
+  ; ("nil", "[]")
+  ; ("true", "true")
+  ; ("false", "false")
+  ; ("hash", "hash_")
+  ; (string_of_kername <%% BV.State %%>, "state")  (* we add [storage] so it is printed without the prefix *) 
+  ; ("tt", "()")
+  ].
+
+  
+(* Time MetaCoq Run (
+  CameLIGO_prepare_extraction PREFIX to_inline TT_remap TT_rename callctx BV_MODULE
+  ).
+
+Time Definition cameLIGO_boardroomvoting := Eval vm_compute in cameligo_boardroomvoting_prepared.
+
+Print cameLIGO_boardroomvoting. 
+
+Redirect "examples/cameligo-extract/BoardroomVoting.mligo" MetaCoq Run (tmMsg cameLIGO_boardroomvoting). *)

--- a/extraction/examples/BoardroomVotingExtractionLiquidity.v
+++ b/extraction/examples/BoardroomVotingExtractionLiquidity.v
@@ -1,7 +1,3 @@
-(** * Extraction of a counter contract with refinement types to Liquidity *)
-
-(** The contract uses refinement types to specify some functional correctness properties *)
-
 From Coq Require Import PeanoNat ZArith.
 
 From ConCert.Extraction Require Import LPretty LiquidityExtract Common.
@@ -37,7 +33,6 @@ Definition generator : Z := Z3.
 Definition hash_func (l : list positive) : positive :=
   N.succ_pos (fold_left (fun a p => N.lxor (Npos p) a) l oneN).
 
-  (* Instance Base : ChainBase := LocalChainBase AddrSize. *)
 Definition AddrSize := (2^128)%N.
 Instance Base : ChainBase := LocalBlockchain.LocalChainBase AddrSize.
 
@@ -71,55 +66,6 @@ Definition svs : list bool :=
                   ++ map (fun _ => false)
                          (seq 0 (num_parties - votes_for)).
 
-(* Compute the public keys for each party *)
-(* 
-Time Definition pks : list Z :=
-  Eval vm_compute in map compute_public_key sks.
-
-Definition rks : list Z :=
-  Eval vm_compute in map (reconstructed_key pks) (seq 0 (length pks)).
-
-Time Definition signups : list Msg :=
-  Eval vm_compute in map (fun '(sk, pk, i) => make_signup_msg sk _5 i)
-                             (Extras.zip (zip sks pks) (seq 0 (length sks))).
-
-(* Compute the submit_vote messages that would be sent by each party *)
-(* Our functional correctness proof assumes that the votes were computed
-   using the make_vote_msg function provided by the contract.
-   In this example we just use the secret key as the random parameters. *)
-Definition votes : list Msg :=
-  Eval vm_compute in map (fun '(i, sk, sv, rk) => make_vote_msg pks i sk sv sk sk sk)
-                             (zip (zip (zip (seq 0 (length pks)) sks) svs) rks).
-
-Definition A a :=
-  BoundedN.of_Z_const AddrSize a.
-
-Local Open Scope nat.
-Definition addrs : list Address.
-Proof.
-  let rec add_addr z n :=
-    match n with
-    | O => constr:(@nil Address)
-    | S ?n => let tail := add_addr (z + 1)%Z n in
-              constr:(cons (A z) tail)
-    end in
-  let num := eval compute in num_parties in
-  let tm := add_addr _11%Z num in
-  let tm := eval vm_compute in tm in
-  exact tm.
-Defined.
-
-Definition voters_map : AddrMap unit := AddressMap.of_list (map (fun a => (a, tt)) addrs).
-
-Definition five := 5%nat.
-
-Definition deploy_setup :=
-  {| eligible_voters := voters_map;
-     finish_registration_by := _3;
-     finish_commit_by := None;
-     finish_vote_by := five;
-     registration_deposit := 0; |}. *)
-
 (* Get string representation of modulus, and remap it. This way we avoid having the extraction compute the number. *)
 Definition modulus_ := StringExtra.string_of_Z modulus.
 
@@ -142,34 +88,86 @@ Definition receive_wrapper (msg : msg)
 Definition dummy_init : init_ctx -> BV.Setup -> option BV.State := fun _ _ => None .
 
 Definition dummy_receive : msg -> BV.State -> option (list ActionBody × BV.State) := 
-  fun _ _  => 
-    let x := add_p 0 _5 in
+  fun m s  => 
+    let x := handle_signup 0 (0, 0) s s.(owner) 0%nat  in
     None.
+
+Definition storage_alias := "type storage = state".
+
+Definition bruteforce_tally_def := 
+ "let bruteforce_tally_aux  = 
+  let rec bruteforce_tally_aux  (n, votes_product) = 
+    if elmeqb (pow_p generator (int n)) votes_product then 
+        Some (n) 
+    else if n = 0p then 
+      None
+    else
+      let n0 = n - 1p in
+        (bruteforce_tally_aux (unsafe_int_to_nat n0, votes_product))
+  in fun n votes_product -> bruteforce_tally_aux (n, votes_product)".
+
+Definition extra_ops := 
+ "let unsafe_int_to_nat (n : int) =
+    let n = match%nat n with
+    | Plus n -> n
+    | Minus _ -> failwith ""n shound not be negative"" in
+    n
+  let predN (n : nat) = unsafe_int_to_nat (n - 1p)
+  
+  let nth  = let rec nth  (n, l, default) = 
+  if n = 0p then (match l with 
+  []  -> default
+   | x :: l' -> x)
+  else let m = predN n in (match l with 
+  []  -> default
+   | x :: t -> (nth (m, t, default)))
+   in fun n l default -> nth (n, l, default)
+  
+  let prod (l : int list) =
+    List.fold (fun (a, b) -> mulInt a b) l 1
+  
+  let firstn (n : nat) (l : 'a list) =
+    let (_,r) = List.fold (fun (b,(n, a)) ->
+        if n = 0p then (0p, a)
+        else (predN n, b :: a)) l (n,[]) in
+    List.rev r
+  
+  let skipn  = let rec skipn  (n, l) = 
+  if n = 0p then l
+   else let n0 = predN n in (match l with 
+  []  -> []
+   | a :: l0 -> (skipn (n0, l0)))
+   in fun n l -> skipn (n, l)
+
+  let existsb (f : 'a -> bool) = let rec existsb  (l) = 
+  match l with 
+  []  -> false
+   | a :: l0 -> (if (f a) then true else (existsb (l0)))
+   in fun l -> existsb (l)".
+
+Definition hash_func_def := "let hash_func (l : ( (nat) list)) = addNat 1p (List.fold (fun (p,a) -> lxorNat p a) l 1p)".
+
 
 Definition BV_MODULE : LiquidityMod msg init_ctx BV.Setup BV.State ActionBody :=
   {| (* a name for the definition with the extracted code *)
     lmd_module_name := "liquidity_boardroomvoting" ;
 
     (* definitions of operations on pairs and ints *)
-    lmd_prelude := LiquidityPrelude;
+    lmd_prelude := concat nl [LiquidityPrelude; extra_ops; hash_func_def];
 
     (* initial storage *)
-    lmd_init := init_wrapper;
+    lmd_init := dummy_init;
 
     (* no extra operations in [init] are required *)
     lmd_init_prelude := "" ;
 
     (* the main functionality *)
-    lmd_receive := receive_wrapper;
+    lmd_receive := dummy_receive;
 
     (* code for the entry point *)
-    lmd_entry_point := printWrapper (PREFIX ++ "receive_wrapper") ++ nl
+    lmd_entry_point := storage_alias ++ nl
+                      ++ printWrapper (PREFIX ++ "receive_wrapper") ++ nl
                       ++ printMain |}.
-
-(** We run the extraction procedure inside the [TemplateMonad].
-    It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
-    that removes application of boxes to constants and constructors. *)
-(* Require Import RecordSet. *)
 
 Definition inline_boardroom_params : list kername :=
   [
@@ -180,22 +178,22 @@ Definition inline_boardroom_params : list kername :=
 
 Definition inline_contract_monad_projection : list kername := 
   [
-      <%% @chain_height %%>
-    ; <%% @current_slot %%>
-    ; <%% @finalized_height %%>
-    ; <%% @caller_addr %%>
-    ; <%% @my_addr %%>
-    ; <%% @my_balance %%>
-    ; <%% @call_amount %%>
-    ; <%% @deployment_setup %%>
-    ; <%% @reject_deployment %%>
-    ; <%% @accept_deployment %%>
-    ; <%% @call_msg %%>
-    ; <%% @my_state %%>
-    ; <%% @queue %%>
-    ; <%% @reject_call %%>
-    ; <%% @accept_call %%>
-    ; <%% @build_contract %%>
+      <%% @ContractMonads.chain_height %%>
+    ; <%% @ContractMonads.current_slot %%>
+    ; <%% @ContractMonads.finalized_height %%>
+    ; <%% @ContractMonads.caller_addr %%>
+    ; <%% @ContractMonads.my_addr %%>
+    ; <%% @ContractMonads.my_balance %%>
+    ; <%% @ContractMonads.call_amount %%>
+    ; <%% @ContractMonads.deployment_setup %%>
+    ; <%% @ContractMonads.reject_deployment %%>
+    ; <%% @ContractMonads.accept_deployment %%>
+    ; <%% @ContractMonads.call_msg %%>
+    ; <%% @ContractMonads.my_state %%>
+    ; <%% @ContractMonads.queue %%>
+    ; <%% @ContractMonads.reject_call %%>
+    ; <%% @ContractMonads.accept_call %%>
+    ; <%% @ContractMonads.build_contract %%>
   ].
 
 
@@ -204,12 +202,11 @@ Definition to_inline : list kername :=
   ++ inline_boardroom_params
   ++ [
     <%% Monads.Monad_option %%>
-  (* ; <%% @Monads.MonadTrans %%> *)
-  
   ; <%% ContractIniterSetupState %%>
   ; <%% ContractReceiverStateMsgState %%>
   ; <%% @contract_initer_monad %%>
   ; <%% @run_contract_initer %%>
+  ; <%% @run_contract_receiver %%>
   ; <%% @contract_receiver_monad %%>
   ; <%% @contract_reader_to_contract_initer %%>
   ; <%% @option_to_contract_initer %%>
@@ -218,8 +215,6 @@ Definition to_inline : list kername :=
   
   ; <%% @ContractReceiver %%>
   ; <%% @ContractIniter %%>
-  (* Dont work *)
-  (* ; <%% @ContractReader %%> *)
   
   ; <%% @Monads.bind %%>
   ; <%% @Monads.ret %%>
@@ -249,20 +244,7 @@ Definition to_inline : list kername :=
   ; <%% @BV.set_VoterInfo_vote_hash %%>
   ; <%% @BV.set_VoterInfo_public_vote %%>
 
-  (* ; <%% @countable.encode %%> *)
   ].
-
-(* Definition asd := (BoardroomMath.add 1 2).
-
-Time MetaCoq Quote Recursively Definition ex1 := asd.
-Check ex1.
-Definition r1 := Eval vm_compute in (liquidity_extract_single TT_remap TT_rename true BV_MODULE.(lmd_prelude) "harness?" ex1).
-Print r1. *)
-(* r1 = 
-inr
-  "Erased environment is not expanded enough for dearging to be provably correct"
-  : string + string
-*)
 
 (* Time MetaCoq Run ('(env, init_nm, receive_nm) <- quote_and_preprocess to_inline BV_MODULE ;;
                   tmDefinition "bv_env" env ;;
@@ -272,9 +254,9 @@ inr
 
 (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
 Definition TT_remap : list (kername * string) :=
-  (* TT_remap_default ++  *)
   [
     remap <%% Amount %%> "tez"
+  ; remap <%% BV.amount_eqb %%> "eqTez"
   ; remap <%% positive %%> "nat"
   ; remap <%% Z %%> "int"
   ; remap <%% Z.of_nat %%> "int"
@@ -285,59 +267,53 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% Z.add %%> "addInt"
   ; remap <%% Z.eqb %%> "eqInt"
   ; remap <%% Z.gtb %%> "gtbInt"
-  ; remap <%% Nat.ltb %%> "ltbNat"
+  ; remap <%% Nat.ltb %%> "ltNat"
   ; remap <%% Z.modulo %%> "modInt"
   ; remap <%% Z.mul %%> "mulInt"
-  (* ; remap <%% Z.pow %%> "powInt" *)
   ; remap <%% N.lxor %%> "lxorNat"
-  ; remap <%% N.succ_pos %%> "(addNat 1)"
+  ; remap <%% N.succ_pos %%> "addNat 1p"
   ; remap <%% mod_pow %%> "mod_pow"
   ; remap <%% Egcd.egcd %%> "egcd"
-  (* ; remap <%% List.nth %%> "List.nth" *)
-  (* ; remap <%% List.firstn %%> "List.firstn" *)
-  (* ; remap <%% List.skipn %%> "List.skipn" *)
+  ; remap <%% bruteforce_tally_aux %%> (bruteforce_tally_def ++ "in bruteforce_tally_aux") 
+  ; remap <%% @List.existsb %%> "existsb"
+  ; remap <%% @List.nth %%> "nth"
+  ; remap <%% @List.firstn %%> "firstn"
+  ; remap <%% @List.skipn %%> "skipn"
+  ; remap <%% Euler.prod %%> "prod"
 
-  ; remap <%% oneN %%> "1"
-  ; remap <%% four %%> "4"
-  ; remap <%% seven %%> "7"
+  ; remap <%% hash_func %%> "hash_func"
+  ; remap <%% oneN %%> "1p"
+  ; remap <%% onePos %%> "1p"
+  ; remap <%% four %%> "4p"
+  ; remap <%% seven %%> "7p"
   ; remap <%% _1234583932 %%> "1234583932"
   ; remap <%% _23241 %%> "23241"
   ; remap <%% _159338231 %%> "159338231"
   ; remap <%% _5 %%> "5"
-  ; remap <%% _3 %%> "3"
+  ; remap <%% _3 %%> "3p"
   ; remap <%% Z3 %%> "3"
   ; remap <%% _11 %%> "11"
-  (* ; remap <%% five %%> "5" *)
-  ; remap <%% @ContractCallContext %%> "(address * (address * int))"
-  ; remap <%% @Chain %%> "(address * (address * address))" (* chain_height, current_slot, finalized_height *)
+  ; remap <%% @ActionBody %%> "operation"
+  ; remap <%% @ContractCallContext %%> "(address * (address * (tez * tez)))"
+  ; remap <%% @Chain %%> "(nat * (nat * nat))" (* chain_height, current_slot, finalized_height *)
   ; remap <%% @chain_height %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
-  ; remap <%% @current_slot %%> "(fun c -> fst (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
+  ; remap <%% @Blockchain.current_slot %%> "(fun c -> c.(1).(0))" (* small hack, but valid since Chain is mapped to a tuple *)
   ; remap <%% @finalized_height %%> "(fun c -> snd (snd c)" (* small hack, but valid since Chain is mapped to a tuple *)
   ; remap <%% @ctx_from %%> "fst" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_amount %%> "(fun c -> c.(1).(1).(1))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_contract_address %%> "(fun c -> c.(1).(0))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
+  ; remap <%% @ctx_contract_balance %%> "(fun c -> c.(1).(1).(0))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
   ; remap <%% @AddressMap.AddrMap %%> "addrMap"
   ; remap <%% @AddressMap.add %%> "Map.add"
   ; remap <%% @AddressMap.find %%> "Map.find"
-  ; remap <%% @AddressMap.values %%> "Map.to_list"
+  ; remap <%% @AddressMap.of_list %%> "Map.of_list"
+  ; remap <%% @AddressMap.values %%> "Map.values"
+  ; remap <%% @AddressMap.keys %%> "Map.keys"
   ; remap <%% @AddressMap.empty %%> "(Map [])"
 
-  (* ; remap <%% BV.verify_secret_vote_proof %%> "verify_secret_vote_proof" *)
-  (* ; remap <%% @BV.make_signup_msg %%> "make_signup_msg" *)
-  (* ; remap <%% @BV.make_commit_msg %%> "make_commit_msg" *)
-  (* ; remap <%% @BV.make_vote_msg %%> "make_vote_msg" *)
-  (* ; remap <%% @BV.secret_vote_proof %%> "secret_vote_proof" *)
-  (* ; remap <%% @BV.secret_key_proof %%> "secret_key_proof" *)
-  (* ; remap <%% @BV.hash_sk_data %%> "hash_sk_data" *)
-  (* ; remap <%% @BV.hash_sv_data %%> "hash_sv_data" *)
-
-  (* ; remap <%% @BV.handle_signup %%> "handle_signup" *)
-  (* ; remap <%% @BV.handle_commit_to_vote %%> "handle_commit_to_vote" *)
-  (* ; remap <%% @BV.handle_submit_vote %%> "handle_submit_vote" *)
-  (* ; remap <%% @BV.handle_tally_votes %%> "handle_tally_votes" *)
-
-
   ; remap <%% modulus %%> modulus_
-  ; remap <%% BV.encodeA %%> "nat"
-  ; remap <%% BV.encodeNat %%> "nat"
+  ; remap <%% BV.encodeA %%> "unsafe_int_to_nat"
+  ; remap <%% BV.encodeNat %%> ""
   
 
   ; remap <%% @List.fold_left %%> "List.fold"
@@ -345,24 +321,25 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% @List.find %%> "List.find"
   ; remap <%% @List.length %%> "List.length"
   ; remap <%% @List.app %%> "List.append"
-  ; remap <%% @Serializable.serialize %%> "TODO_serialize"
-  ; remap <%% @Serializable.deserialize %%> "TODO_deserialize"
   ].
 (** A translation table of constructors and some constants. The corresponding definitions will be extracted and renamed. *)
 Definition TT_rename : list (string * string):=
   [ ("Some", "Some")
   ; ("None", "None")
   ; ("Zpos" ,"int")
-  ; ("Npos" ,"(fun (n:nat) -> n)")
+  ; ("Npos" ,"")
   ; ("Zneg" ,"-")
   ; ("Z0" ,"0")
-  ; ("N0" ,"0")
+  ; ("0" ,"0p")
+  ; ("N0" ,"0p")
   ; ("xH" ,"0")
   ; ("1" ,"1")
+  ; ("2" ,"2p")
+  ; ("S" ,"1p +")
   ; ("nil", "[]")
   ; ("true", "true")
   ; ("false", "false")
-  ; (string_of_kername <%% BV.State %%>, "State")  (* we add [storage] so it is printed without the prefix *) 
+  ; (string_of_kername <%% BV.State %%>, "state")  (* we add [storage] so it is printed without the prefix *) 
   ; ("tt", "()")
   ].
 
@@ -371,14 +348,5 @@ Definition TT_rename : list (string * string):=
   tmDefinition BV_MODULE.(lmd_module_name) t
   ).
 
-Print liquidity_boardroomvoting.  *)
-
-Time MetaCoq Run
-     (t <- liquidity_extraction_specialize PREFIX TT_remap TT_rename to_inline BV_MODULE ;;
-      tmDefinition BV_MODULE.(lmd_module_name) t
-     ).
-
-Print liquidity_boardroomvoting.
-
 (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
-Redirect "examples/liquidity-extract/BoardroomVoting.liq" Compute liquidity_boardroomvoting.
+Redirect "examples/liquidity-extract/BoardroomVoting.liq" MetaCoq Run (tmMsg liquidity_boardroomvoting). *)

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -130,10 +130,10 @@ Definition TT_remap_default : list (kername * string) :=
 
   (* operations *)
   ; remap <%% List.fold_left %%> "List.fold"
-  ; remap <%% Pos.add %%> "addNat"
-  ; remap <%% Pos.sub %%> "subNat"
-  ; remap <%% Pos.leb %%> "leNat"
-  ; remap <%% Pos.eqb %%> "eqNat"
+  ; remap <%% Pos.add %%> "addN"
+  ; remap <%% Pos.sub %%> "subN"
+  ; remap <%% Pos.leb %%> "leN"
+  ; remap <%% Pos.eqb %%> "eqN"
   ; remap <%% Z.add %%> "addTez"
   ; remap <%% Z.sub %%> "subTez"
   ; remap <%% Z.leb %%> "leTez"

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -197,6 +197,7 @@ Section print_term.
       ; "val"
       ; "balance"
       ; "continue"
+      ; "hash"
     ].
 
   Definition is_fresh (Γ : context) (id : ident) :=
@@ -493,17 +494,19 @@ Section print_term.
     end
   | tConst c => fun bt =>
     let cst_name := string_of_kername c in
-    from_option (look TT cst_name) (prefix ++ c.2)
+    let nm_tt := from_option (look TT cst_name) (prefix ++ c.2) in
+    if (nm_tt =? "Map.empty") || (nm_tt =? "AddressMap.empty") then
+      "(Map.empty: " ++ print_box_type prefix TT bt ++ ")"
+    else
+      nm_tt  
   | tConstruct ind l => fun bt =>
     let nm := get_constr_name ind l in
     let nm_tt := from_option (look TT nm) (capitalize (prefix ++ nm)) in
     (* print annotations for 0-ary constructors of polymorphic types (like [], None, and Map.empty) *)
-    if nm_tt =? "[]" then
+    if (nm_tt =? "[]") || (nm_tt =? "nil") then
       "([]:" ++ print_box_type prefix TT bt ++ ")"
     else if nm_tt =? "None" then
       "(None:" ++ print_box_type prefix TT bt ++ ")"
-    else if nm_tt =? "Map.empty" then
-      "(Map.empty: " ++ print_box_type prefix TT bt ++ ")"    
     else nm_tt
   | tCase (mkInd mind i as ind, nparam) t brs =>
     let fix print_branch ctx arity params (br : term) {struct br} : annots box_type br -> (_ * _) :=
@@ -817,6 +820,7 @@ Definition int_ops :=
   "[@inline] let subIntTruncated (a : int) (b : int) = let res = a - b in if res < 0 then 0 else res" ;
   "[@inline] let multInt (i : int) (j : int) = i * j" ;
   "[@inline] let divInt (i : int) (j : int) = i / j" ;
+  "[@inline] let modInt (a : int)(b : int) : int = int (a mod b)" ;
   "[@inline] let leInt (i : int) (j : int) = i <= j" ;
   "[@inline] let ltInt (i : int) (j : int) = i < j" ;
   "[@inline] let eqInt (i : int) (j : int) = i = j"

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -375,6 +375,7 @@ Section print_term.
       concat (" " ++ ctor ++ " ") vars ++ " -> " ++ pt.2
     else
       let ctor_nm := from_option (look TT ctor) (capitalize prefix ++ capitalize ctor) in
+      let ctor_nm := if ctor_nm =? "Pair" then "" else ctor_nm in
       let print_parens := (Nat.ltb 1 (List.length pt.1)) in
       print_uncurried ctor_nm vars ++ " -> " ++ pt.2.
 
@@ -728,7 +729,15 @@ Definition int_ops :=
     ++ nl
     ++ "let[@inline] ltInt (i : int) (j : int) = i < j"
     ++ nl
-    ++ "let[@inline] eqInt (i : int) (j : int) = i = j".
+    ++ "let[@inline] eqInt (i : int) (j : int) = i = j"
+    ++ nl
+    ++ "let[@inline] modInt(a : int)(b : int) : int = match a/b with | Some (_, r) -> int r | None -> 0"
+    ++ nl
+    ++ "let rec powIntAcc((a,b,acc) : int*int*int) =
+        if b <= 0 then acc
+        else powIntAcc(a, (b-1), acc * a)"
+    ++ nl
+    ++ "let powInt(a : int)(b : int) = powIntAcc(a,b,1)".
 
 Definition tez_ops :=
        "let[@inline] addTez (n : tez) (m : tez) = n + m"
@@ -758,6 +767,8 @@ Definition nat_ops :=
     ++ "let[@inline] leNat (i : nat) (j : nat) = i <= j"
     ++ nl
     ++ "let[@inline] ltNat (i : nat) (j : nat) = i < j"
+    ++ nl
+    ++ "let[@inline] lxorNat (i : nat) (j : nat) = i lxor j"
     ++ nl
     ++ "let[@inline] eqNat (i : nat) (j : nat) = i = j".
 

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -276,6 +276,8 @@ Section print_term.
       end
     in aux n.
 
+  
+
   Definition fresh_name (Γ : context) (na : name) (t : term) :=
     let id := match na with
               | nNamed id => id

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -59,7 +59,7 @@ Arguments lmd_entry_point {_ _ _ _ _}.
 Definition overridden_masks (kn : kername) : option bitmask :=
   if eq_kername kn <%% @AddressMap.empty %%> then Some [true]
   else None.
-  
+
 (* Machinery for specializing chain base *)
 Definition extract_template_env_specialize
            (params : extract_template_env_params)
@@ -71,7 +71,6 @@ Definition extract_template_env_specialize
   Σ <- specialize_ChainBase_env Σ ;;
   wfΣ <- check_wf_env_func params Σ;;
   extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
->>>>>>> liq extraction with chainbase
 
 (* Machinery for specializing chain base *)
 Definition extract_template_env_specialize

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -109,7 +109,7 @@ Definition extract_liquidity_within_coq (to_inline : kername -> bool)
      pcuic_args :=
        {| optimize_prop_discr := true;
           extract_transforms :=
-            [dearg_transform overridden_masks true true true true true ]
+            [dearg_transform overridden_masks true true true false true ]
        |}
   |}.
 
@@ -190,8 +190,8 @@ Definition liquidity_ignore_default :=
 Definition TT_remap_default : list (kername * string) :=
   [
     (* types *)
-    remap <%% Z %%> "tez"
-  ; remap <%% N %%> "nat"
+    (* remap <%% Z %%> "tez" *)
+    remap <%% N %%> "nat"
   ; remap <%% nat %%> "nat"
   ; remap <%% bool %%> "bool"
   ; remap <%% unit %%> "unit"
@@ -214,12 +214,12 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% Pos.sub %%> "subNat"
   ; remap <%% Pos.leb %%> "leNat"
   ; remap <%% Pos.eqb %%> "eqNat"
-  ; remap <%% Z.add %%> "addTez"
+  (* ; remap <%% Z.add %%> "addTez"
   ; remap <%% Z.sub %%> "subTez"
   ; remap <%% Z.leb %%> "leTez"
   ; remap <%% Z.ltb %%> "ltTez"
   ; remap <%% Z.eqb %%> "eqTez"
-  ; remap <%% Z.gtb %%> "gtbTez"
+  ; remap <%% Z.gtb %%> "gtbTez" *)
   ; remap <%% N.add %%> "addInt"
   ; remap <%% N.sub %%> "subInt"
   ; remap <%% N.leb %%> "leInt"
@@ -233,8 +233,8 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% @stdpp.base.insert %%> "Map.add"
   ; remap <%% @stdpp.base.lookup %%> "Map.find_opt"
   ; remap <%% @stdpp.base.empty %%> "Map.empty"
-  ; remap <%% @address_eqdec %%> ""
-  ; remap <%% @address_countable %%> ""
+  (* ; remap <%% @address_eqdec %%> "" *)
+  (* ; remap <%% @address_countable %%> "" *)
   ].
 
 (* We assume the structure of the context from the [PreludeExt]:
@@ -320,22 +320,6 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
                              init_nm receive_nm ;;
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
-
-Definition liquidity_extraction_test {msg ctx params storage operation : Type}
-           (prefix : string)
-           (TT_defs : list (kername *  string))
-           (TT_ctors : MyEnv.env string)
-           (m : LiquidityMod msg ctx params storage operation) :=
-  '(Σ,_) <- tmQuoteRecTransp m false ;;
-  init_nm <- extract_def_name m.(lmd_init);;
-  receive_nm <- extract_def_name m.(lmd_receive);;
-  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
-  let TT :=
-      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
-  tmEval lazy
-             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
-             | Ok a => a
-             | Err _ => [] end).
 
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -321,6 +321,22 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
 
+Definition liquidity_extraction_test {msg ctx params storage operation : Type}
+           (prefix : string)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (m : LiquidityMod msg ctx params storage operation) :=
+  '(Σ,_) <- tmQuoteRecTransp m false ;;
+  init_nm <- extract_def_name m.(lmd_init);;
+  receive_nm <- extract_def_name m.(lmd_receive);;
+  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
+  let TT :=
+      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  tmEval lazy
+             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
+             | Ok a => a
+             | Err _ => [] end).
+
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.
 (* Liquidity extraction *with* chainbase specialization *)

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -310,22 +310,6 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
 
-Definition liquidity_extraction_test {msg ctx params storage operation : Type}
-           (prefix : string)
-           (TT_defs : list (kername *  string))
-           (TT_ctors : MyEnv.env string)
-           (m : LiquidityMod msg ctx params storage operation) :=
-  '(Σ,_) <- tmQuoteRecTransp m false ;;
-  init_nm <- extract_def_name m.(lmd_init);;
-  receive_nm <- extract_def_name m.(lmd_receive);;
-  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
-  let TT :=
-      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
-  tmEval lazy
-             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
-             | Ok a => a
-             | Err _ => [] end).
-
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.
 (* Liquidity extraction *with* chainbase specialization *)

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -59,6 +59,19 @@ Arguments lmd_entry_point {_ _ _ _ _}.
 Definition overridden_masks (kn : kername) : option bitmask :=
   if eq_kername kn <%% @AddressMap.empty %%> then Some [true]
   else None.
+  
+(* Machinery for specializing chain base *)
+Definition extract_template_env_specialize
+           (params : extract_template_env_params)
+           (Σ : global_env)
+           (seeds : KernameSet.t)
+           (ignore : kername -> bool) : result ExAst.global_env string :=
+  let Σ := SafeTemplateChecker.fix_global_env_universes Σ in
+  let Σ := TemplateToPCUIC.trans_global_decls Σ in
+  Σ <- specialize_ChainBase_env Σ ;;
+  wfΣ <- check_wf_env_func params Σ;;
+  extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
+>>>>>>> liq extraction with chainbase
 
 (* Machinery for specializing chain base *)
 Definition extract_template_env_specialize
@@ -308,6 +321,22 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
                              init_nm receive_nm ;;
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
+
+Definition liquidity_extraction_test {msg ctx params storage operation : Type}
+           (prefix : string)
+           (TT_defs : list (kername *  string))
+           (TT_ctors : MyEnv.env string)
+           (m : LiquidityMod msg ctx params storage operation) :=
+  '(Σ,_) <- tmQuoteRecTransp m false ;;
+  init_nm <- extract_def_name m.(lmd_init);;
+  receive_nm <- extract_def_name m.(lmd_receive);;
+  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
+  let TT :=
+      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
+  tmEval lazy
+             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
+             | Ok a => a
+             | Err _ => [] end).
 
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -72,30 +72,6 @@ Definition extract_template_env_specialize
   wfΣ <- check_wf_env_func params Σ;;
   extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
 
-(* Machinery for specializing chain base *)
-Definition extract_template_env_specialize
-           (params : extract_template_env_params)
-           (Σ : global_env)
-           (seeds : KernameSet.t)
-           (ignore : kername -> bool) : result ExAst.global_env string :=
-  let Σ := SafeTemplateChecker.fix_global_env_universes Σ in
-  let Σ := TemplateToPCUIC.trans_global_decls Σ in
-  Σ <- specialize_ChainBase_env Σ ;;
-  wfΣ <- check_wf_env_func params Σ;;
-  extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
-
-(* Machinery for specializing chain base *)
-Definition extract_template_env_specialize
-           (params : extract_template_env_params)
-           (Σ : global_env)
-           (seeds : KernameSet.t)
-           (ignore : kername -> bool) : result ExAst.global_env string :=
-  let Σ := SafeTemplateChecker.fix_global_env_universes Σ in
-  let Σ := TemplateToPCUIC.trans_global_decls Σ in
-  Σ <- specialize_ChainBase_env Σ ;;
-  wfΣ <- check_wf_env_func params Σ;;
-  extract_pcuic_env (pcuic_args params) Σ wfΣ seeds ignore.
-
 (* Extract an environment with some minimal checks. This assumes the environment
    is well-formed (to make it computable from within Coq) but furthermore checks that the
    erased context is closed, expanded and that the masks are valid before dearging.
@@ -109,7 +85,8 @@ Definition extract_liquidity_within_coq (to_inline : kername -> bool)
      pcuic_args :=
        {| optimize_prop_discr := true;
           extract_transforms :=
-            [dearg_transform overridden_masks true true true false true ]
+            (* TODO: a 'false' second-last arg disables fully expanded environments - only for boardroomvoting *)
+            [dearg_transform overridden_masks true true true true true ]
        |}
   |}.
 

--- a/extraction/theories/LiquidityExtract.v
+++ b/extraction/theories/LiquidityExtract.v
@@ -322,22 +322,6 @@ Definition liquidity_extraction_ {msg ctx params storage operation : Type}
     tmEval lazy
            (wrap_in_delimiters (concat (nl ++ nl) [m.(lmd_prelude); s; m.(lmd_entry_point)])).
 
-Definition liquidity_extraction_test {msg ctx params storage operation : Type}
-           (prefix : string)
-           (TT_defs : list (kername *  string))
-           (TT_ctors : MyEnv.env string)
-           (m : LiquidityMod msg ctx params storage operation) :=
-  '(Σ,_) <- tmQuoteRecTransp m false ;;
-  init_nm <- extract_def_name m.(lmd_init);;
-  receive_nm <- extract_def_name m.(lmd_receive);;
-  let ignore := (map fst TT_defs ++ liquidity_ignore_default)%list in
-  let TT :=
-      (TT_ctors ++ map (fun '(kn,d) => (string_of_kername kn, d)) TT_defs)%list in
-  tmEval lazy
-             (match extract_template_env_specialize_test Σ init_nm receive_nm ignore with
-             | Ok a => a
-             | Err _ => [] end).
-
 (* Liquidity extraction *without* chainbase specialization *)
 Definition liquidity_extraction {msg ctx params storage operation : Type} := @liquidity_extraction_ msg ctx params storage operation printLiquidityDefs.
 (* Liquidity extraction *with* chainbase specialization *)


### PR DESCRIPTION
- specialized boardroomvoting to `Z` in `BoardroomVotingZ.v` which is used for extraction
- extract boardroomvoting
  - output compiles out-of-the-box for cameLIGO
  - liquidity has the issue with typings of lambdas, so the output currently doesn't compile 
- various smaller fixes in pretty printers