### PR TITLE
CameLIGO extraction cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ extraction/examples/extracted-code/liquidity-extract/tests/*
 extraction/examples/extracted-code/midlang-extract/*
 extraction/examples/extracted-code/midlang-extract/tests/*
 
+## CameLIGO tests
+extraction/examples/extracted-code/cameligo-extract/*
+extraction/examples/extracted-code/cameligo-extract/tests/*
+
 .coq-native/
 .csdp.cache
 .lia.cache

--- a/execution/examples/BoardroomVotingZ.v
+++ b/execution/examples/BoardroomVotingZ.v
@@ -25,8 +25,6 @@ Import RecordSetNotations.
 
 Module BR := BoardroomVoting.BoardroomVoting.
 
-About BR.Msg.
-
 Module Type BoardroomParams.
   Parameter H : list positive -> positive.
   Parameter prime : Z.
@@ -238,7 +236,6 @@ Definition ContractReceiverStateMsgState := ContractReceiver State Msg State.
 Definition isSome {A} (a : option A) := match a with Some _ => true | None => false end.
 
 Definition isNone {A} (a : option A) := match a with Some _ => false | None => true end.
-Definition onePos := 1%positive .
 Definition twoZ : Z := 2.
 
 Definition handle_signup pk prf state caller cur_slot : ContractReceiverStateMsgState := 
@@ -247,11 +244,11 @@ Definition handle_signup pk prf state caller cur_slot : ContractReceiverStateMsg
   do lift (if AddressMap.find caller (registered_voters state) then None else Some tt);
   do amt <- lift call_amount;
   do lift (if (amount_eqb amt  (registration_deposit (setup state)))%Z then Some tt else None);
-  do lift (if Z.of_nat (length (public_keys state)) <? order - twoZ then Some tt else None);
+  do lift (if Z.of_nat (length (public_keys state)) <? order - 2 then Some tt else None);
   let index := length (public_keys state) in
   do lift (if verify_secret_key_proof pk index prf then Some tt else None);
   let inf := {| voter_index := index;
-                vote_hash := onePos;
+                vote_hash := 1;
                 public_vote := 0; |} in
   let new_state := {| owner := state.(owner);
                       registered_voters := AddressMap.add caller inf state.(registered_voters);

--- a/extraction/Makefile
+++ b/extraction/Makefile
@@ -38,19 +38,47 @@ process-extraction-examples: theory
 	./process-extraction-examples.sh
 .PHONY: process-extraction-examples
 
-test-extraction:
+LIQUIDITY_SRC_DIR=./examples/extracted-code/liquidity-extract/tests
+LIQUIDITYFILES=$(wildcard $(LIQUIDITY_SRC_DIR)/*.liq)
+LIQUIDITY_DIST=$(patsubst $(LIQUIDITY_SRC_DIR)/%.liq,$(LIQUIDITY_SRC_DIR)/%.tz,$(LIQUIDITYFILES))
+
+LIGO_SRC_DIR=./examples/extracted-code/cameligo-extract/tests
+LIGOFILES=$(wildcard $(LIGO_SRC_DIR)/*.mligo)
+LIGO_DIST=$(patsubst $(LIGO_SRC_DIR)/%.mligo,$(LIGO_SRC_DIR)/%.tz,$(LIGOFILES))
+
+test-extraction: test-elm test-liquidity test-ligo test-concordium
+
+test-concordium:
+	$(foreach dir, $(wildcard ./examples/extracted-code/concordium-extract/*-extracted), cd $(dir) && cargo concordium test && cd ../../../..;)
+
+test-elm:
 	cd ./examples/extracted-code/elm-extract/; elm-test
 	cd ./examples/extracted-code/elm-web-extract/; elm make src/Main.elm
-	$(foreach file, $(wildcard ./examples/extracted-code/liquidity-extract/tests/*.liq), liquidity $(file);)
-	$(foreach dir, $(wildcard ./examples/extracted-code/concordium-extract/*-extracted), cd $(dir) && cargo concordium test && cd ../../../..;)
-	$(foreach file, $(wildcard ./examples/extracted-code/cameligo-extract/tests/*.mligo), ligo compile-contract $(file) main;)
-.PHONY: test-extraction
 
-clean-extraction-examples:
+test-liquidity: clean-compiled-liquidity $(LIQUIDITY_DIST)
+
+$(LIQUIDITY_SRC_DIR)/%.tz:
+	liquidity $(LIQUIDITY_SRC_DIR)/$*.liq -o $@
+
+
+test-ligo: clean-comiped-ligo $(LIGO_DIST)
+
+$(LIGO_SRC_DIR)/%.tz:
+	ligo compile-contract $(LIGO_SRC_DIR)/$*.mligo main --output-file=$@ --warn=false
+
+clean-comiped-ligo:
+	rm ./examples/extracted-code/cameligo-extract/tests/*.tz -f
+
+clean-compiled-liquidity:
+	rm ./examples/extracted-code/liquidity-extract/tests/*.tz -f
+
+clean-extraction-examples: clean-comiped-ligo clean-compiled-liquidity
 	rm ./examples/extracted-code/elm-extract/*.elm.out
 	rm ./examples/extracted-code/elm-extract/tests/*.elm
 	rm ./examples/extracted-code/liquidity-extract/*.liq.out
 	rm ./examples/extracted-code/liquidity-extract/tests/*.liq
 	rm ./examples/extracted-code/midlang-extract/*.midlang.out
+	rm ./examples/extracted-code/cameligo-extract/tests/*.mligo
 	rm ./examples/*.vo # to force recompilation of examples (a bit ad-hoc though)
-.PHONY: clean-extraction-examples
+
+.PHONY: clean-extraction-examples clean-comiped-ligo clean-comiped-ligo test-concordium test-elm test-liquidity test-ligo test-extraction

--- a/extraction/examples/BoardroomVotingExtractionLiquidity.v
+++ b/extraction/examples/BoardroomVotingExtractionLiquidity.v
@@ -1,6 +1,6 @@
 (** * Extraction of the Boardroom voting contract Liquidity *)
 
-(** NOTE: Currently does not compile due to some restrictions on closures in Liquidity *)
+(** NOTE: Currently does not compile due to some restrictions on closures in Liquidity. Moreover, the printing of literals might need adjustments. *)
 
 
 From Coq Require Import PeanoNat ZArith.
@@ -287,8 +287,8 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% Euler.prod %%> "prod"
 
   ; remap <%% hash_func %%> "hash_func"
-  ; remap <%% oneN %%> "1p"
-  ; remap <%% onePos %%> "1p"
+  (* ; remap <%% oneN %%> "1p" *)
+  (* ; remap <%% onePos %%> "1p" *)
   ; remap <%% four %%> "4p"
   ; remap <%% seven %%> "7p"
   ; remap <%% _1234583932 %%> "1234583932"

--- a/extraction/theories/LPretty.v
+++ b/extraction/theories/LPretty.v
@@ -10,8 +10,7 @@ Liquidity allows only tail-recursive calls and recursive functions must have onl
 Another issue: constructors accept only one argument, so we have to uncurry (pack in a tuple) applications as well. This transformation is applied to all constructors and the pretty-printing stage. Again, we assume that the constructors are fully applied (e.g. eta-expanded at the previous stage).
 
 Pattern-macthing: pattern-matching on pairs is not supported by Liquidity, so all the programs must use projections.
-
-Printing polymoprhic definitions is not supported currently (due to the need of removing redundant types from the type scheme). But the machinery is there, just need to switch to erased types.  *)
+ *)
 
 From Coq Require Import List Program String Ascii.
 From ConCert.Utils Require Import StringExtra.
@@ -399,9 +398,11 @@ Definition get_record_projs (oib : ExAst.one_inductive_body) : list ident :=
   Fixpoint fresh_names (Γ : context) (vs : list name) : context * list name :=
     match vs with
     | [] => (Γ, [])
-    | v :: vs0 => let Γ0 := vass v :: Γ in (* add name to the context to avoid shadowing due to name clashes *)
-                  let '(Γ1, vs1) := fresh_names Γ0 vs0 in
-                  (Γ1, fresh_name Γ v (tVar "dummy") :: vs1)
+    | v :: vs0 =>
+      let nm := fresh_name Γ v (tVar "dummy") in
+      let Γ0 := vass nm :: Γ in (* add name to the context to avoid shadowing due to name clashes *)
+      let '(Γ1, vs1) := fresh_names Γ0 vs0 in
+      (Γ1, nm :: vs1)
     end.
 
   (* [print_pat] expects that the names in pt.1 are already checked for freshness *)


### PR DESCRIPTION
* fix various small issues with wrappers;
* call context represented as a record;
* change all usages of `SimpleCallCtx` to `ContractCallContext`;
* extend standard remappings to cover most common cases (e.g. escrow doesn't require extra remappings at all);
* fix bugs in literal printing;
* improve extraction testing in the makefile