### PR TITLE
Add call origin

### DIFF
--- a/embedding/examples/ExecFrameworkIntegration.v
+++ b/embedding/examples/ExecFrameworkIntegration.v
@@ -42,12 +42,12 @@ Definition to_action_body (sab : SimpleActionBody_coq) : ActionBody :=
   end.
 
 Definition to_contract_call_context (scc : SimpleContractCallContext_coq) : ContractCallContext :=
-  let '(Build_ctx_coq from contr_addr contr_bal am) := scc in
-  build_ctx from contr_addr contr_bal am.
+  let '(Build_ctx_coq origin from contr_addr contr_bal am) := scc in
+  build_ctx origin from contr_addr contr_bal am.
 
 Definition of_contract_call_context (cc : ContractCallContext) : SimpleContractCallContext_coq :=
-  let '(build_ctx from contr_addr contr_bal am) := cc in
-  Build_ctx_coq from contr_addr contr_bal am.
+  let '(build_ctx origin from contr_addr contr_bal am) := cc in
+  Build_ctx_coq origin from contr_addr contr_bal am.
 
 Import Serializable Prelude.Maps.
 

--- a/embedding/theories/SimpleBlockchain.v
+++ b/embedding/theories/SimpleBlockchain.v
@@ -44,6 +44,8 @@ Module AcornBlockchain.
   Definition SimpleContractCallContextAcorn : global_dec :=
     [\ record SimpleContractCallContext :=
        Build_ctx {
+           (* Address initiating the transaction *)
+           "Ctx_origin" : Address;
            (* Address sending the funds *)
            "Ctx_from" : Address;
            (* Address of the contract being called *)

--- a/execution/examples/BoardroomVoting.v
+++ b/execution/examples/BoardroomVoting.v
@@ -808,7 +808,10 @@ Proof.
       rewrite queue_prev in H2.
       cbn in H2.
       destruct (address_eqb_spec (act_from act) to_addr); cbn in *; try congruence.
-      subst act; cbn in *; congruence.
+      match goal with
+      | [ H : act = _ |- _ ] => rewrite H in *
+      end.
+      cbn in *; congruence.
 Qed.
 
 Theorem boardroom_voting_correct

--- a/execution/examples/BoardroomVotingTest.v
+++ b/execution/examples/BoardroomVotingTest.v
@@ -146,6 +146,18 @@ Defined.
 
 Definition voters_map : AddrMap unit := AddressMap.of_list (map (fun a => (a, tt)) addrs).
 
+Fixpoint validate_addrs (xs : list Address) : list {a : Address | address_is_contract a = false} :=
+  match xs with
+  | [] => []
+  | a :: tail => match (Bool.bool_dec (address_is_contract a) true ) with
+               | left _ => []
+               | right p => exist _ a (Bool.not_true_is_false _ p) :: validate_addrs tail
+               end
+  end.
+
+Definition user_addrs : list {a : Address | address_is_contract a = false} :=
+  validate_addrs addrs.
+
 Definition five := 5%nat.
 
 Definition deploy_setup :=
@@ -156,7 +168,7 @@ Definition deploy_setup :=
      registration_deposit := 0; |}.
 
 Local Open Scope list.
-Definition boardroom_example : option nat :=
+Program Definition boardroom_example : option nat :=
   let chain : ChainBuilder := builder_initial in
   let creator : Address := A 10 in
   let add_block (chain : ChainBuilder) (acts : list Action) :=
@@ -168,15 +180,15 @@ Definition boardroom_example : option nat :=
              block_reward := 50; |} in
       option_of_result (builder_add_block chain next_header acts) in
   do chain <- add_block chain [];
-  let dep := build_act creator (create_deployment 0 boardroom_voting deploy_setup) in
+  let dep := build_act creator _ creator (create_deployment 0 boardroom_voting deploy_setup) in
   do chain <- add_block chain [dep];
   do caddr <- hd_error (AddressMap.keys (lc_contracts (lcb_lc chain)));
-  let send addr m := build_act addr (act_call caddr 0 (serialize m)) in
-  let calls := map (fun '(addr, m) => send addr m) (zip addrs signups) in
+  let send addr m := build_act (proj1_sig addr) (proj2_sig addr) addr (act_call caddr 0 (serialize m)) in
+  let calls := map (fun '(addr, m) => send addr m) (zip user_addrs signups) in
   do chain <- add_block chain calls;
-  let votes := map (fun '(addr, m) => send addr m) (zip addrs votes) in
+  let votes := map (fun '(addr, m) => send addr m) (zip user_addrs votes) in
   do chain <- add_block chain votes;
-  let tally := build_act creator (act_call caddr 0 (serialize tally_votes)) in
+  let tally := build_act creator _ creator (act_call caddr 0 (serialize tally_votes)) in
   do chain <- add_block chain [tally];
   do state <- contract_state (lcb_lc chain) caddr;
   BV.tally state.

--- a/execution/examples/Congress_Buggy.v
+++ b/execution/examples/Congress_Buggy.v
@@ -318,7 +318,7 @@ Section Theories.
                block_finalized_height := finalized_height chain;
                block_creator := creator;
                block_reward := 50; |} in
-        let acts := map (build_act creator) act_bodies in
+        let acts := map (build_act creator eq_refl creator) act_bodies in
         option_of_result (builder_add_block chain next_header acts) in
     (* Get some money on the creator *)
     do chain <- add_block chain [];

--- a/execution/examples/Counter.v
+++ b/execution/examples/Counter.v
@@ -189,7 +189,9 @@ Proof.
     { apply lift_outgoing_acts_nil with (contract := counter_contract);eauto.
       intros. eapply (receive_produces_no_calls (chain:=chain) (ctx:=ctx));eauto. apply H. }
     unfold outgoing_acts in *. rewrite queue_prev in *.
-    subst act;cbn in Hempty.
+    match goal with
+    | [H : act = _ |- _] => rewrite H in *
+    end;cbn in Hempty.
     now destruct_address_eq.
 Qed.
 

--- a/execution/examples/Dexter2FA12.v
+++ b/execution/examples/Dexter2FA12.v
@@ -971,13 +971,17 @@ Proof.
     destruct_action_eval; auto.
 Qed.
 
-Lemma no_self_calls' : forall bstate from_addr to_addr amount msg acts,
+Lemma no_self_calls' : forall bstate origin origin_valid from_addr to_addr amount msg acts,
   reachable bstate ->
   env_contracts bstate to_addr = Some (contract : WeakContract) ->
-  chain_state_queue bstate = {| act_from := from_addr; act_body :=
-    match msg with
-    | Some msg => act_call to_addr amount msg
-    | None => act_transfer to_addr amount
+  chain_state_queue bstate =
+  {| act_origin := origin;
+     act_origin_valid := origin_valid;
+     act_from := from_addr;
+     act_body :=
+       match msg with
+       | Some msg => act_call to_addr amount msg
+       | None => act_transfer to_addr amount
     end |} :: acts ->
   from_addr <> to_addr.
 Proof.
@@ -1069,7 +1073,10 @@ Proof.
     subst. cbn.
     split.
     + now apply Z.ge_le.
-    + now eapply no_self_calls'.
+    + match goal with
+      | [H : act = _ |- _] => rewrite H in *
+      end.
+      now eapply no_self_calls'.
 Qed.
 
 Lemma contract_balance_bound : forall bstate caddr (trace : ChainTrace empty_state bstate),

--- a/execution/examples/Escrow.v
+++ b/execution/examples/Escrow.v
@@ -525,7 +525,9 @@ Section Theories.
            as all.
       unfold outgoing_acts in *.
       rewrite queue_prev in *.
-      subst act; cbn in all.
+      match goal with
+      | [H : act = _ |- _] => rewrite H in *
+      end; cbn in all.
       destruct_address_eq; cbn in *; auto.
       inversion_clear all as [|? ? hd _].
       destruct msg.

--- a/execution/examples/LocalBlockchainTests.v
+++ b/execution/examples/LocalBlockchainTests.v
@@ -55,7 +55,7 @@ Section LocalBlockchainTests.
 
   (* Creator transfers 10 coins to person_1 *)
   Definition chain3 : ChainBuilder :=
-    unpack_result (add_block chain2 [build_act creator (act_transfer person_1 10)]).
+    unpack_result (add_block chain2 [build_act creator eq_refl creator (act_transfer person_1 10)]).
 
   Compute (env_account_balances chain3 person_1).
   Compute (env_account_balances chain3 creator).
@@ -72,7 +72,7 @@ Section LocalBlockchainTests.
     create_deployment 5 Congress.contract setup.
 
   Definition chain4 : ChainBuilder :=
-    unpack_result (add_block chain3 [build_act person_1 deploy_congress]).
+    unpack_result (add_block chain3 [build_act person_1 eq_refl person_1 deploy_congress]).
 
   Definition congress_1 : Address :=
     match outgoing_txs (builder_trace chain4) person_1 with
@@ -114,8 +114,8 @@ Section LocalBlockchainTests.
     congress_ifc.(send) 0 (Some (add_member p)).
 
   Definition chain5 : ChainBuilder :=
-    let acts := [build_act person_1 (add_person person_1);
-                 build_act person_1 (add_person person_2)] in
+    let acts := [build_act person_1 eq_refl person_1 (add_person person_1);
+                 build_act person_1 eq_refl person_1 (add_person person_2)] in
     unpack_result (add_block chain4 acts).
 
   Compute (FMap.elements (congress_state chain5).(members)).
@@ -127,7 +127,7 @@ Section LocalBlockchainTests.
     congress_ifc.(send) 0 (Some (create_proposal [cact_transfer person_3 3])).
 
   Definition chain6 : ChainBuilder :=
-    unpack_result (add_block chain5 [build_act person_1 create_proposal_call]).
+    unpack_result (add_block chain5 [build_act person_1 eq_refl person_1 create_proposal_call]).
 
   Compute (FMap.elements (congress_state chain6).(proposals)).
 
@@ -136,7 +136,8 @@ Section LocalBlockchainTests.
     congress_ifc.(send) 0 (Some (vote_for_proposal 1)).
 
   Definition chain7 : ChainBuilder :=
-    let acts := [build_act person_1 vote_proposal; build_act person_2 vote_proposal] in
+    let acts := [build_act person_1 eq_refl person_1 vote_proposal;
+                 build_act person_2 eq_refl person_2 vote_proposal] in
     unpack_result (add_block chain6 acts).
 
   Compute (FMap.elements (congress_state chain7).(proposals)).
@@ -146,7 +147,7 @@ Section LocalBlockchainTests.
     congress_ifc.(send) 0 (Some (finish_proposal 1)).
 
   Definition chain8 : ChainBuilder :=
-    unpack_result (add_block chain7 [build_act person_3 finish_proposal]).
+    unpack_result (add_block chain7 [build_act person_3 eq_refl person_3 finish_proposal]).
 
   Compute (FMap.elements (congress_state chain8).(proposals)).
   (* Balances before: *)

--- a/execution/tests/AllTests.v
+++ b/execution/tests/AllTests.v
@@ -34,12 +34,12 @@ End Congress.
 Module Congress_Buggy.
 Import Congress_BuggyTests.
 
-QuickChick (
+QuickChick (expectFailure (
   {{fun _ _ => true}}
   congress_caddr
   {{receive_state_well_behaved_P}}
-).
-(* *** Failed after 10 tests and 1 shrinks. (0 discards) *)
+)).
+(* *** Failed (as expected) after 10 tests and 1 shrinks. (0 discards) *)
 End Congress_Buggy.
 
 
@@ -48,8 +48,8 @@ End Congress_Buggy.
 Module Dexter.
 Import DexterTests.
 
-QuickChick tokens_to_asset_correct.
-(* *** Failed after 1 tests and 1 shrinks. (0 discards) *)
+QuickChick (expectFailure tokens_to_asset_correct).
+(* *** Failed (as expected) after 1 tests and 1 shrinks. (0 discards) *)
 End Dexter.
 
 
@@ -68,8 +68,8 @@ QuickChick (
 QuickChick (forAllTokenChainTraces 5 (checker_get_state sum_balances_eq_init_supply)).
 (* +++ Passed 10000 tests (0 discards) *)
 
-QuickChick (sum_allowances_le_init_supply_P 5).
-(* *** Failed after 21 tests and 8 shrinks. (0 discards) *)
+QuickChick (expectFailure (sum_allowances_le_init_supply_P 5)).
+(* *** Failed (as expected) after 21 tests and 8 shrinks. (0 discards) *)
 
 QuickChick (token_cb ~~> (person_has_tokens person_3 12)).
 (* Success - found witness satisfying the predicate!
@@ -97,8 +97,8 @@ QuickChick (
   }
 ).*)
 
-QuickChick reapprove_transfer_from_safe_P.
-(* *** Failed after 1 tests and 4 shrinks. (14 discards) *)
+QuickChick (expectFailure reapprove_transfer_from_safe_P).
+(* *** Failed (as expected) after 1 tests and 4 shrinks. (14 discards) *)
 End EIP20Token.
 
 
@@ -127,26 +127,22 @@ Import TestInfo.
 QuickChick (forAll gUniqueAddrPair (fun p => isSomeCheck p (fun '(addr1, addr2) => negb (address_eqb addr1 addr2)))).
 (* +++ Passed 10000 tests (0 discards) *)
 
-(* Test doesn't work *)(*
 QuickChick (
   {{ msg_is_transfer }}
     token_contract_base_addr
   {{ post_transfer_correct }}
-  chain_without_transfer_hook).*)
+  chain_without_transfer_hook).
 
-(* Test doesn't work *)(*
-QuickChick (forAllFA2TracesStatePairs chain_with_transfer_hook 1 transfer_balances_correct).*)
+QuickChick (forAllFA2TracesStatePairs chain_with_transfer_hook 1 transfer_balances_correct).
 
-(* Test doesn't work *)(*
-QuickChick (forAllFA2TracesStatePairs chain_with_transfer_hook 10 transfer_satisfies_policy_P).*)
+QuickChick (forAllFA2TracesStatePairs chain_with_transfer_hook 10 transfer_satisfies_policy_P).
 
-(* Test doesn't work *)(*
 QuickChick (
   {{msg_is_update_operator}}
   token_contract_base_addr
   {{post_last_update_operator_occurrence_takes_effect}}
   chain_without_transfer_hook
-).*)
+).
 End FA2Token.
 
 
@@ -154,16 +150,16 @@ End FA2Token.
 Module iTokenBuggy.
 Import iTokenBuggyTests.
 
-QuickChick token_supply_preserved.
-(* *** Failed after 5 tests and 1000 shrinks. (0 discards) *)
+QuickChick (expectFailure token_supply_preserved).
+(* *** Failed (as expected) after 5 tests and 1000 shrinks. (0 discards) *)
 
-QuickChick (forAllTokenChainTraces 4 (checker_get_state sum_balances_eq_init_supply_checker)).
-(* *** Failed after 1 tests and 7 shrinks. (0 discards) *)
+QuickChick (expectFailure (forAllTokenChainTraces 4 (checker_get_state sum_balances_eq_init_supply_checker))).
+(* *** Failed (as expected) after 1 tests and 7 shrinks. (0 discards) *)
 
-QuickChick (
+QuickChick (expectFailure (
   {{msg_is_not_mint_or_burn}}
   token_caddr
   {{sum_balances_unchanged}}
-).
-(* *** Failed after 3 tests and 8 shrinks. (0 discards) *)
+)).
+(* *** Failed (as expected) after 3 tests and 8 shrinks. (0 discards) *)
 End iTokenBuggy.

--- a/execution/tests/ChainPrinters.v
+++ b/execution/tests/ChainPrinters.v
@@ -156,6 +156,7 @@ Instance showAddBlockError `{Show (@Action Base)} : Show AddBlockError :=
   show err := match err with
               | invalid_header => "invalid_header"
               | invalid_root_action act => "invalid_root_action: " ++ show act
+              | origin_from_mismatch act => "origin_from_mismatch: " ++ show act
               | action_evaluation_depth_exceeded => "action_evaluation_depth_exceeded"
               | action_evaluation_error act eval_error =>
                 "action_evaluation_error for " ++ show act ++ " with error: " ++ show eval_error

--- a/execution/tests/CongressTests/CongressGens.v
+++ b/execution/tests/CongressTests/CongressGens.v
@@ -118,14 +118,16 @@ Definition bindCallerIsOwnerOpt {A : Type}
 Definition try_gNewOwner state calling_addr contract_addr : GOpt Address:=
   bindCallerIsOwnerOpt state calling_addr contract_addr (gCongressMember_without_caller state calling_addr contract_addr).
 
-
+(* NOTE: we assume that the calls are coming from user addresses, therefore we validate the addresses and use them as origins*)
 Definition vote_proposal (caddr : Address)
                          (members_and_proposals : FMap Address (list ProposalId))
-                         (call : Address -> Address -> Msg -> GOpt Action)
+                         (call : forall (caddr : Address) (origin : Address),
+                             address_is_contract origin = false -> Msg -> GOpt Action)
                          (vote : ProposalId -> Msg):=
   '(member, pids) <- sampleFMapOpt members_and_proposals ;;
+  p <- validate_origin member ;;
   pid <- elems_opt pids ;;
-  call caddr member (vote pid).
+  call caddr member p (vote pid).
 
 (* Returns a mapping to proposals which have been discussed long enough, according to the
    current rules in the given congress' state *)
@@ -139,13 +141,14 @@ Definition finishable_proposals (state : Congress.State)
   then pids_map_filtered
   else FMap.empty.
 
+(* NOTE: all call considered top-level calls (from users) *)
 Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GOpt Action :=
-  let call contract_addr caller_addr msg :=
+  let call contract_addr caller_addr caller_addr_is_user msg :=
     amount <- match env.(env_account_balances) caller_addr with
               | 0%Z => returnGenSome 0%Z
               | caller_balance => genToOpt (choose (0%Z, caller_balance))
               end ;;
-    returnGenSome (build_act caller_addr
+    returnGenSome (build_act caller_addr caller_addr_is_user caller_addr
       (congress_action_to_chain_action (cact_call contract_addr amount (serializeMsg msg)))) in
   congress_state <- returnGen (get_contract_state Congress.State env caddr) ;;
   let members := (map fst o FMap.elements) congress_state.(members) in
@@ -156,19 +159,23 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
       (* transfer_ownership *)
       (1, members <- elems_opt (congressContractsMembers_nonowners congress_state) ;;
           new_owner <- (try_gNewOwner congress_state owner caddr) ;;
-          call caddr owner (transfer_ownership new_owner)
+          p <- validate_origin owner ;;
+          call caddr owner p (transfer_ownership new_owner)
       ) ;
       (* change_rules *)
       (1, rules <- genToOpt (gRulesSized 4) ;;
-          (call caddr owner (change_rules rules))
+          p <- validate_origin owner ;;
+          (call caddr owner p (change_rules rules))
       ) ;
       (* add_member *)
       (2, addr <- returnGen (try_newCongressMember congress_state caddr 10) ;;
-          call caddr owner (add_member addr)
+          p <- validate_origin owner ;;
+          call caddr owner p (add_member addr)
       ) ;
       (* remove_member *)
       (1, member <- elems_opt members ;;
-          call caddr owner (remove_member member)
+          p <- validate_origin owner ;;
+          call caddr owner p (remove_member member)
       ) ;
       (* vote_for_proposal *)
       (* Requirements:
@@ -187,11 +194,12 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
          - only contract owner can finish proposals
          - the debating period must have passed *)
       (2, '(pid, _) <- sampleFMapOpt (finishable_proposals congress_state env.(current_slot)) ;;
-           call caddr owner (finish_proposal pid)
+          p <- validate_origin owner ;;
+          call caddr owner p (finish_proposal pid)
       )
     ]
   | S fuel' => backtrack [
-    (3, GCongressAction env fuel' caddr) ;
+    (3, GCongressAction env fuel'  caddr) ;
     (* add_proposal *)
     (1,
       (* recurse. Msg is converted to a SerializedType using 'serialize' *)
@@ -206,7 +214,8 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
       | act_call caddr amount msg =>
         member <- elems_opt members ;;
         let ca := cact_call caddr amount msg in
-        call caddr member (create_proposal [ca])
+        p <- validate_origin member ;;
+        call caddr member p (create_proposal [ca])
       | _ => returnGenSome act
       end)
   ]

--- a/execution/tests/CongressTests/CongressTests.v
+++ b/execution/tests/CongressTests/CongressTests.v
@@ -22,7 +22,7 @@ Definition LocalChainBase : ChainBase := TestUtils.LocalChainBase.
 Definition chain1 : ChainBuilder := builder_initial.
 Definition chain2 : ChainBuilder := unpack_result (add_block chain1 []).
 Definition chain3 : ChainBuilder := unpack_result
-  (add_block chain2 [build_act creator (act_transfer person_1 10)]).
+  (add_block chain2 [build_act creator eq_refl creator (act_transfer person_1 10)]).
 
 Definition setup_rules :=
   {| min_vote_count_permille := 200; (* 20% of congress needs to vote *)
@@ -33,7 +33,7 @@ Definition setup := Congress.build_setup setup_rules.
 Definition deploy_congress : ActionBody :=
   create_deployment 5 Congress.contract setup.
 Definition chain4 : ChainBuilder :=
-  unpack_result (add_block chain3 [build_act person_1 deploy_congress]).
+  unpack_result (add_block chain3 [build_act person_1 eq_refl person_1 deploy_congress]).
 Definition congress_1 : Address :=
   match outgoing_txs (builder_trace chain4) person_1 with
   | tx :: _ => tx_to tx
@@ -54,13 +54,13 @@ end.
 Definition add_person p :=
   congress_ifc.(send) 0 (Some (add_member p)).
 Definition chain5 : ChainBuilder :=
-  let acts := [build_act person_1 (add_person person_1);
-                build_act person_1 (add_person person_2)] in
+  let acts := [build_act person_1 eq_refl person_1 (add_person person_1);
+               build_act person_1 eq_refl person_1 (add_person person_2)] in
   unpack_result (add_block chain4 acts).
 Definition create_proposal_call :=
   congress_ifc.(send) 0 (Some (create_proposal [cact_transfer person_3 3])).
 Definition chain6 : ChainBuilder :=
-  unpack_result (add_block chain5 [build_act person_1 create_proposal_call]).
+  unpack_result (add_block chain5 [build_act person_1 eq_refl person_1 create_proposal_call]).
 
 Definition congress_chain := chain5.
 Definition congress_caddr := BoundedN.of_Z_const AddrSize 128%Z.
@@ -121,11 +121,11 @@ Definition receive_state_well_behaved_P (chain : Chain)
   | _ => false
   end.
 
-(* QuickChick (
-  {{fun _ _ => true}}
-  congress_caddr
-  {{receive_state_well_behaved_P}}
-). *)
+(* QuickChick ( *)
+(*   {{fun _ _ => true}} *)
+(*   congress_caddr *)
+(*   {{receive_state_well_behaved_P}} *)
+(* ). *)
 
 (* coqtop-stdout:+++ Passed 10000 tests (0 discards) *)
 

--- a/execution/tests/CongressTests/Congress_BuggyGens.v
+++ b/execution/tests/CongressTests/Congress_BuggyGens.v
@@ -89,13 +89,21 @@ Definition bindCallerIsOwnerOpt {A : Type}
 Definition try_gNewOwner state calling_addr contract_addr : GOpt Address:=
   bindCallerIsOwnerOpt state calling_addr contract_addr (gCongressMember_without_caller state calling_addr contract_addr).
 
+Fixpoint validate_addr (a : Address) : GOpt (address_is_contract a = false) :=
+  match (Bool.bool_dec (address_is_contract a) true ) with
+  | left _ => ret None
+  | right p => ret (Some (Bool.not_true_is_false _ p))
+  end.
+
 Definition vote_proposal (caddr : Address)
                          (members_and_proposals : FMap Address (list ProposalId))
-                         (call : Address -> Address -> Msg -> GOpt Action)
+                         (call : forall (caddr : Address) (origin : Address),
+                             address_is_contract origin = false -> Msg -> GOpt Action)
                          (vote : ProposalId -> Msg):=
   '(member, pids) <- sampleFMapOpt members_and_proposals ;;
+  p <- validate_addr member ;;
   pid <- elems_opt pids ;;
-  call caddr member (vote pid).
+  call caddr member p (vote pid).
 
 (* Returns a mapping to proposals which have been discussed long enough, according to the
    current rules in the given congress' state *)
@@ -140,12 +148,12 @@ Definition lc_contract_members_and_proposals_with_votes (state : Congress_Buggy.
     else FMap.empty.
 
 Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GOpt Action :=
-  let call contract_addr caller_addr msg :=
+  let call contract_addr caller_addr caller_addr_is_user msg :=
     amount <- match env.(env_account_balances) caller_addr with
               | 0%Z => returnGenSome 0%Z
               | caller_balance => genToOpt (choose (0%Z, caller_balance))
               end ;;
-    returnGenSome (build_act caller_addr
+    returnGenSome (build_act caller_addr caller_addr_is_user caller_addr
       (congress_action_to_chain_action (cact_call contract_addr amount (serializeMsg msg)))) in
   congress_state <- returnGen (get_contract_state Congress_Buggy.State env caddr) ;;
   let members := (map fst o FMap.elements) congress_state.(members) in
@@ -156,19 +164,23 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
       (* transfer_ownership *)
       (1, members <- elems_opt (congressContractsMembers_nonowners congress_state) ;;
           new_owner <- (try_gNewOwner congress_state owner caddr) ;;
-          call caddr owner (transfer_ownership new_owner)
+          p <- validate_addr owner ;;
+          call caddr owner p (transfer_ownership new_owner)
       ) ;
       (* change_rules *)
       (1, rules <- genToOpt (gRulesSized 4) ;;
-          (call caddr owner (change_rules rules))
+          p <- validate_addr owner ;;
+          call caddr owner p (change_rules rules)
       ) ;
       (* add_member *)
       (2, addr <- returnGen (try_newCongressMember congress_state caddr 10) ;;
-          call caddr owner (add_member addr)
+          p <- validate_addr owner ;;
+          call caddr owner p (add_member addr)
       ) ;
       (* remove_member *)
       (1, member <- elems_opt members ;;
-          call caddr owner (remove_member member)
+          p <- validate_addr owner ;;
+          call caddr owner p (remove_member member)
       ) ;
       (* vote_for_proposal *)
       (* Requirements:
@@ -187,7 +199,8 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
          - only contract owner can finish proposals
          - the debating period must have passed *)
       (2, '(pid, _) <- sampleFMapOpt (finishable_proposals congress_state env.(current_slot)) ;;
-           call caddr owner (finish_proposal pid)
+          p <- validate_addr owner ;;
+          call caddr owner p (finish_proposal pid)
       )
     ]
   | S fuel' => backtrack [
@@ -206,7 +219,8 @@ Fixpoint GCongressAction (env : Environment) (fuel : nat) (caddr : Address) : GO
       | act_call caddr amount msg =>
         member <- elems_opt members ;;
         let ca := cact_call caddr amount msg in
-        call caddr member (create_proposal [ca])
+        p <- validate_addr member ;;
+        call caddr member p (create_proposal [ca])
       | _ => returnGenSome act
       end)
   ]

--- a/execution/tests/CongressTests/Congress_BuggyTests.v
+++ b/execution/tests/CongressTests/Congress_BuggyTests.v
@@ -45,7 +45,7 @@ Definition exploit_example : option (Address * ChainBuilder) :=
              block_finalized_height := finalized_height chain;
              block_creator := creator;
              block_reward := 50; |} in
-      let acts := map (build_act creator) act_bodies in
+      let acts := map (build_act creator eq_refl creator) act_bodies in
       option_of_result (builder_add_block chain next_header acts) in
   (* Get some money on the creator *)
   (* Deploy congress and exploit contracts *)
@@ -108,11 +108,11 @@ Definition receive_state_well_behaved_P (chain : Chain)
   | _ => checker false
   end.
 
-(* QuickChick (
-  {{fun _ _ => true}}
-  congress_caddr
-  {{receive_state_well_behaved_P}}
-). *)
+(* QuickChick ( *)
+(*   {{fun _ _ => true}} *)
+(*   congress_caddr *)
+(*   {{receive_state_well_behaved_P}} *)
+(* ). *)
 
 (* 
 Chain{| 

--- a/execution/tests/DexterTests/DexterTests.v
+++ b/execution/tests/DexterTests/DexterTests.v
@@ -104,13 +104,13 @@ Definition chain0 : ChainBuilder :=
 Definition chain1 : ChainBuilder :=
   unpack_result (TraceGens.add_block chain0
   [
-    build_act creator (act_transfer person_1 10) ;
-    build_act creator deploy_fa2token ;
-    build_act creator deploy_dexter ;
-    build_act creator deploy_exploit ;
-    build_act person_1 (act_call fa2_caddr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
-    build_act creator (act_call dexter_caddr 10%Z (serialize _ _ (dexter_other_msg (add_to_tokens_reserve 0%N)))) ;
-    build_act person_1 (act_call fa2_caddr 0%Z  (serialize _ _ (msg_update_operators [add_operator (add_operator_all person_1 exploit_caddr);
+    build_act creator eq_refl creator (act_transfer person_1 10) ;
+    build_act creator eq_refl creator deploy_fa2token ;
+    build_act creator eq_refl creator deploy_dexter ;
+    build_act creator eq_refl creator deploy_exploit ;
+    build_act person_1 eq_refl person_1 (act_call fa2_caddr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
+    build_act creator eq_refl creator (act_call dexter_caddr 10%Z (serialize _ _ (dexter_other_msg (add_to_tokens_reserve 0%N)))) ;
+    build_act person_1 eq_refl person_1 (act_call fa2_caddr 0%Z  (serialize _ _ (msg_update_operators [add_operator (add_operator_all person_1 exploit_caddr);
                                                                                       add_operator (add_operator_all person_1 dexter_caddr)])))
   ]).
 
@@ -131,17 +131,22 @@ Module TestInfo <: DexterTestsInfo.
 End TestInfo.
 Module MG := DexterGens.DexterGens TestInfo. Import MG.
 
-Definition call_dexter owner_addr :=
+Definition call_dexter owner_addr owner_addr_not_contract :=
   let dummy_descriptor := {|
     transfer_descr_fa2 := fa2_caddr;
     transfer_descr_batch := [];
     transfer_descr_operator := dexter_caddr;
   |} in
-  build_act owner_addr (act_call exploit_caddr 0%Z (@serialize _ _ (tokens_sent dummy_descriptor))).
+  build_act owner_addr owner_addr_not_contract owner_addr (act_call exploit_caddr 0%Z (@serialize _ _ (tokens_sent dummy_descriptor))).
 
 Definition gExploitAction : GOpt Action :=
-  bindGen (elems [person_1; person_2; person_3]) (fun addr =>
-    returnGenSome (call_dexter addr)
+  bindGen (elems [person_1; person_2; person_3])
+          (fun addr => bindGen (validate_origin addr)
+                            (fun p_opt =>
+                               match p_opt with
+                               | Some p => returnGenSome (call_dexter addr p)
+                               | None => returnGen None
+                               end)
   ).
 
 Definition gExploitChainTraceList max_acts_per_block cb length :=
@@ -202,7 +207,6 @@ Definition tokens_to_asset_correct_P env :=
 
 Definition tokens_to_asset_correct :=
   forAllBlocks 1 chain1 (gExploitChainTraceList 1) tokens_to_asset_correct_P.
-(* QuickChick tokens_to_asset_correct. *)
 
 (* Illustration of how the reentrancy attack can give the caller more money with the same amount of tokens.
    Notice how in the second sequence, the second argument remains the same, ie. it emulates the reentrancy attack. *)
@@ -230,7 +234,7 @@ Definition tokens_to_asset_correct :=
 (* 2 *)
 (* total = 16 *)
 
-(* QuickChick tokens_to_asset_correct. *)
+(* QuickChick (expectFailure tokens_to_asset_correct). *)
 (*
 Begin Trace:
 step_action{Action{act_from: 11%256, act_body: (act_call 130%256, 0, transferhook transfer_descriptor_param{transfer_descr_fa2: 128%256, transfer_descr_batch: [], transfer_descr_operator: 129%256})}}

--- a/execution/tests/EIP20Tests/EIP20TokenGens.v
+++ b/execution/tests/EIP20Tests/EIP20TokenGens.v
@@ -76,27 +76,33 @@ Definition gTransfer_from (state : EIP20Token.State) : GOpt (Address * Msg) :=
 Local Close Scope N_scope.
 (* Main generator. *)
 Definition gEIP20TokenAction (env : Environment) : GOpt Action :=
-  let call contract_addr caller_addr msg :=
-    returnGenSome {|
-      act_from := caller_addr;
-      act_body := act_call contract_addr 0%Z (serializeMsg msg)
-    |} in
+  let call contract_addr caller_addr caller_addr_is_user msg :=
+      returnGenSome {|
+          act_origin := caller_addr;
+          act_origin_valid := caller_addr_is_user;
+          act_from := caller_addr;
+          act_body := act_call contract_addr 0%Z (serializeMsg msg)
+        |} in
   state <- returnGen (get_contract_state EIP20Token.State env contract_addr) ;;
   backtrack [
     (* transfer *)
-    (2, '(caller, msg) <- gTransfer env state ;;
-        call contract_addr caller msg
+      (2, '(caller, msg) <- gTransfer env state ;;
+          p <- validate_origin caller ;;
+          call contract_addr caller p msg
     ) ;
     (* transfer_from *)
     (3, bindGenOpt (gTransfer_from state)
         (fun '(caller, msg) =>
-        call contract_addr caller msg
+          p <- validate_origin caller ;;
+          call contract_addr caller p msg
+
         )
     );
     (* approve *)
     (2, bindGenOpt (gApprove state)
         (fun '(caller, msg) =>
-        call contract_addr caller msg
+          p <- validate_origin caller ;;
+          call contract_addr caller p msg
         )
     )
   ].

--- a/execution/tests/EIP20Tests/EIP20TokenTests.v
+++ b/execution/tests/EIP20Tests/EIP20TokenTests.v
@@ -34,10 +34,10 @@ Let contract_base_addr := BoundedN.of_Z_const AddrSize 128%Z.
 Definition token_cb :=
   ResultMonad.unpack_result (TraceGens.add_block (lcb_initial AddrSize)
   [
-    build_act creator (act_transfer person_1 0);
-    build_act creator (act_transfer person_2 0);
-    build_act creator (act_transfer person_3 0);
-    build_act creator deploy_eip20token
+    build_act creator eq_refl creator (act_transfer person_1 0);
+    build_act creator eq_refl creator (act_transfer person_2 0);
+    build_act creator eq_refl creator (act_transfer person_3 0);
+    build_act creator eq_refl creator deploy_eip20token
   ]).
 
 Module TestInfo <: EIP20GensInfo.
@@ -118,9 +118,9 @@ Definition checker_get_state {prop} `{Checkable prop} (pf : State -> prop) (cs :
   | None => checker true (* trivially true case *) 
   end.
 
-(* QuickChick (forAllTokenChainTraces 5 (checker_get_state sum_balances_eq_init_supply)). *)
-(* coqtop-stdout:+++ Passed 10000 tests (1570 discards) *)
-(* 8 seconds *)
+(* Time QuickChick (forAllTokenChainTraces 5 (checker_get_state sum_balances_eq_init_supply)). *)
+(* coqtop-stdout:+++ Passed 10000 tests (0 discards) *)
+(* 9 seconds *)
 
 (* INVALID PROPERTY: accounts may allow multiple other accounts to transfer tokens, but the actual transfer ensures that
    no more tokens are sent than the balance of the sender. *)
@@ -154,6 +154,8 @@ Notation "'{' lc '~~>' pf1 '===>' pf2 '}'" :=
   (at level 45, lc at next level, left associativity).
 
 (* QuickChick (token_cb ~~> (person_has_tokens person_3 12)). *)
+
+(* TODO: check if the properties below make sense now, some of the definitions seems to be missing, e.g. [chain_with_token_deployed] *)
 
 (* QuickChick (chain_with_token_deployed ~~> (fun lc => isSome (person_has_tokens person_3 12 lc))). *)
 (* QuickChick (chain_with_token_deployed ~~> person_has_tokens creator 0). *)

--- a/execution/tests/EscrowTests/EscrowTests.v
+++ b/execution/tests/EscrowTests/EscrowTests.v
@@ -37,8 +37,8 @@ Section TestSetup.
   Definition escrow_chain : ChainBuilder :=
     unpack_result (TraceGens.add_block (lcb_initial AddrSize)
     [
-      build_act creator (act_transfer buyer 10);
-      build_act seller (deploy_escrow 2)
+      build_act seller eq_refl seller (act_transfer buyer 10);
+      build_act seller eq_refl seller (deploy_escrow 2)
     ]).
     
 End TestSetup.
@@ -264,7 +264,7 @@ Discarded: 20000 *)
 (* +++ Passed 10000 tests (0 discards) *)
 (* Or alternatively we can just write: *)
 (* QuickChick escrow_correct_P. *)
-(* +++ Passed 10000 tests (40 discards) *)
+(* +++ Passed 10000 tests  (40 discards) *)
 (* Not sure where the 40 discards come from, but it's an acceptable amount for sure... *)
 
 (* Note that we are implicitly using the "better" generator here to generate arbitrary ChainTraces *)

--- a/execution/tests/FA2Tests/FA2Gens.v
+++ b/execution/tests/FA2Tests/FA2Gens.v
@@ -194,16 +194,19 @@ Definition gUpdateOperators (chain : Chain)
 
 
 Definition gFA2TokenAction (env : Environment) : GOpt Action :=
-  let mk_call caller_addr amount msg :=
-    returnGenSome {|
-      act_from := caller_addr;
-      act_body := act_call fa2_contract_addr amount (serialize FA2Token.Msg _ msg)
+  let mk_call caller_addr caller_addr_is_user amount msg :=
+      returnGenSome {|
+          act_origin := caller_addr;
+          act_origin_valid := caller_addr_is_user;
+          act_from := caller_addr;
+          act_body := act_call fa2_contract_addr amount (serialize FA2Token.Msg _ msg)
     |} in
   fa2_state <- returnGen (get_contract_state FA2Token.State env fa2_contract_addr) ;;
   backtrack [
     (* transfer tokens *)
     (4, '(caller, trx) <- gTransfer fa2_state 4 ;;
-        mk_call caller 0%Z trx
+        p <- validate_origin caller ;;
+        mk_call caller p 0%Z trx
     ) ;
     (* create tokens *)
     (1, let has_balance amount := Z.ltb 0 amount in
@@ -212,12 +215,14 @@ Definition gFA2TokenAction (env : Environment) : GOpt Action :=
         (* caller <- liftM fst (sampleFMapOpt_filter lc.(lc_account_balances)
                             (fun p => (is_not_contract_addr (fst p)) && (has_balance (snd p)))) ;; *)
         '(amount, msg) <- gCreateTokens env caller fa2_state ;;
-        mk_call caller amount msg
+        p <- validate_origin caller ;;
+        mk_call caller p amount msg
     ) ;
     (* update operators *)
     (2, caller <- liftOptGen (gAddrWithout []) ;;
         upd <- gUpdateOperators env fa2_state 2 ;;
-        mk_call caller 0%Z upd
+        p <- validate_origin caller ;;
+        mk_call caller p 0%Z upd
     )
   ].
 End FA2ContractGens.
@@ -238,16 +243,19 @@ Definition gIsOperatorMsg : G (option ClientMsg) :=
     returnGenSome (client_other_msg (Call_fa2_is_operator params)).
 
 Definition gClientAction (env : Environment) : GOpt Action :=
-  let mk_call_fa2 caller fa2_caddr msg :=
-    returnGenSome {|
-      act_from := caller;
-      act_body := act_call fa2_client_addr 0%Z (serialize ClientMsg _ msg)
-    |} in
+  let mk_call_fa2 caller caller_is_user fa2_caddr msg :=
+      returnGenSome {|
+          act_origin := caller;
+          act_origin_valid := caller_is_user;
+          act_from := caller;
+          act_body := act_call fa2_client_addr 0%Z (serialize ClientMsg _ msg)
+        |} in
   state <- returnGen (get_contract_state ClientState env fa2_client_addr) ;;
   let fa2_caddr := state.(fa2_caddr) in
   caller <- liftOptGen (gAddrWithout []) ;;
   msg <- gIsOperatorMsg ;;
-  mk_call_fa2 caller fa2_caddr msg.
+  p <- validate_origin caller ;;
+  mk_call_fa2 caller p fa2_caddr msg.
 
 End FA2ClientGens.
 

--- a/execution/tests/FA2Tests/FA2TokenTests.v
+++ b/execution/tests/FA2Tests/FA2TokenTests.v
@@ -91,41 +91,41 @@ Definition client_contract_addr : Address := BoundedN.of_Z_const AddrSize 129%Z.
 Definition chain_with_token_deployed_with_hook : ChainBuilder :=
   unpack_result (TraceGens.add_block (lcb_initial AddrSize)
   [
-    build_act creator (act_transfer person_1 10);
-    build_act creator (act_transfer person_2 10);
-    build_act creator (act_transfer person_3 10);
-    build_act creator deploy_fa2token_with_transfer_hook;
-    build_act creator deploy_fa2token_client;
-    build_act creator deploy_fa2hook
+    build_act creator eq_refl creator (act_transfer person_1 10);
+    build_act creator eq_refl creator (act_transfer person_2 10);
+    build_act creator eq_refl creator (act_transfer person_3 10);
+    build_act creator eq_refl creator deploy_fa2token_with_transfer_hook;
+    build_act creator eq_refl creator deploy_fa2token_client;
+    build_act creator eq_refl creator deploy_fa2hook
   ]).
 
 Definition chain_with_token_deployed_without_hook : ChainBuilder :=
   unpack_result (TraceGens.add_block (lcb_initial AddrSize)
   [
-    build_act creator (act_transfer person_1 10);
-    build_act creator (act_transfer person_2 10);
-    build_act creator (act_transfer person_3 10);
-    build_act creator deploy_fa2token_without_transfer_hook;
-    build_act creator deploy_fa2token_client
+    build_act creator eq_refl creator (act_transfer person_1 10);
+    build_act creator eq_refl creator (act_transfer person_2 10);
+    build_act creator eq_refl creator (act_transfer person_3 10);
+    build_act creator eq_refl creator deploy_fa2token_without_transfer_hook;
+    build_act creator eq_refl creator deploy_fa2token_client
   ]).
 
 Definition chain_without_transfer_hook' : result ChainBuilder AddBlockError :=
   (TraceGens.add_block chain_with_token_deployed_without_hook
   [
-    build_act person_1 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
-    build_act person_2 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N)))
+    build_act person_1 eq_refl person_1 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
+    build_act person_2 eq_refl person_2 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N)))
   ]).
 
 Definition chain_with_transfer_hook' : result ChainBuilder AddBlockError :=
   (TraceGens.add_block chain_with_token_deployed_with_hook
   [
-    build_act person_1 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
-    build_act person_2 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N)))
+    build_act person_1 eq_refl person_1 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N))) ;
+    build_act person_2 eq_refl person_2 (act_call token_contract_base_addr 10%Z (serialize _ _ (msg_create_tokens 0%N)))
   ]).
 
-(* Uncomment for testing. This is commented because it is computationally expensive (> 20 seconds to compute) *)
-(* Definition chain_without_transfer_hook := unpack_result chain_without_transfer_hook'. *)
-(* Definition chain_without_transfer_hook := unpack_result chain_without_transfer_hook'. *)
+Definition chain_without_transfer_hook := unpack_result chain_without_transfer_hook'.
+Definition chain_with_transfer_hook := unpack_result chain_with_transfer_hook'.
+
 
 Definition client_other_msg := @other_msg _ FA2ClientMsg _.
 
@@ -232,11 +232,11 @@ Definition post_transfer_correct (chain : Chain) (cctx : ContractCallContext) ol
   | None => checker false
   end.
 
-(* QuickChick (
-  {{ msg_is_transfer }}
-    token_contract_base_addr
-  {{ post_transfer_correct }}
-  chain_without_transfer_hook). *)
+(* QuickChick ( *)
+(*   {{ msg_is_transfer }} *)
+(*     token_contract_base_addr *)
+(*   {{ post_transfer_correct }} *)
+(*   chain_without_transfer_hook). *)
 (* 14 seconds, max size 7, 1 act per block *)
 (* +++ Passed 10000 tests (0 discards) *)
 

--- a/execution/tests/TestUtils.v
+++ b/execution/tests/TestUtils.v
@@ -32,6 +32,12 @@ Definition person_4 : Address :=
 Definition person_5 : Address :=
   BoundedN.of_Z_const AddrSize 15.
 
+Fixpoint validate_origin (a : Address) : GOpt (address_is_contract a = false) :=
+  match (Bool.bool_dec (address_is_contract a) true ) with
+  | left _ => ret None
+  | right p => ret (Some (Bool.not_true_is_false _ p))
+  end.
+
 Definition test_chain_addrs := [person_1; person_2; person_3; person_4; person_5].
 
 (* Misc utility functions *)

--- a/execution/tests/TraceGens.v
+++ b/execution/tests/TraceGens.v
@@ -441,7 +441,7 @@ Section TraceGens.
           env_from.(env_account_balances) caddr
         else
           (env_from.(env_account_balances) caddr + amount)%Z in
-      let cctx := build_ctx act.(act_from) caddr new_balance amount in
+      let cctx := build_ctx act.(act_origin) act.(act_from) caddr new_balance amount in
         match act.(act_body) with
         | act_call to _ ser_msg =>
           if address_eqb to caddr

--- a/execution/tests/iTokenBuggyTests/iTokenBuggyGens.v
+++ b/execution/tests/iTokenBuggyTests/iTokenBuggyGens.v
@@ -62,28 +62,34 @@ Definition gBurn (state : iTokenBuggy.State) : GOpt (Address * Msg) :=
 Local Close Scope N_scope.
 (* Main generator. *)
 Definition giTokenBuggyAction (env : Environment) : GOpt Action :=
-  let call contract_addr caller_addr msg :=
-    returnGenSome {|
-      act_from := caller_addr;
-      act_body := act_call contract_addr 0%Z (serializeMsg msg)
-    |} in
+  let call caller_addr caller_addr_is_user contract_addr msg :=
+      returnGenSome {|
+          act_origin := caller_addr;
+          act_origin_valid := caller_addr_is_user;
+          act_from := caller_addr;
+          act_body := act_call contract_addr 0%Z (serializeMsg msg)
+        |} in
   state <- returnGen (get_contract_state iTokenBuggy.State env contract_addr) ;;
   backtrack [
     (* mint *)
     (1, '(caller, msg) <- gMint env state ;;
-         call contract_addr caller msg
+        p <- validate_origin caller ;;
+        call caller p contract_addr msg
     ) ;
     (* burn *)
     (1, '(caller, msg) <- gBurn state ;;
-         call contract_addr caller msg
+        p <- validate_origin caller ;;
+        call caller p contract_addr msg
     ) ;
     (* transfer_from *)
     (4, '(caller, msg) <- gTransfer_from state ;;
-         call contract_addr caller msg
+        p <- validate_origin caller ;;
+        call caller p contract_addr msg
     );
     (* approve *)
     (2, '(caller, msg) <- gApprove state ;;
-         call contract_addr caller msg
+        p <- validate_origin caller ;;
+        call caller p contract_addr msg
     )
   ].
 

--- a/execution/tests/iTokenBuggyTests/iTokenBuggyTests.v
+++ b/execution/tests/iTokenBuggyTests/iTokenBuggyTests.v
@@ -48,10 +48,10 @@ Definition token_caddr := BoundedN.of_Z_const AddrSize 128%Z.
 Definition token_cb :=
   ResultMonad.unpack_result (TraceGens.add_block (lcb_initial AddrSize)
   [
-    build_act creator (act_transfer person_1 0);
-    build_act creator (act_transfer person_2 0);
-    build_act creator (act_transfer person_3 0);
-    build_act creator deploy_iToken
+    build_act creator eq_refl creator (act_transfer person_1 0);
+    build_act creator eq_refl creator (act_transfer person_2 0);
+    build_act creator eq_refl creator (act_transfer person_3 0);
+    build_act creator eq_refl creator deploy_iToken
   ]).
 
 Module TestInfo <: iTokenBuggyGensInfo.
@@ -118,10 +118,10 @@ Conjecture token_supply_preserved : forall sig_to : {to | reachable to},
   let to := proj1_sig sig_to in
   get_state sum_balances_eq_init_supply to = true.
 
-(* QuickChick token_supply_preserved. *)
+(* QuickChick (expectFailure token_supply_preserved). *)
 (* Or alternatively, for better output: *)
-(* QuickChick (forAllTokenChainTraces 4 (checker_get_state sum_balances_eq_init_supply_checker)). *)
-(* *** Failed after 5 tests and 1000 shrinks. (0 discards) *)
+(* QuickChick (expectFailure (forAllTokenChainTraces 4 (checker_get_state sum_balances_eq_init_supply_checker))). *)
+(* *** Failed (as expected) after 5 tests and 1000 shrinks. (0 discards) *)
 (* Action{act_from: 11%256, act_body: (act_call 128%256, 0, withdraw)}}
 balances_sum: 12
 total_supply: 10
@@ -149,10 +149,12 @@ Definition sum_balances_unchanged (chain : Chain)
   | None => false ==> true
   end.
 
-(* QuickChick (
-  {{msg_is_not_mint_or_burn}}
-  token_caddr
-  {{sum_balances_unchanged}}
-). *)
-(* *** Failed after 1 tests and 0 shrinks. (0 discards)
+(*
+QuickChick (expectFailure (
+                {{msg_is_not_mint_or_burn}}
+                  token_caddr
+                  {{sum_balances_unchanged}}
+           )).
+*)
+(* *** Failed (as expected) after 1 tests and 0 shrinks. (0 discards)
        On Msg: transfer_from 13%256 13%256 1 *)

--- a/execution/theories/Circulation.v
+++ b/execution/theories/Circulation.v
@@ -32,11 +32,13 @@ Proof.
 Qed.
 
 Lemma eval_action_from_to_same
+      {origin : Address}
+      {origin_valid : address_is_contract origin = false}
       {pre : Environment}
       {act : Action}
       {post : Environment}
       {new_acts : list Action}
-      (eval : ActionEvaluation pre act post new_acts) :
+      (eval : ActionEvaluation origin origin_valid pre act post new_acts) :
   eval_from eval = eval_to eval ->
   circulation post = circulation pre.
 Proof.
@@ -45,18 +47,20 @@ Proof.
   induction (elements Address) as [| x xs IH].
   - reflexivity.
   - cbn in *.
-    rewrite IH, (account_balance_post eval), from_eq_to.
+    rewrite IH, (account_balance_post _ eval), from_eq_to.
     lia.
 Qed.
 
 Hint Resolve eval_action_from_to_same : core.
 
 Lemma eval_action_circulation_unchanged
+      {origin : Address}
+      {origin_valid : address_is_contract origin = false}
       {pre : Environment}
       {act : Action}
       {post : Environment}
       {new_acts : list Action} :
-  ActionEvaluation pre act post new_acts ->
+  ActionEvaluation origin origin_valid pre act post new_acts ->
   circulation post = circulation pre.
 Proof.
   intros eval.
@@ -67,8 +71,8 @@ Proof.
   unfold circulation.
   rewrite 2!(sumZ_permutation perm).
   cbn.
-  rewrite (account_balance_post_to eval from_neq_to).
-  rewrite (account_balance_post_from eval from_neq_to).
+  rewrite (account_balance_post_to _ eval from_neq_to).
+  rewrite (account_balance_post_from _ eval from_neq_to).
   enough (sumZ (env_account_balances pre) suf = sumZ (env_account_balances post) suf)
     by lia.
 
@@ -79,7 +83,7 @@ Proof.
   { apply (in_NoDup_app _ [eval_from eval; eval_to eval] _); intuition. }
 
   clear perm perm_set.
-  pose proof (account_balance_post_irrelevant eval) as balance_irrel.
+  pose proof (account_balance_post_irrelevant _ eval) as balance_irrel.
   induction suf as [| x xs IH]; auto.
   cbn in *.
   rewrite IH, balance_irrel; auto.

--- a/extraction/examples/ERC20LiquidityExtraction.v
+++ b/extraction/examples/ERC20LiquidityExtraction.v
@@ -86,8 +86,8 @@ Section EIP20TokenExtraction.
   Open Scope N_scope.
   Open Scope bool.
 
-  (* We define a version of [receive] that has the right signature.
-     TODO: remove, once the [LiquidityMod] is fixed. *)
+  (* We define a version of [receive] that has the right signature. *)
+  (* TODO: remove, once the [LiquidityMod] is fixed. *)
   Definition test_receive
       (ctx : ContractCallContext)
       (state : EIP20Token.State)
@@ -118,13 +118,20 @@ Section EIP20TokenExtraction.
             allowances := AddressMap.empty |}.
   Open Scope Z_scope.
 
+  Definition printERC20Wrapper (contract : string): string :=
+  "let wrapper param (st : storage)"
+        ++ " = "
+        ++ "match " ++ contract ++ " (" ++ liquidity_call_ctx ++ ", param) st" ++ " with"
+        ++ "| Some v -> v"
+        ++ "| None -> failwith ()".
+
   Definition EIP20Token_MODULE : LiquidityMod params ContractCallContext EIP20Token.Setup EIP20Token.State ActionBody :=
   {| (* a name for the definition with the extracted code *)
       lmd_module_name := "liquidity_eip20token" ;
 
       (* definitions of operations on pairs and ints *)
       lmd_prelude := LPretty.LiquidityPrelude;
-                       
+
 
       (* initial storage *)
       lmd_init := init ;
@@ -136,7 +143,7 @@ Section EIP20TokenExtraction.
 
       (* code for the entry point *)
       lmd_entry_point := "type storage = state" ++ nl
-                          ++ LPretty.printWrapper (PREFIX ++ "receive_wrapper") ++ nl
+                          ++ printERC20Wrapper (PREFIX ++ "receive_wrapper") ++ nl
       ++ LPretty.printMain |}.
 
 

--- a/extraction/examples/extracted-code/concordium-extract/escrow-extracted/src/tests.rs
+++ b/extraction/examples/extracted-code/concordium-extract/escrow-extracted/src/tests.rs
@@ -118,6 +118,7 @@ mod tests {
         let init_balance = 10;
         let slot_time = Timestamp::from_timestamp_millis(11);
         ctx.set_metadata_slot_time(slot_time);
+        ctx.set_invoker(buyer_addr);
         ctx.set_sender(Address::Account(buyer_addr));
         ctx.set_self_address(self_addr);
         ctx.set_self_balance(concordium_std::Amount::from_micro_gtu(init_balance));

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -179,6 +179,7 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% @stdpp.base.empty %%> "Map.empty"
 
   (* call context *)
+  ; remap <%% @ctx_origin %%> "ctx_origin"
   ; remap <%% @ctx_from %%> "ctx_from"
   ; remap <%% @ctx_contract_address %%> "ctx_contract_address"
   ; remap <%% @ctx_contract_balance %%> "ctx_contract_balance"

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -930,6 +930,7 @@ Definition CameLIGO_call_ctx_type_name : string := "cctx".
 Definition CameLIGO_call_ctx_type :=
 <$ "(* ConCert's call context *)"
 ; "type " ^ CameLIGO_call_ctx_type_name ^ " = {"
+; "  ctx_origin_ : address;"
 ; "  ctx_from_ : address;"
 ; "  ctx_contract_address_ : address;"
 ; "  ctx_contract_balance_ : tez;"
@@ -940,7 +941,8 @@ $>.
 Definition CameLIGO_call_ctx_instance :=
 <$"(* a call context instance with fields filled in with required data *)"
 ; "let cctx_instance : " ^ CameLIGO_call_ctx_type_name ^ "= "
-; "{ ctx_from_ = Tezos.sender;"
+; "{ ctx_origin_ = Tezos.source;"
+; "  ctx_from_ = Tezos.sender;"
 ; "  ctx_contract_address_ = Tezos.self_address;"
 ; "  ctx_contract_balance_ = Tezos.balance;"
 ; "  ctx_amount_ = Tezos.balance"

--- a/extraction/theories/ConcordiumExtract.v
+++ b/extraction/theories/ConcordiumExtract.v
@@ -359,6 +359,7 @@ Section ConcordiumPrinting.
      "        " ++ RustExtract.ty_const_global_ident_of_kername <%% @ContractCallContext %%> ++ "::build_ctx(";
      "            PhantomData,";
      "            Address::Account(ctx.init_origin()),";
+     "            Address::Account(ctx.init_origin()),";
      "            Address::Contract(ContractAddress { index: 0, subindex: 0 }),";
      "            amount.micro_gtu as i64,";
      "            amount.micro_gtu as i64);";
@@ -437,6 +438,7 @@ Section ConcordiumPrinting.
      "    let cctx =";
      "        " ++ RustExtract.ty_const_global_ident_of_kername <%% @ContractCallContext %%> ++ "::build_ctx(";
      "            PhantomData,";
+     "            Address::Account(ctx.invoker()),";
      "            ctx.sender(),";
      "            Address::Contract(ctx.self_address()),";
      "            balance,";


### PR DESCRIPTION
Addressing issue #118.

Call origin is added to the `ContractCallContext` and to `Action`.
In `Action` we also add the `act_origin_valid` field to ensure that `act_origin` is never a contract.