### PR TITLE
Implementation of the Concordium's ccd wrapper token (cis1-wccd) and proofs of compliance with CIS1

### DIFF
--- a/execution/_CoqProject
+++ b/execution/_CoqProject
@@ -41,6 +41,7 @@ examples/FA2Interface.v
 examples/FA2Token.v
 examples/LocalBlockchainTests.v
 examples/StackInterpreter.v
+examples/Cis1wccd.v
 
 -R tests ConCert.Execution.QCTests
 tests/ChainPrinters.v

--- a/execution/examples/Cis1wccd.v
+++ b/execution/examples/Cis1wccd.v
@@ -1,0 +1,481 @@
+(**
+  This file contains an implementation of the example token that complies with the Concordium's CIS1 standard.
+  The development is inspired by the Rust implementation: https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/examples/cis1-wccd
+*)
+
+From Coq Require Import ZArith.
+From Coq Require Import List.
+From ConCert.Execution Require Import Monads.
+From ConCert.Execution Require Import Containers.
+From ConCert.Execution Require Import Extras.
+From ConCert.Execution Require Import Serializable.
+From ConCert.Execution Require Import Blockchain.
+From ConCert.Execution.Examples Require Import Common.
+From ConCert.Execution.Standards.CIS1 Require Import CIS1Spec.
+From ConCert.Utils Require Import RecordUpdate.
+
+Import ListNotations.
+Import RecordSetNotations.
+
+Definition requireTrue (cond : bool) :=
+  if cond then Some tt else None.
+
+Section WccdToken.
+  Context {BaseTypes : ChainBase}.
+  Set Nonrecursive Elimination Schemes.
+
+  Definition TOKEN_ID_WCCD : TokenID := 0.
+
+  Open Scope bool.
+
+  (** * Entry points *)
+
+  Record wccd_transfer_params :=
+    { wccd_td_amount   : TokenAmount;
+      wccd_td_from     : Address;
+      wccd_td_to       : Address }.
+
+  Inductive OpUpdateKind :=
+    opAdd
+  | opDelete.
+
+  Inductive Msg :=
+  | wccd_msg_transfer (params : list wccd_transfer_params)
+  | wccd_msg_balanceOf (query : list Address)
+                   (send_results_to : Address)
+  | wccd_msg_updateOperator (params : list (OpUpdateKind * Address))
+  | wccd_msg_mint (receiver : Address)
+  | wccd_msg_burn (amount : TokenAmount).
+
+  (** * Contract's state *)
+  (** The state tracked for each address.*)
+  Record AddressState := {
+        wccd_balance:   TokenAmount;
+        wccd_operators: list Address
+    }.
+
+  (* begin hide *)
+  MetaCoq Run (make_setters AddressState).
+  (* end hide *)
+
+
+  (** The contract state: a mapping from addresses to [AddressState] *)
+
+  Definition State := AddressMap.AddrMap AddressState.
+
+  Section Serialization.
+
+    Global Instance OpUpdateKind_serializable : Serializable OpUpdateKind :=
+      Derive Serializable OpUpdateKind_rect <opAdd, opDelete>.
+
+    Global Instance state_serializable : Serializable AddressState :=
+      Derive Serializable AddressState_rect <Build_AddressState>.
+
+    Global Instance wccd_transfer_params_serializable : Serializable wccd_transfer_params :=
+      Derive Serializable wccd_transfer_params_rect <Build_wccd_transfer_params>.
+
+    Global Instance msg_serializable : Serializable Msg :=
+      Derive Serializable Msg_rect <wccd_msg_transfer, wccd_msg_balanceOf, wccd_msg_updateOperator, wccd_msg_mint, wccd_msg_burn>.
+
+  End Serialization.
+
+  (** Transfer *)
+
+  Definition increment_balance (st : State) (addr : Address) (inc : TokenAmount) : State :=
+    match AddressMap.find addr st with
+    | Some old => AddressMap.add addr (old<| wccd_balance := old.(wccd_balance) + inc |>) st
+    | None => AddressMap.add addr {| wccd_balance := inc
+                                   ; wccd_operators := [] |} st
+    end.
+
+  Definition decrement_balance (st : State) (addr : Address) (dec : TokenAmount) : option State :=
+    do old <- AddressMap.find addr st;
+    let old_balance := old.(wccd_balance) in
+    do requireTrue (dec <=? old_balance);
+    ret (AddressMap.add addr (old<| wccd_balance := old_balance - dec |>) st).
+
+  (** Single transfer of [amount] between [from] and [to] *)
+  Definition wccd_transfer_single
+             (token_id : TokenID)
+             (amount : TokenAmount)
+             (from to : Address)
+             (prev_st : State) : option State :=
+    do requireTrue (token_id =? TOKEN_ID_WCCD);
+    do st <- decrement_balance prev_st from amount;
+    ret (increment_balance st to amount).
+
+  (** Batch execution of all transfers in the list. Note that the
+      operation succeeds only if all transfers in the batch succeed *)
+  Definition wccd_transfer (transfers : list wccd_transfer_params) (prev_st : State)
+    : option State :=
+    monad_foldl (fun acc x =>
+                   wccd_transfer_single TOKEN_ID_WCCD x.(wccd_td_amount) x.(wccd_td_from) x.(wccd_td_to) acc)
+                prev_st transfers.
+
+  (** * balanceOf *)
+
+  Definition get_balance_opt (addr : Address) (st : State) : option TokenAmount :=
+    match AddressMap.find addr st with
+    | Some data => Some data.(wccd_balance)
+    | None => None
+    end.
+
+  Definition wccd_balanceOf (query : list Address) (st : State)
+    : list (TokenID * Address * TokenAmount) :=
+    map (fun addr => (TOKEN_ID_WCCD, addr, with_default TOKEN_ID_WCCD (get_balance_opt addr st))) query.
+
+  (** * updateOperator *)
+
+  Definition add_remove (param : OpUpdateKind * Address) (operators : list Address) :=
+    let '(updateKind,addr) := param in
+    match updateKind with
+    | opAdd => addr :: operators
+    | opDelete => remove address_eqdec addr operators
+    end.
+
+  Definition wccd_updateOperator (owner : Address) (params : list (OpUpdateKind * Address)) (prev_st : State)
+    : option State :=
+    (* NOTE: in contrast to the Concordium's implementation, we do not
+       allow to add operators to non-existing addresses *)
+    do owner_data <- AddressMap.find owner prev_st;
+    let updated_owner_data := owner_data<| wccd_operators := fold_right add_remove owner_data.(wccd_operators) params |> in
+    ret (AddressMap.add owner updated_owner_data prev_st).
+
+  (** * Wccd receive *)
+
+  (* We dispatch on a message of type [Msg] and call the corresponding functions with received parameters *)
+  Definition wccd_receive (chain : Chain) (ctx : ContractCallContext) (prev_st : State) (msg : option Msg) :
+    option (State * list ActionBody) :=
+    match msg with
+    | Some (wccd_msg_transfer params) =>
+        do next_st <- wccd_transfer params prev_st;
+        let contract_accounts := filter (fun x => address_is_contract x.(wccd_td_to)) params in
+        let mk_callback_data x :=
+          serialize
+            (CIS1_receiver_receive_hook unit
+            (TOKEN_ID_WCCD,x.(wccd_td_amount), x.(wccd_td_from))) in
+        let ops := map (fun x => act_call x.(wccd_td_to) 0 (mk_callback_data x)) contract_accounts in
+        ret (next_st, ops)
+    | Some (wccd_msg_balanceOf query send_to) =>
+        let balances := wccd_balanceOf query prev_st in
+        do requireTrue (address_is_contract send_to);
+        ret (prev_st, [act_call send_to 0 (serialize balances)])
+    | Some (wccd_msg_updateOperator params) =>
+        do next_st <- wccd_updateOperator ctx.(ctx_from) params prev_st;
+        ret (next_st, [])
+    | Some (wccd_msg_mint receiver) =>
+        (** Check that the sender is not the receiver *)
+        do requireTrue (negb (address_eqb receiver ctx.(ctx_from)));
+        let next_st := increment_balance prev_st receiver (Z.to_nat ctx.(ctx_amount)) in
+        (** NOTE: we only update the state and do not notify the receiver *)
+        ret (next_st,[])
+    | Some (wccd_msg_burn amt) =>
+        (** Check that the sender is not the receiver *)
+        do next_st <- decrement_balance prev_st ctx.(ctx_from) amt;
+        ret (next_st, [act_transfer ctx.(ctx_from) (Z.of_nat amt)])
+    | None => None
+    end.
+
+End WccdToken.
+
+(** * Wccd token complies with CIS1 *)
+
+Module WccdTypes <: CIS1Types.
+
+  Definition Msg `{ChainBase} := Msg.
+
+  Definition Storage `{ChainBase} := State.
+
+End WccdTypes.
+
+Module WccdView <: CIS1View WccdTypes.
+
+  Import WccdTypes.
+
+  Section WccdViewDefs.
+
+    Context `{ChainBase}.
+
+    Definition get_balance_opt st (token_id : TokenID) addr :=
+      do requireTrue (token_id =? TOKEN_ID_WCCD);
+      get_balance_opt addr st.
+
+    Definition get_operators (st : Storage) (addr : Address) :=
+      match AddressMap.find addr st with
+      | Some v => v.(wccd_operators)
+      | None => []
+      end.
+
+    Definition get_owners : Storage -> TokenID -> list Address :=
+      fun st token_id => if (token_id =? TOKEN_ID_WCCD) then
+                           FMap.keys st
+                         else [].
+
+    Lemma get_owners_no_dup : forall st token_id, NoDup (get_owners st token_id).
+    Proof.
+      intros. unfold get_owners.
+      destruct (_ =? _);[apply FMap.NoDup_keys | constructor ].
+    Qed.
+
+    Lemma In_keys_In_elements_iff {K V : Type} `{countable.Countable K} (m : FMap K V) (k : K) :
+      In k (FMap.keys m) <-> exists v, In (k,v) (FMap.elements m).
+    Proof.
+      split.
+      - induction m using fin_maps.map_ind; intros Hin.
+        + easy.
+        + unfold FMap.keys in *.
+          rewrite FMap.elements_add in Hin by assumption.
+          cbn in *. destruct Hin.
+          * exists x. rewrite FMap.elements_add by assumption. now left.
+          * destruct (IHm H2) as [x0 Hx0]. exists x0.
+            rewrite FMap.elements_add by assumption.
+            now right.
+      - induction m using fin_maps.map_ind; intros Hex.
+        + now destruct Hex.
+        + destruct Hex as [v Hv].
+          unfold FMap.keys.
+          rewrite FMap.elements_add in * by assumption;cbn in *.
+          destruct Hv as [HH | HH];try inversion HH;easy.
+    Qed.
+
+    Lemma get_owners_balances : forall st owner token_id,
+        In owner (get_owners st token_id) <->
+          exists balance, get_balance_opt st token_id owner = Some balance.
+    Proof.
+      split.
+      + intros Hin. unfold get_owners in *.
+        unfold get_balance_opt,Cis1wccd.get_balance_opt.
+        destruct (_ =? _);try inversion Hin.
+        apply In_keys_In_elements_iff in Hin.
+        destruct Hin as [a_st HH].
+        exists a_st.(wccd_balance).
+        apply FMap.In_elements in HH.
+        unfold AddressMap.find,FMap.find in *.
+        now rewrite HH.
+      + intros Hex.
+        destruct Hex as [b Hb].
+        unfold get_owners, FMap.keys.
+        unfold get_balance_opt,Cis1wccd.get_balance_opt in *.
+        destruct (_ =? _);try inversion Hb.
+        destruct (AddressMap.find owner st) eqn:Heq;try congruence.
+        unfold AddressMap.find in *.
+        apply FMap.In_elements in Heq.
+        apply In_keys_In_elements_iff.
+        eauto.
+    Qed.
+
+    Definition token_id_exists (st : Storage) (token_id : TokenID) : bool :=
+      token_id =? TOKEN_ID_WCCD.
+
+
+  End WccdViewDefs.
+End WccdView.
+
+Module WccdReceiveSpec <: CIS1ReceiveSpec WccdTypes WccdView.
+
+  Module cis1_axioms := CIS1Axioms WccdTypes WccdView.
+  Import cis1_axioms.
+
+  Module BalancesFacts := CIS1Balances WccdTypes WccdView.
+  Import BalancesFacts.
+
+  Section WccdReceiveDefs.
+
+    Context `{ChainBase}.
+
+    Definition to_cis1_transfer_data (p : wccd_transfer_params) : CIS1_transfer_data :=
+      let '(Build_wccd_transfer_params amt from_addr to_addr) := p in
+      {| cis1_td_token_id := TOKEN_ID_WCCD;
+         cis1_td_amount := amt;
+         cis1_td_from := from_addr;
+        cis1_td_to := to_addr |}.
+
+    Definition to_cis1_updateOperator_kind (op : OpUpdateKind) : CIS1_updateOperator_kind :=
+      match op with
+      | opAdd => cis1_ou_add_operator
+      | opDelete => cis1_ou_remove_operator
+      end.
+
+    Definition to_cis1_balanceOf_params (query : list Address) (send_to : Address)
+      : option CIS1_balanceOf_params :=
+      match Bool.bool_dec (address_is_contract send_to) true with
+      | left p =>
+          Some {|cis1_bo_query := map (fun addr => Build_CIS1_balanceOf_query _ TOKEN_ID_WCCD addr) query;
+                 cis1_bo_result_address := send_to;
+                 cis1_bo_result_address_is_contract := p |}
+      | right _ => None
+      end.
+
+    Definition get_CIS1_entry_point : Msg -> option CIS1_entry_points :=
+      fun msg => match msg with
+              | wccd_msg_transfer params =>
+                  let params :=
+                    {| cis_tr_transfers := map to_cis1_transfer_data params|} in
+                  Some (CIS1_transfer params)
+              | wccd_msg_balanceOf query send_results_to =>
+                  do p <- to_cis1_balanceOf_params query send_results_to;
+                  Some (CIS1_balanceOf p)
+              | wccd_msg_updateOperator params =>
+                  let upd_list :=
+                    map (fun '(upd_kind, addr) =>
+                           Build_CIS1_updateOperator_update _ (to_cis1_updateOperator_kind upd_kind) addr) params in
+                  Some (CIS1_updateOperator {| cis1_ou_params := upd_list |})
+              | wccd_msg_mint receiver => None
+              | wccd_msg_burn amount => None
+              end.
+
+    Definition get_contract_msg :  CIS1_entry_points -> Msg.
+    Admitted.
+
+    Lemma left_inverse_get_CIS1_entry_point (entry_point : CIS1_entry_points) :
+      get_CIS1_entry_point (get_contract_msg entry_point) = Some entry_point.
+    Proof.
+      Admitted.
+
+    Lemma inctement_balance_find_ne st addr1 addr2 amt :
+      addr1 <> addr2 ->
+      AddressMap.find addr1 (increment_balance st addr2 amt) = AddressMap.find addr1 st.
+    Proof.
+      intros Hneq.
+      unfold increment_balance.
+      destruct (AddressMap.find addr2 _);
+        unfold AddressMap.add, AddressMap.find;
+        now rewrite fin_maps.lookup_insert_ne.
+    Qed.
+
+    Import Lia.
+
+    Lemma wccd_transfer_single_cis1 (amt : TokenAmount) (from_addr to_addr : Address)
+          (prev_st st : State) :
+        wccd_transfer_single TOKEN_ID_WCCD amt from_addr to_addr prev_st = Some st ->
+        transfer_single_spec prev_st st TOKEN_ID_WCCD eq_refl eq_refl from_addr to_addr amt.
+    Proof.
+      intros Haddr.
+      cbn in *.
+      destruct (AddressMap.find _ _) as [v |] eqn:Hv;try congruence.
+      destruct (requireTrue _) eqn:Heq;try congruence.
+      inversion Haddr;subst;clear Haddr.
+      destruct (amt <=? wccd_balance v) eqn:Hamt;cbn in *;try congruence.
+      apply leb_complete in Hamt.
+      repeat split;cbn.
+      + intros.
+        unfold setter_from_getter_AddressState_wccd_balance,set_AddressState_wccd_balance.
+        unfold WccdView.get_balance_opt, get_balance_opt.
+        rewrite inctement_balance_find_ne by assumption.
+        unfold AddressMap.find,AddressMap.add.
+        now erewrite fin_maps.lookup_insert_ne.
+      + intros. unfold setter_from_getter_AddressState_wccd_balance,set_AddressState_wccd_balance.
+        unfold WccdView.get_balance_opt, get_balance_opt.
+        unfold requireTrue in Heq.
+        destruct (_ =? _) eqn:Heq1;auto;cbn. now rewrite Nat.eqb_eq in Heq1.
+      + repeat rewrite get_balance_total_get_balance_default.
+        repeat unfold setter_from_getter_AddressState_wccd_balance,
+          set_AddressState_wccd_balance,increment_balance.
+        unfold get_balance_default,cis1_axioms.VExtra.get_balance in *. cbn.
+        unfold setter_from_getter_AddressState_wccd_balance,set_AddressState_wccd_balance.
+        destruct (AddressMap.find to_addr _) eqn:Haddr.
+        * unfold get_balance_opt,AddressMap.find,AddressMap.add in *.
+          rewrite Hv.
+          rewrite FMap.add_commute with (m:=prev_st) by auto.
+          rewrite FMap.find_add with (m:=(FMap.add _ _ prev_st));cbn.
+          lia.
+        * unfold get_balance_opt,AddressMap.find,AddressMap.add in *.
+          rewrite FMap.add_commute with (m:=prev_st) by auto.
+          rewrite FMap.find_add with (m:=(FMap.add _ _ prev_st)).
+          cbn. rewrite Hv. unfold requireTrue in Heq.
+          lia.
+      + repeat rewrite get_balance_total_get_balance_default.
+        repeat unfold setter_from_getter_AddressState_wccd_balance,
+          set_AddressState_wccd_balance,increment_balance.
+        unfold get_balance_default,cis1_axioms.VExtra.get_balance in *. cbn.
+        unfold setter_from_getter_AddressState_wccd_balance,set_AddressState_wccd_balance.
+        destruct (AddressMap.find to_addr _) eqn:Haddr.
+        * unfold get_balance_opt,AddressMap.find,AddressMap.add in *.
+          rewrite FMap.find_add with (m:=(FMap.add _ _ prev_st));cbn.
+          rewrite FMap.find_add_ne with (m:=prev_st) in Haddr by auto.
+          unfold FMap.find in *.
+          now rewrite Haddr.
+        * unfold get_balance_opt,AddressMap.find,AddressMap.add in *.
+          rewrite FMap.find_add with (m:=(FMap.add _ _ prev_st));cbn.
+          rewrite FMap.find_add_ne with (m:=prev_st) in Haddr by auto.
+          unfold FMap.find in *.
+          now rewrite Haddr.
+      + subst. repeat rewrite get_balance_total_get_balance_default.
+        repeat unfold setter_from_getter_AddressState_wccd_balance,
+          set_AddressState_wccd_balance,increment_balance.
+        unfold get_balance_default,cis1_axioms.VExtra.get_balance in *. cbn.
+        unfold setter_from_getter_AddressState_wccd_balance,set_AddressState_wccd_balance.
+        unfold get_balance_opt. now rewrite Hv.
+      + subst.
+        repeat rewrite get_balance_total_get_balance_default.
+        repeat unfold setter_from_getter_AddressState_wccd_balance,
+          set_AddressState_wccd_balance,increment_balance.
+        unfold get_balance_default,cis1_axioms.VExtra.get_balance in *. cbn.
+        unfold get_balance_opt.
+        rewrite Hv.
+        unfold AddressMap.find,AddressMap.add.
+        rewrite FMap.find_add with (m:=prev_st);cbn.
+        rewrite FMap.find_add with (m:=FMap.add _ _ prev_st);cbn.
+        lia.
+    Qed.
+
+    Definition contract_receive := wccd_receive.
+
+    Theorem receive_spec :
+    forall (chain : Chain)
+      (ctx : ContractCallContext)
+      (entry : CIS1_entry_points)
+      (msg : Msg)
+      (prev_st next_st : State)
+      (ops : list ActionBody),
+      get_CIS1_entry_point msg = Some entry ->
+      wccd_receive chain ctx prev_st (Some msg) = Some (next_st, ops) ->
+      match entry with
+      | CIS1_transfer params => transfer_spec params prev_st next_st ops
+      | CIS1_updateOperator params => updateOperator_spec ctx params prev_st next_st ops
+      | CIS1_balanceOf params => balanceOf_spec params prev_st next_st ops
+      end.
+    Proof.
+      intros ? ? ? ? ? ? ? Hep Hreceive.
+      destruct msg;cbn;inversion Hep;subst;clear Hep;try easy.
+      + simpl in *.
+        destruct (wccd_transfer _ _) eqn:Htr;try congruence.
+        inversion Hreceive;subst;clear Hreceive.
+        constructor.
+        * cbn.
+          revert dependent next_st.
+          revert dependent prev_st.
+          induction params.
+          ** cbn in *. congruence.
+          ** intros prev_st next_st Hreceive.
+             cbn -[wccd_transfer_single] in *.
+             destruct (wccd_transfer_single _ _ _ _ _) as [st |] eqn:Haddr;try congruence.
+             destruct a as [amt from_addr to_addr];cbn.
+             simpl in *.
+             exists st, eq_refl, eq_refl.
+             split.
+             *** cbn in *. now apply wccd_transfer_single_cis1.
+             *** now eapply IHparams.
+        * cbn.
+          revert dependent prev_st.
+          revert dependent next_st.
+          induction params.
+          ** intros;cbn;auto.
+          ** intros;cbn -[wccd_transfer_single] in *.
+             destruct (wccd_transfer_single _ _ _ _ _) as [st |] eqn:Haddr;try congruence.
+             destruct a as [amt from_addr to_addr];cbn.
+             destruct (address_is_contract _).
+             *** constructor;simpl in *.
+                 eexists. split.
+                 **** reflexivity.
+                 **** exists unit. eexists.
+                      apply deserialize_serialize.
+                 **** eapply IHparams;eauto.
+             *** eapply IHparams;eauto.
+      + simpl in *.
+        admit.
+      + admit.
+    Admitted.
+
+  End WccdReceiveDefs.
+End WccdReceiveSpec.

--- a/execution/standards/cis1/CIS1Spec.v
+++ b/execution/standards/cis1/CIS1Spec.v
@@ -40,17 +40,15 @@ Notation:
 
 From ConCert.Execution Require Import Blockchain.
 From ConCert.Execution Require Import Serializable.
+From ConCert.Execution Require Import Monads.
 From ConCert.Execution.Examples Require Import Common.
 From ConCert.Execution.Standards.CIS1 Require Import CIS1Utils.
-
-From MetaCoq.Template Require Import monad_utils.
 
 From Coq Require Import Basics.
 From Coq Require Import List.
 From Coq Require Import ZArith.
 
 Import ListNotations.
-Import MonadNotation.
 Import RemoveProperties.
 
 (** * General types *)
@@ -385,7 +383,7 @@ CIS1: A transfer of some amount of a token type MUST only transfer the exact amo
       (fun q =>
          let addr := q.(cis1_bo_query_address) in
          let token_id := q.(cis1_bo_query_token_id) in
-         balance <- get_balance st token_id addr;;
+         do balance <- get_balance st token_id addr;
          Some (token_id, addr, balance)) params.(cis1_bo_query).
 
   Record balanceOf_spec
@@ -806,8 +804,8 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
       we can conclude that if has been enough tokens for the transfer. *)
   Lemma transfer_single_spec_sufficient_funds `{ChainBase}
         prev_st next_st token_id from to amount
-        (p : token_id_exists prev_st token_id)
-        (q : token_id_exists next_st token_id)
+        (p : token_id_exists prev_st token_id = true)
+        (q : token_id_exists next_st token_id = true)
         (spec : transfer_single_spec prev_st next_st token_id p q from to amount) :
     get_balance_total prev_st token_id p from >= amount.
   Proof.
@@ -822,8 +820,8 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
       of an [amount] between [from] and [to]. *)
   Lemma transfer_single_spec_preserves_balances `{ChainBase}
         prev_st next_st token_id from to amount
-        (p : token_id_exists prev_st token_id)
-        (q : token_id_exists next_st token_id)
+        (p : token_id_exists prev_st token_id = true)
+        (q : token_id_exists next_st token_id = true)
         (spec : transfer_single_spec prev_st next_st token_id p q from to amount) :
     let owners1 := get_owners prev_st token_id in
     let owners2 := get_owners next_st token_id in

--- a/execution/standards/cis1/CIS1Spec.v
+++ b/execution/standards/cis1/CIS1Spec.v
@@ -69,7 +69,7 @@ ReceiveHookParameter ::= (id: TokenID) (amount: TokenAmount) (from: Address)
                          (contract: ContractName) (data: AdditionalData).
 >> *)
 
-(** NOTE: there is no notion of a contract name in ConCert; [AdditionalData] is not handled at the moment *)
+(** NOTE: there is no notion of the contract name in ConCert; [AdditionalData] is not handled at the moment *)
 Definition receive_hook_params `{ChainBase} : Type := TokenID * TokenAmount * Address.
 
 (** All addresses owning tokens must support the following interface, since all receiving
@@ -89,10 +89,8 @@ Global Instance CIS1ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializabl
 (** Abstract types of messages and storage (the contract's state) *)
 Module Type CIS1Types.
 
-  Parameter Msg : Type.
-  Parameter Storage : Type.
-
-  Parameter contract_receive : forall `{ChainBase}, Chain -> ContractCallContext -> Storage -> option Msg -> option (Storage * list ActionBody).
+  Parameter Msg : forall `{ChainBase}, Type.
+  Parameter Storage : forall `{ChainBase}, Type.
 
 End CIS1Types.
 
@@ -104,51 +102,66 @@ Module Type CIS1View (cis1_types : CIS1Types).
 
   Import cis1_types.
 
-  Parameter get_balance_opt : forall `{ChainBase}, Storage -> TokenID -> Address -> option TokenAmount.
+  Section CISViewDefs.
 
-  Parameter get_operators : forall `{ChainBase}, Storage -> Address -> list Address.
+    Context `{ChainBase}.
 
-  Parameter get_owners : forall `{ChainBase}, Storage -> TokenID -> list Address.
+    Parameter get_balance_opt : Storage -> TokenID -> Address -> option TokenAmount.
 
-  Axiom get_owners_no_dup : forall `{ChainBase} st token_id, NoDup (get_owners st token_id).
+    Parameter get_operators : Storage -> Address -> list Address.
 
-  (** Owners are determined by their balances *)
-  Axiom get_owners_balances : forall `{ChainBase} st owner token_id,
-    In owner (get_owners st token_id) <->
-    exists balance, get_balance_opt st token_id owner = Some balance.
+    Parameter get_owners :  Storage -> TokenID -> list Address.
 
-  Parameter token_id_exists : Storage -> TokenID -> bool.
+    Axiom get_owners_no_dup : forall st token_id, NoDup (get_owners st token_id).
 
-  Parameter get_token_ids : Storage -> list TokenID.
+    (** Owners are determined by their balances *)
+    Axiom get_owners_balances : forall st owner token_id,
+        In owner (get_owners st token_id) <->
+          exists balance, get_balance_opt st token_id owner = Some balance.
+
+    Parameter token_id_exists : Storage -> TokenID -> bool.
+  End CISViewDefs.
+
+End CIS1View.
+
+
+(** Definition of extra functions, based on [CIS1View] *)
+Module CIS1ViewExtra (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
+
+  Import cis1_types.
+  Import cis1_view.
 
   Definition get_balance `{ChainBase} : Storage -> TokenID -> Address -> option TokenAmount :=
-    fun st token_id addr => if token_id_exists st token_id then
+      fun st token_id addr => if token_id_exists st token_id then
                               match get_balance_opt st token_id addr with
                               | Some bal => Some bal
                               | None => Some 0
                               end
                             else None.
 
-  Definition get_balance_total `{ChainBase}
-             (st : Storage)
-             (token_id : TokenID)
-             (p : token_id_exists st token_id = true)
-             (addr : Address) : TokenAmount :=
-    let o := get_balance st token_id addr in
-    match o as o' return (o' = o -> _) with
-    | Some bal => fun _ => bal
-    | None => fun heq => False_rect _ (ltac:(intros;subst o; unfold get_balance in *;rewrite p in *;
-    destruct (get_balance_opt st token_id addr);congruence))
-    end eq_refl.
+    Definition get_balance_total `{ChainBase}
+               (st : Storage)
+               (token_id : TokenID)
+               (p : token_id_exists st token_id = true)
+               (addr : Address) : TokenAmount :=
+      let o := get_balance st token_id addr in
+      match o as o' return (o' = o -> _) with
+      | Some bal => fun _ => bal
+      | None => fun heq =>
+                 False_rect _ (ltac:(intros;subst o; unfold get_balance in *;rewrite p in *;
+                                     destruct (get_balance_opt st token_id addr);congruence))
+      end eq_refl.
+End CIS1ViewExtra.
 
-End CIS1View.
-
-(** The module below specifies an abstract interface of the CIS1 token along with the properties
-    that must be satisfied by each entry point required by the standard. *)
-Module Type CIS1Axioms (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
+(** The module below specifies an abstract interface of the CIS1 token along with the
+    properties that must be satisfied by each entry point required by the standard. *)
+Module CIS1Axioms (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
 
   Import cis1_types.
   Import cis1_view.
+
+  Module VExtra := CIS1ViewExtra cis1_types cis1_view.
+  Import VExtra.
 
   (** * Contract functions *)
 
@@ -190,17 +203,6 @@ Module Type CIS1Axioms (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types
   | CIS1_transfer (params : CIS1_transfer_params)
   | CIS1_updateOperator (params : CIS1_updateOperator_params)
   | CIS1_balanceOf (params : CIS1_balanceOf_params).
-
-  (** We require that it is possible to convert between the entry point and the input data specified
-      by the standard and the actual type of messages accepted by a particular contract *)
-  Parameter get_CIS1_entry_point : forall `{ChainBase}, Msg -> option CIS1_entry_points.
-  Parameter get_contract_msg : forall `{ChainBase}, CIS1_entry_points -> Msg.
-
-  (** This axiom captures the intuition that a contact that implements CIS1 can handle _at least_
-      [CIS1_entry_points].  *)
-  Axiom left_inverse_get_CIS1_entry_point :
-    forall `{ChainBase} (entry_point : CIS1_entry_points),
-      get_CIS1_entry_point (get_contract_msg entry_point) = Some entry_point.
 
   (** ** Transfer *)
 
@@ -248,8 +250,9 @@ Module Type CIS1Axioms (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types
     (** CIS1: A transfer MUST non-strictly decrease the balance of the from address and non-strictly increase the balance of the to address.
 
 CIS1: A transfer of some amount of a token type MUST only transfer the exact amount of the given token type between balances. *)
-    prev_from = next_from + amount /\
-    next_to = prev_to + amount.
+    (from <> to -> prev_from = next_from + amount /\ next_to = prev_to + amount) /\
+    (** if the [from] and [to] addresses coincide, the transfer does not change the balance for this address *)
+    (from = to -> amount <= prev_from /\ prev_from = next_from).
 
   (** CIS1: The list of transfers MUST be executed in order. *)
   Fixpoint compose_transfers
@@ -276,8 +279,8 @@ CIS1: A transfer of some amount of a token type MUST only transfer the exact amo
   (** A receive hook call is valid if the call parameters are deserialised to a [CIS1_receiver_receive_hook]
       constructor with appropriate data *)
   Definition is_valid_receive_hook `{cb : ChainBase} (p : receive_hook_params) (serialized_params : SerializedValue) : Prop :=
-    exists (Msg : Type) (sMsg : Serializable Msg) (msg : @CIS1ReceiverMsg Msg sMsg cb),
-      deserialize serialized_params = Some (@CIS1_receiver_receive_hook Msg sMsg _  p).
+    exists (Msg : Type) (sMsg : Serializable Msg),
+      deserialize serialized_params = Some (@CIS1_receiver_receive_hook Msg sMsg _ p).
 
   (** A specification for the batch transfer *)
   Record transfer_spec `{ChainBase}
@@ -301,13 +304,9 @@ CIS1: A transfer of some amount of a token type MUST only transfer the exact amo
       transfer_receive_hook_calls :
       (** We consider only transfers to addresses that are contracts *)
       let transfers_to_contracts := filter (fun x => address_is_contract x.(cis1_td_to)) params.(cis_tr_transfers) in
-      Forall (fun '(op,(to_addr, params)) =>
-                exists val,
-                  op = act_call to_addr 0%Z val /\
-                 is_valid_receive_hook params val)
-             (combine ret_ops (get_receive_hook_params transfers_to_contracts)) /\
-      ret_ops = map (fun '(to_addr, params) => act_call to_addr 0 (serialize params))
-                    (get_receive_hook_params transfers_to_contracts)
+      Forall2 (fun op '(to_addr, params) =>
+                 exists val, op = act_call to_addr 0%Z val /\ is_valid_receive_hook params val)
+                 ret_ops (get_receive_hook_params transfers_to_contracts)
     }.
 
   (** ** updateOperator *)
@@ -415,14 +414,36 @@ CIS1: A transfer of some amount of a token type MUST only transfer the exact amo
         end
     }.
 
-  (** ** Full specification of [receive] *)
+End CIS1Axioms.
+
+(** ** Full specification of [receive] *)
+Module Type CIS1ReceiveSpec (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
+
+  Import cis1_types.
+  Import cis1_view.
+
+  Module cis1_axioms := CIS1Axioms cis1_types cis1_view.
+  Import cis1_axioms.
+
+  (** We require that it is possible to convert betwee the entry point and the input data specified
+      by the standard and the actual type of messages accepted by a particular contract *)
+  Parameter get_CIS1_entry_point : forall `{ChainBase}, Msg -> option CIS1_entry_points.
+  Parameter get_contract_msg : forall `{ChainBase}, CIS1_entry_points -> Msg.
+
+  (** This axiom captures the intuition that a contact that implements CIS1 can handle _at least_
+      [CIS1_entry_points].  *)
+  Axiom left_inverse_get_CIS1_entry_point :
+    forall `{ChainBase} (entry_point : CIS1_entry_points),
+      get_CIS1_entry_point (get_contract_msg entry_point) = Some entry_point.
+
+
+  Parameter contract_receive : forall `{ChainBase}, Chain -> ContractCallContext -> Storage -> option Msg -> option (Storage * list ActionBody).
+
 
   (** The contract's [receive] function satisfies the CIS1 standard if for each entry points it
       satisfies the corresponding specification. *)
   Axiom receive_spec :
     forall `{ChainBase}
-      (receive_func : Chain -> ContractCallContext -> Storage -> option Msg
-                      -> option (Storage * list ActionBody))
       (chain : Chain)
       (ctx : ContractCallContext)
       (entry : CIS1_entry_points)
@@ -430,21 +451,23 @@ CIS1: A transfer of some amount of a token type MUST only transfer the exact amo
       (prev_st next_st : Storage)
       (ops : list ActionBody),
       get_CIS1_entry_point msg = Some entry ->
-      receive_func chain ctx prev_st (Some msg) = Some (next_st, ops) ->
+      contract_receive chain ctx prev_st (Some msg) = Some (next_st, ops) ->
       match entry with
       | CIS1_transfer params => transfer_spec params prev_st next_st ops
       | CIS1_updateOperator params => updateOperator_spec ctx params prev_st next_st ops
       | CIS1_balanceOf params => balanceOf_spec params prev_st next_st ops
       end.
 
-  End CIS1Axioms.
+End CIS1ReceiveSpec.
 
 (** * CIS1 properties  *)
 
 (** ** Operator updates *)
 
-Module CIS1Operators (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
-       (cis1_axioms : CIS1Axioms cis1_types cis1_view).
+Module CIS1Operators (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
+
+  Module cis1_axioms := CIS1Axioms cis1_types cis1_view.
+  Import cis1_axioms.
 
   (** Sanity checks for the batch operator update spec *)
 
@@ -508,8 +531,10 @@ End CIS1Operators.
 
 
 (** ** Balances *)
-Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
-       (cis1_axioms : CIS1Axioms cis1_types cis1_view).
+Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
+
+  Module cis1_axioms := CIS1Axioms cis1_types cis1_view.
+  Import cis1_axioms.
 
   (** In this module we prove properties related to the preservation of the sum of all balances for
       all token ids.
@@ -519,6 +544,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
       prove here. *)
 
   Import cis1_types cis1_view cis1_axioms.
+
+  Import VExtra.
+
   Import Lia.
 
   (* begin hide *)
@@ -711,6 +739,8 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
     now destruct (get_balance_opt st token_id _).
   Qed.
 
+  Hint Constructors transfer_spec : hints.
+
   (** We can recover a statement for the whole "batch" of transfers from the transfers spec where
       the same property is assumed for each transfer in the batch *)
   Lemma transfer_token_ids_preserved `{ChainBase} transfers prev_st next_st ops :
@@ -730,14 +760,11 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
       destruct Htrans as [st [p [q [Hsingle Htrs]]]].
       transitivity (token_id_exists st token_id).
       * now destruct Hsingle as [HH0 [HH1 [HH2 HH3]]].
-      * eapply IHtransfers;eauto.
-        constructor. apply Htrs. cbn.
-        destruct Hcalls as [Hforall Hops].
-        destruct (address_is_contract (cis1_td_to a)).
-        ** subst. now inversion Hforall;subst.
-        ** easy.
+      * destruct (address_is_contract (cis1_td_to a)).
+        ** inversion Hcalls;subst.
+           eapply IHtransfers;eauto with hints.
+        ** eapply IHtransfers;eauto with hints.
   Qed.
-
 
   (** The balances of all token-address pairs NOT mentioned in the transfer batch remain unchanged
   *)
@@ -770,11 +797,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
            subst. symmetry. now apply Hbal_not_addr.
         * now symmetry.
       + cbn in *.
-        destruct Hcalls as [Hforall Hops].
-        destruct (address_is_contract (cis1_td_to a)).
-        * subst;inversion Hforall.
-           eapply IHtransfers;firstorder.
-        * eapply IHtransfers;firstorder.
+        destruct (address_is_contract (cis1_td_to a));
+          inversion Hcalls;
+          eapply IHtransfers;firstorder.
   Qed.
 
   (** If the properties of the single transfer holds (the transfer succeeds), then
@@ -786,8 +811,10 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
         (spec : transfer_single_spec prev_st next_st token_id p q from to amount) :
     get_balance_total prev_st token_id p from >= amount.
   Proof.
-    destruct spec as [H1 [H2 H3]].
-    lia.
+    destruct spec as [H1 [H2 [H3 [H4 H5]]]].
+    destruct (address_eqb_spec from to) as [| Hneq].
+    * subst. specialize (H5 eq_refl). lia.
+    * specialize (H4 Hneq). lia.
   Qed.
 
   (** An important lemma for the main result. The spec for a single transfer ensures that for a
@@ -823,6 +850,7 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
         destruct (address_eqb_spec addr to);subst. exfalso;apply (remove_In _ _ _ H0).
         eauto. }
       repeat rewrite get_balance_total_get_balance_default in H3, H4.
+      specialize (H4 eq_refl).
       lia.
     + rewrite remove_owner with (st := prev_st) (owner := from)
         by (subst owners1;auto with hints).
@@ -833,8 +861,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
       rewrite remove_owner with (st := next_st) (owner := to)
         by (assert (In to owners2 \/ get_balance_default next_st token_id to = 0);
             subst owners2;auto with hints;intuition;auto with hints).
-      repeat rewrite get_balance_total_get_balance_default in H3, H4.
-      rewrite H3. rewrite H4.
+      specialize (H3 Haddr). destruct H3 as [Hfrom Hto].
+      repeat rewrite get_balance_total_get_balance_default in Hfrom,Hto.
+      rewrite Hfrom. rewrite Hto.
       assert (HH :
                 sum_balances next_st token_id (remove addr_eq_dec to (remove addr_eq_dec from owners2)) =
               sum_balances prev_st token_id (remove addr_eq_dec to (remove addr_eq_dec from owners1))).
@@ -880,11 +909,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types)
           ** intros.
           apply get_balance_opt_default;symmetry;auto.
       + cbn in *.
-        destruct Hcalls as [Hforall Hops].
-        destruct (address_is_contract (cis1_td_to a)).
-        ** subst;inversion Hforall.
-           eapply IHtransfers;firstorder.
-        ** eapply IHtransfers;firstorder.
+        destruct (address_is_contract (cis1_td_to a));
+          inversion Hcalls;
+          eapply IHtransfers;firstorder.
   Qed.
 
   Lemma balanceOf_preserves_sum_of_balances `{ChainBase} params prev_st next_st token_id ops

--- a/execution/standards/cis1/CIS1Spec.v
+++ b/execution/standards/cis1/CIS1Spec.v
@@ -268,9 +268,11 @@ Module CIS1Axioms (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
     (** Token ids are preserved by a single transfer *)
     (forall token_id,
         token_id_exists prev_st token_id =  token_id_exists next_st token_id) /\
-    (** CIS1: A transfer MUST non-strictly decrease the balance of the from address and non-strictly increase the balance of the to address.
+    (** CIS1: A transfer MUST non-strictly decrease the balance of the from address and
+        non-strictly increase the balance of the to address.
 
-CIS1: A transfer of some amount of a token type MUST only transfer the exact amount of the given token type between balances. *)
+CIS1: A transfer of some amount of a token type MUST only transfer the exact amount of
+the given token type between balances. *)
     (from <> to -> prev_from = next_from + amount /\ next_to = prev_to + amount) /\
     (** if the [from] and [to] addresses coincide, the transfer does not change the balance for this address *)
     (from = to -> amount <= prev_from /\ prev_from = next_from).

--- a/execution/theories/Monads.v
+++ b/execution/theories/Monads.v
@@ -52,3 +52,26 @@ Proof.
   - intros; cbn.
     destruct t; auto.
 Qed.
+
+Fixpoint monad_map {A B} {m : Type -> Type} `{Monad m} (f : A -> m B) (xs : list A) : m (list B) :=
+  match xs with
+  | nil => ret nil
+  | cons x xs' =>
+      do v <- f x;
+      do vs <- monad_map f  xs';
+      ret (cons v vs)
+  end.
+
+Fixpoint monad_foldr {A B} {m : Type -> Type} `{Monad m} (f : A -> B -> m A) (a : A) (xs : list B) : m A :=
+  match xs with
+  | nil => ret a
+  | cons x xs' => do v <- monad_foldr f a xs';
+                  f v x
+  end.
+
+Fixpoint monad_foldl {A B} {m : Type -> Type} `{Monad m} (f : A -> B -> m A) (a : A) (xs : list B) : m A :=
+  match xs with
+  | nil => ret a
+  | cons x xs' => do v <- f a x;
+                  monad_foldl f v xs'
+  end.

--- a/execution/theories/Monads.v
+++ b/execution/theories/Monads.v
@@ -1,4 +1,6 @@
-(* This file defines some helpful notations for monads. *)
+(** This file defines some helpful notations for monads. *)
+From Coq Require Import List.
+From Coq Require Import Basics.
 
 Class Monad (m : Type -> Type) : Type :=
 build_monad {
@@ -61,6 +63,15 @@ Fixpoint monad_map {A B} {m : Type -> Type} `{Monad m} (f : A -> m B) (xs : list
       do vs <- monad_map f  xs';
       ret (cons v vs)
   end.
+
+Lemma monad_map_map {A B Z} {m : Type -> Type} `{Monad m}
+      (f : A -> m B) (g : Z -> A) (xs : list Z) :
+  monad_map f (map g xs) = monad_map (compose f g) xs.
+Proof.
+  induction xs.
+  - easy.
+  - cbn. now rewrite IHxs.
+Qed.
 
 Fixpoint monad_foldr {A B} {m : Type -> Type} `{Monad m} (f : A -> B -> m A) (a : A) (xs : list B) : m A :=
   match xs with

--- a/extra/resources/coqdocjs/coqdocjs.css
+++ b/extra/resources/coqdocjs/coqdocjs.css
@@ -118,7 +118,7 @@ html, body {
 #main {
     display: block;
     padding: 16px;
-    padding-top: 1em;
+    padding-top: 2em;
     padding-bottom: 2em;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
A token inspired by the Rust implementation: https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/examples/cis1-wccd

We use the CIS1 standard spec to prove that the `receive` method of the token complies with the CIS1 standard.
NOTE: the `updateOperator` functionality is a bit more restrictive, because it does not allow for adding operators to non-existing addresses (addresses that do not have an entry in the account mapping).