### PR TITLE
Extraction of Dexter 2 CPMM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: aucobra/concert:deps-coq-8.11-with-compilers
+    container: aucobra/concert:deps-coq-8.11-with-compilers-ligo-0.31.0
     steps:
     - run: sudo chown -R coq:coq .
     - uses: actions/checkout@v2

--- a/execution/examples/Dexter2CPMM.v
+++ b/execution/examples/Dexter2CPMM.v
@@ -27,17 +27,13 @@ Import ListNotations.
 
 
 (** * Contract types *)
-Section Dexter.
+Section DexterTypes.
 Context {BaseTypes : ChainBase}.
 Set Primitive Projections.
 Set Nonrecursive Elimination Schemes.
 Open Scope N_scope.
 
 (** ** Type synonyms *)
-
-(* Null address that will newer contain contracts *)
-Parameter null_address : Address.
-Axiom null_address_not_contract : address_is_contract null_address = false.
 
 Definition update_token_pool_internal_ := list FA2Interface.balance_of_response.
 Definition token_id := FA2Interface.token_id.
@@ -107,70 +103,6 @@ Inductive DexterMsg :=
 | UpdateTokenPool : DexterMsg
 | TokenToToken : token_to_token_param -> DexterMsg.
 
-(* begin hide *)
-(* Instance add_liquidity_param_serializable : Serializable add_liquidity_param := *)
-(*   Derive Serializable add_liquidity_param_rect <build_add_liquidity_param>. *)
-
-(* Global Instance remove_liquidity_param_serializable : Serializable remove_liquidity_param := *)
-(*   Derive Serializable remove_liquidity_param_rect <build_remove_liquidity_param>. *)
-
-(* Global Instance xtz_to_token_param_serializable : Serializable xtz_to_token_param := *)
-(*   Derive Serializable xtz_to_token_param_rect <build_xtz_to_token_param>. *)
-
-(* Global Instance token_to_xtz_param_serializable : Serializable token_to_xtz_param := *)
-(*   Derive Serializable token_to_xtz_param_rect <build_token_to_xtz_param>. *)
-
-(* Global Instance set_baker_param_serializable : Serializable set_baker_param := *)
-(*   Derive Serializable set_baker_param_rect <build_set_baker_param>. *)
-
-(* Global Instance token_to_token_param_serializable : Serializable token_to_token_param := *)
-(*   Derive Serializable token_to_token_param_rect <build_token_to_token_param>. *)
-
-(* Global Instance DexterMsg_serializable : Serializable DexterMsg := *)
-(*     Derive Serializable DexterMsg_rect <AddLiquidity, *)
-(*                                         RemoveLiquidity, *)
-(*                                         XtzToToken, *)
-(*                                         TokenToXtz, *)
-(*                                         SetBaker, *)
-(*                                         SetManager, *)
-(*                                         SetLqtAddress, *)
-(*                                         UpdateTokenPool, *)
-(*                                         TokenToToken>. *)
-(* end hide *)
-
-Axiom add_liquidity_param_serializable : Serializable add_liquidity_param.
-Existing Instance add_liquidity_param_serializable.
-
-Axiom remove_liquidity_param_serializable : Serializable remove_liquidity_param.
-Existing Instance remove_liquidity_param_serializable.
-
-Axiom xtz_to_token_param_serializable : Serializable xtz_to_token_param.
-Existing Instance xtz_to_token_param_serializable.
-
-
-Axiom token_to_xtz_param_serializable : Serializable token_to_xtz_param.
-Existing Instance token_to_xtz_param_serializable.
-
-Axiom set_baker_param_serializable : Serializable set_baker_param.
-Existing Instance set_baker_param_serializable.
-
-Axiom token_to_token_param_serializable : Serializable token_to_token_param.
-Existing Instance token_to_token_param_serializable.
-
-Axiom DexterMsg_serializable : Serializable DexterMsg.
-Existing Instance DexterMsg_serializable.
-
-Axiom Dexter2FA12_Msg_serialize : Serializable Dexter2FA12.Msg.
-Existing Instance Dexter2FA12_Msg_serialize.
-
-
-Axiom FA2ReceiverMsg_serialize : Serializable FA2Token.FA2ReceiverMsg.
-Existing Instance FA2ReceiverMsg_serialize.
-
-Definition Msg := @FA2Token.FA2ReceiverMsg BaseTypes DexterMsg _.
-
-
-
 (** ** Storage types *)
 
 Record State :=
@@ -197,1381 +129,342 @@ Record Setup :=
 (* begin hide *)
 MetaCoq Run (make_setters State).
 MetaCoq Run (make_setters Setup).
-
-(* Section Serialization. *)
-
-(* Global Instance setup_serializable : Serializable Setup := *)
-(*   Derive Serializable Setup_rect <build_setup>. *)
-
-(* Global Instance ClientMsg_serializable : Serializable Msg := FA2Token.FA2ReceiverMsg_serializable. *)
-
-(* Global Instance state_serializable : Serializable State := *)
-(*   Derive Serializable State_rect <build_state>. *)
-
-(* End Serialization. *)
-
-Axiom setup_serializable : Serializable Setup.
-
-Existing Instance setup_serializable.
-
-Axiom ClientMsg_serializable : Serializable Msg.
-Existing Instance ClientMsg_serializable.
-
-Axiom state_serializable : Serializable State.
-Existing Instance state_serializable.
-
 (* end hide *)
 
+End DexterTypes.
+
+Module Type Dexter2Serializable.
+  Section DS.
+    Context `{ChainBase}.
+    Axiom add_liquidity_param_serializable : Serializable add_liquidity_param.
+    Existing Instance add_liquidity_param_serializable.
+
+    Axiom remove_liquidity_param_serializable : Serializable remove_liquidity_param.
+    Existing Instance remove_liquidity_param_serializable.
+
+    Axiom xtz_to_token_param_serializable : Serializable xtz_to_token_param.
+    Existing Instance xtz_to_token_param_serializable.
 
 
-(** * Contract functions *)
-(** ** Helper functions *)
+    Axiom token_to_xtz_param_serializable : Serializable token_to_xtz_param.
+    Existing Instance token_to_xtz_param_serializable.
+
+    Axiom set_baker_param_serializable : Serializable set_baker_param.
+    Existing Instance set_baker_param_serializable.
+
+    Axiom token_to_token_param_serializable : Serializable token_to_token_param.
+    Existing Instance token_to_token_param_serializable.
+
+    Axiom DexterMsg_serializable : Serializable DexterMsg.
+    Existing Instance DexterMsg_serializable.
+
+    Axiom Dexter2FA12_Msg_serialize : Serializable Dexter2FA12.Msg.
+    Existing Instance Dexter2FA12_Msg_serialize.
+
+    Axiom setup_serializable : Serializable Setup.
+    Existing Instance setup_serializable.
+
+    Axiom ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg _ DexterMsg DexterMsg_serializable).
+    Existing Instance ClientMsg_serializable.
+
+    Axiom state_serializable : Serializable State.
+    Existing Instance state_serializable.
+
+    Axiom FA2Token_Msg_serializable : Serializable FA2Token.Msg.
+    Existing Instance FA2Token_Msg_serializable.
+    
+  End DS.
+End Dexter2Serializable.
+
+Module Dexter2 (SI : Dexter2Serializable).
+
+  Import SI.
+
+  Existing Instance add_liquidity_param_serializable.
+  Existing Instance remove_liquidity_param_serializable.
+  Existing Instance xtz_to_token_param_serializable.
+  Existing Instance token_to_xtz_param_serializable.
+  Existing Instance set_baker_param_serializable.
+  Existing Instance token_to_token_param_serializable.
+  Existing Instance DexterMsg_serializable.
+  Existing Instance Dexter2FA12_Msg_serialize.
+  Existing Instance setup_serializable.
+  Existing Instance ClientMsg_serializable.
+  Existing Instance state_serializable.
+  Existing Instance FA2Token_Msg_serializable.
+
+  Section DexterDefs.
+    Context `{BaseTypes : ChainBase}.
+    Open Scope N_scope.
+
+    (** * Contract functions *)
+
+    (** ** Helper functions *)
+
+    Definition result : Type := option (State * list ActionBody).
+    Definition isNone {A : Type} (a : option A) := match a with | Some _ => false | None => true end.
+    Definition isSome {A : Type} (a : option A) := negb (isNone a).
+    Definition sub (n m : N) : option N := do _ <- throwIf (n <? m) ; Some (n - m).
+    Definition div (n m : N) : option N := do _ <- throwIf (m =? 0) ; Some (n / m).
+    Definition ceildiv (n m : N) : option N :=
+      if N.modulo n m =? 0
+      then div n m
+      else do result <- div n m ; Some (result + 1).
+    Definition ceildiv_ (n m : N) : N :=
+      if N.modulo n m =? 0
+      then n / m
+      else (n / m) + 1.
+    Opaque ceildiv.
+    Opaque ceildiv_.
+    Opaque div.
+    Opaque sub.
+
+    (** Place holder for tezos set delegate operation *)
+    Definition set_delegate_call (addr : option Address) : list ActionBody := [].
+
+    Definition non_zero_amount (amt : Z) : bool:= (0 <? amt)%Z.
+    Global Arguments non_zero_amount _ /. (* always unfold, if applied *)
+
+    (** Null address that will newer contain contracts *)
+    Parameter null_address : Address.
+    Axiom null_address_not_contract : address_is_contract null_address = false.
+
+    Definition Msg := @FA2Token.FA2ReceiverMsg BaseTypes DexterMsg _.
+
+  Definition call_liquidity_token (addr : Address) (amt : N) (msg : Dexter2FA12.Msg) :=
+    act_call addr (Z.of_N amt) (serialize msg).
+
+  Definition mint_or_burn (state : State) (target : Address) (quantitiy : Z) : option ActionBody :=
+      do _ <- throwIf (address_eqb state.(lqtAddress) null_address) ; (* error lqtAddress not set *)
+      Some (call_liquidity_token state.(lqtAddress)
+                                 0
+                                 (Dexter2FA12.msg_mint_or_burn
+                                    (Dexter2FA12.build_mintOrBurn_param quantitiy target))).
+
+  Definition call_to_token (token_addr : Address) (amt : N) (msg : FA2Token.Msg) :=
+    act_call token_addr (Z.of_N amt) (serialize msg).
+    
+  Definition token_transfer (state : State) (from to : Address) (amount : N) : ActionBody :=
+    call_to_token state.(tokenAddress)
+                  0
+                  (FA2Token.msg_transfer
+                     [FA2Interface.build_transfer from to state.(tokenId) amount None]).
+
+  Definition xtz_transfer (to : Address) (amount : N) : option ActionBody :=
+    if address_is_contract to
+    then None (* error_INVALID_TO_ADDRESS *)
+    else Some (act_transfer to (Z.of_N amount)).
 
 
-Definition result : Type := option (State * list ActionBody).
-Definition isNone {A : Type} (a : option A) := match a with | Some _ => false | None => true end.
-Definition isSome {A : Type} (a : option A) := negb (isNone a).
-Definition sub (n m : N) : option N := do _ <- throwIf (n <? m) ; Some (n - m).
-Definition div (n m : N) : option N := do _ <- throwIf (m =? 0) ; Some (n / m).
-Definition ceildiv (n m : N) : option N :=
-  if N.modulo n m =? 0
-  then div n m
-  else do result <- div n m ; Some (result + 1).
-Definition ceildiv_ (n m : N) : N :=
-  if N.modulo n m =? 0
-  then n / m
-  else (n / m) + 1.
-Opaque ceildiv.
-Opaque ceildiv_.
-Opaque div.
-Opaque sub.
+  (** ** Add liquidity *)
+  Definition add_liquidity (chain : Chain) (ctx : ContractCallContext)
+                           (state : State) (param : add_liquidity_param)
+                           : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (param.(add_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
+    do lqt_minted <- div ((Z.to_N ctx.(ctx_amount)) * state.(lqtTotal)) state.(xtzPool) ; (* error_DIV_by_0 *)
+    do tokens_deposited <- ceildiv ((Z.to_N ctx.(ctx_amount)) * state.(tokenPool)) state.(xtzPool) ; (* error_DIV_by_0 *)
+    do _ <- throwIf (param.(maxTokensDeposited) <? tokens_deposited) ; (* error_MAX_TOKENS_DEPOSITED_MUST_BE_GREATER_THAN_OR_EQUAL_TO_TOKENS_DEPOSITED *)
+    do _ <- throwIf (lqt_minted <? param.(minLqtMinted)) ; (* error_LQT_MINTED_MUST_BE_GREATER_THAN_MIN_LQT_MINTED *)
+    let new_state := state<| lqtTotal := state.(lqtTotal) + lqt_minted |>
+                          <| tokenPool := state.(tokenPool) + tokens_deposited |>
+                          <| xtzPool := state.(xtzPool) + (Z.to_N ctx.(ctx_amount))|> in
+    let op_token := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) tokens_deposited in
+    do op_lqt <- mint_or_burn state param.(owner) (Z.of_N lqt_minted) ;
+    Some (new_state, [op_token; op_lqt]).
 
-(* Place holder for tezos set delegate operation *)
-Definition set_delegate_call (addr : option Address) : list ActionBody := [].
+  (** ** Remove liquidity *)
+  Definition remove_liquidity (chain : Chain) (ctx : ContractCallContext)
+                              (state : State) (param : remove_liquidity_param)
+                              : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (param.(remove_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do xtz_withdrawn <-  div (param.(lqtBurned) * state.(xtzPool)) state.(lqtTotal) ; (* error_DIV_by_0 *)
+    do tokens_withdrawn <- div (param.(lqtBurned) * state.(tokenPool)) state.(lqtTotal) ; (* error_DIV_by_0 *)
+    do _ <- throwIf (xtz_withdrawn <? param.(minXtzWithdrawn)) ; (* error_THE_AMOUNT_OF_XTZ_WITHDRAWN_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_XTZ_WITHDRAWN *)
+    do _ <- throwIf (tokens_withdrawn <? param.(minTokensWithdrawn)) ; (* error_THE_AMOUNT_OF_TOKENS_WITHDRAWN_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_TOKENS_WITHDRAWN *)
+    do new_lqtPool <- sub state.(lqtTotal) param.(lqtBurned) ; (* error_CANNOT_BURN_MORE_THAN_THE_TOTAL_AMOUNT_OF_LQT *)
+    do new_tokenPool <- sub state.(tokenPool) tokens_withdrawn ; (* error_TOKEN_POOL_MINUS_TOKENS_WITHDRAWN_IS_NEGATIVE *)
+    do new_xtzPool <- sub state.(xtzPool) xtz_withdrawn ; (* mutez subtraction run time error *)
+    do op_lqt <- mint_or_burn state ctx.(ctx_from) (0 - (Z.of_N param.(lqtBurned)))%Z ;
+    let op_token := token_transfer state ctx.(ctx_contract_address) param.(liquidity_to) tokens_withdrawn in
+    do opt_xtz <- xtz_transfer param.(liquidity_to) xtz_withdrawn ;
+    let new_state :=
+      {| tokenPool :=  new_tokenPool;
+         xtzPool := new_xtzPool;
+         lqtTotal := new_lqtPool;
+         selfIsUpdatingTokenPool := state.(selfIsUpdatingTokenPool);
+         freezeBaker := state.(freezeBaker);
+         manager := state.(manager);
+         tokenAddress := state.(tokenAddress);
+         tokenId := state.(tokenId);
+         lqtAddress := state.(lqtAddress) |} in
+    Some (new_state, [op_lqt; op_token; opt_xtz]).
 
-Definition non_zero_amount (amt : Z) : bool:= (0 <? amt)%Z.
-Arguments non_zero_amount _ /. (* always unfold, if applied *)
+  (** ** XTZ to tokens *)
+  Definition xtz_to_token (chain : Chain) (ctx : ContractCallContext)
+                          (state : State) (param : xtz_to_token_param)
+                          : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (param.(xtt_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
+    do tokens_bought <- div
+      ((Z.to_N ctx.(ctx_amount)) * 997 * state.(tokenPool))
+        (state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) ; (* error_DIV_by_0 *)
+    do _ <- throwIf (tokens_bought <? param.(minTokensBought)) ; (* error_TOKENS_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_TOKENS_BOUGHT *)
+    do new_tokenPool <- sub state.(tokenPool) tokens_bought ; (* error_TOKEN_POOL_MINUS_TOKENS_BOUGHT_IS_NEGATIVE *)
+    let new_state := state<| xtzPool := state.(xtzPool) + (Z.to_N ctx.(ctx_amount)) |>
+                          <| tokenPool := new_tokenPool |> in
+    let op := token_transfer state ctx.(ctx_contract_address) param.(tokens_to) tokens_bought in
+    Some (new_state, [op]).
 
-Definition call_liquidity_token (addr : Address) (amt : N) (msg : Dexter2FA12.Msg) :=
-  act_call addr (Z.of_N amt) (serialize msg).
+  (** ** Tokes to XTZ *)
+  Definition token_to_xtz (chain : Chain) (ctx : ContractCallContext)
+                          (state : State) (param : token_to_xtz_param)
+                          : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (param.(ttx_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do xtz_bought <- div
+      (param.(tokensSold) * 997 * state.(xtzPool))
+        (state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) ; (* error_DIV_by_0 *)
+    do _ <- throwIf (xtz_bought <? param.(minXtzBought)) ; (* error_XTZ_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_XTZ_BOUGHT *)
+    do new_xtzPool <- sub state.(xtzPool) xtz_bought ; (* mutez subtraction run time error *)
+    let op_token := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) param.(tokensSold) in
+    do op_tez <- xtz_transfer param.(xtz_to) xtz_bought ;
+    let new_state := state<| tokenPool := state.(tokenPool) + param.(tokensSold) |>
+                          <| xtzPool := new_xtzPool |> in
+    Some (new_state, [op_token; op_tez]).
 
-Definition mint_or_burn (state : State) (target : Address) (quantitiy : Z) : option ActionBody :=
-    do _ <- throwIf (address_eqb state.(lqtAddress) null_address) ; (* error lqtAddress not set *)
-    Some (call_liquidity_token state.(lqtAddress)
-                               0
-                               (Dexter2FA12.msg_mint_or_burn
-                                  (Dexter2FA12.build_mintOrBurn_param quantitiy target))).
+  (** ** Default entrypoint *)
+  Definition default_ (chain : Chain) (ctx : ContractCallContext)
+                      (state : State) : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    let new_state := state<| xtzPool := state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> in
+      Some (new_state, []).
 
-Axiom FA2Token_Msg_serializable : Serializable FA2Token.Msg.
-Existing Instance FA2Token_Msg_serializable.
+  (** ** Set baker *)
+  Definition set_baker (chain : Chain) (ctx : ContractCallContext)
+                       (state : State) (param : set_baker_param)
+                       : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_BAKER *)
+    do _ <- throwIf (state.(freezeBaker)) ; (* error_BAKER_PERMANENTLY_FROZEN *)
+      Some (state<| freezeBaker := param.(freezeBaker_) |>, set_delegate_call param.(baker)).
 
-Definition call_to_token (token_addr : Address) (amt : N) (msg : FA2Token.Msg) :=
-  act_call token_addr (Z.of_N amt) (serialize msg).
-
-Definition token_transfer (state : State) (from to : Address) (amount : N) : ActionBody :=
-  call_to_token state.(tokenAddress)
-                0
-                (FA2Token.msg_transfer
-                   [FA2Interface.build_transfer from to state.(tokenId) amount None]).
-
-Definition xtz_transfer (to : Address) (amount : N) : option ActionBody :=
-  if address_is_contract to
-  then None (* error_INVALID_TO_ADDRESS *)
-  else Some (act_transfer to (Z.of_N amount)).
-
-
-(** ** Add liquidity *)
-Definition add_liquidity (chain : Chain) (ctx : ContractCallContext)
-                         (state : State) (param : add_liquidity_param)
+  (** ** Set manager *)
+  Definition set_manager (chain : Chain) (ctx : ContractCallContext)
+                         (state : State) (new_manager : Address)
                          : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (param.(add_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
-  do lqt_minted <- div ((Z.to_N ctx.(ctx_amount)) * state.(lqtTotal)) state.(xtzPool) ; (* error_DIV_by_0 *)
-  do tokens_deposited <- ceildiv ((Z.to_N ctx.(ctx_amount)) * state.(tokenPool)) state.(xtzPool) ; (* error_DIV_by_0 *)
-  do _ <- throwIf (param.(maxTokensDeposited) <? tokens_deposited) ; (* error_MAX_TOKENS_DEPOSITED_MUST_BE_GREATER_THAN_OR_EQUAL_TO_TOKENS_DEPOSITED *)
-  do _ <- throwIf (lqt_minted <? param.(minLqtMinted)) ; (* error_LQT_MINTED_MUST_BE_GREATER_THAN_MIN_LQT_MINTED *)
-  let new_state := state<| lqtTotal := state.(lqtTotal) + lqt_minted |>
-                        <| tokenPool := state.(tokenPool) + tokens_deposited |>
-                        <| xtzPool := state.(xtzPool) + (Z.to_N ctx.(ctx_amount))|> in
-  let op_token := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) tokens_deposited in
-  do op_lqt <- mint_or_burn state param.(owner) (Z.of_N lqt_minted) ;
-  Some (new_state, [op_token; op_lqt]).
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_MANAGER *)
+      Some (state<| manager := new_manager |>, []).
 
-(** ** Remove liquidity *)
-Definition remove_liquidity (chain : Chain) (ctx : ContractCallContext)
-                            (state : State) (param : remove_liquidity_param)
-                            : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (param.(remove_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do xtz_withdrawn <-  div (param.(lqtBurned) * state.(xtzPool)) state.(lqtTotal) ; (* error_DIV_by_0 *)
-  do tokens_withdrawn <- div (param.(lqtBurned) * state.(tokenPool)) state.(lqtTotal) ; (* error_DIV_by_0 *)
-  do _ <- throwIf (xtz_withdrawn <? param.(minXtzWithdrawn)) ; (* error_THE_AMOUNT_OF_XTZ_WITHDRAWN_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_XTZ_WITHDRAWN *)
-  do _ <- throwIf (tokens_withdrawn <? param.(minTokensWithdrawn)) ; (* error_THE_AMOUNT_OF_TOKENS_WITHDRAWN_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_TOKENS_WITHDRAWN *)
-  do new_lqtPool <- sub state.(lqtTotal) param.(lqtBurned) ; (* error_CANNOT_BURN_MORE_THAN_THE_TOTAL_AMOUNT_OF_LQT *)
-  do new_tokenPool <- sub state.(tokenPool) tokens_withdrawn ; (* error_TOKEN_POOL_MINUS_TOKENS_WITHDRAWN_IS_NEGATIVE *)
-  do new_xtzPool <- sub state.(xtzPool) xtz_withdrawn ; (* mutez subtraction run time error *)
-  do op_lqt <- mint_or_burn state ctx.(ctx_from) (0 - (Z.of_N param.(lqtBurned)))%Z ;
-  let op_token := token_transfer state ctx.(ctx_contract_address) param.(liquidity_to) tokens_withdrawn in
-  do opt_xtz <- xtz_transfer param.(liquidity_to) xtz_withdrawn ;
-  let new_state :=
-    {| tokenPool :=  new_tokenPool;
-       xtzPool := new_xtzPool;
-       lqtTotal := new_lqtPool;
-       selfIsUpdatingTokenPool := state.(selfIsUpdatingTokenPool);
-       freezeBaker := state.(freezeBaker);
-       manager := state.(manager);
-       tokenAddress := state.(tokenAddress);
-       tokenId := state.(tokenId);
-       lqtAddress := state.(lqtAddress) |} in
-  Some (new_state, [op_lqt; op_token; opt_xtz]).
+  (** ** Set liquidity address *)
+  Definition set_lqt_address (chain : Chain) (ctx : ContractCallContext)
+                             (state : State) (new_lqt_address : Address)
+                             : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_LQT_ADRESS *)
+    do _ <- throwIf (negb (address_eqb state.(lqtAddress) null_address)) ; (* error_LQT_ADDRESS_ALREADY_SET *)
+      Some (state<| lqtAddress := new_lqt_address |>, []).
 
-(** ** XTZ to tokens *)
-Definition xtz_to_token (chain : Chain) (ctx : ContractCallContext)
-                        (state : State) (param : xtz_to_token_param)
-                        : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (param.(xtt_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
-  do tokens_bought <- div
-    ((Z.to_N ctx.(ctx_amount)) * 997 * state.(tokenPool))
-      (state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) ; (* error_DIV_by_0 *)
-  do _ <- throwIf (tokens_bought <? param.(minTokensBought)) ; (* error_TOKENS_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_TOKENS_BOUGHT *)
-  do new_tokenPool <- sub state.(tokenPool) tokens_bought ; (* error_TOKEN_POOL_MINUS_TOKENS_BOUGHT_IS_NEGATIVE *)
-  let new_state := state<| xtzPool := state.(xtzPool) + (Z.to_N ctx.(ctx_amount)) |>
-                        <| tokenPool := new_tokenPool |> in
-  let op := token_transfer state ctx.(ctx_contract_address) param.(tokens_to) tokens_bought in
-  Some (new_state, [op]).
+  (** ** Update token pool *)
+  Definition update_token_pool (chain : Chain) (ctx : ContractCallContext)
+                               (state : State) : result :=
+    do _ <- throwIf (negb (address_eqb ctx.(ctx_from) ctx.(ctx_origin))) ; (* error_CALL_NOT_FROM_AN_IMPLICIT_ACCOUNT *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_UNEXPECTED_REENTRANCE_IN_UPDATE_TOKEN_POOL *)
+    let balance_of_request :=
+      FA2Interface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
+    let balance_of_param :=
+      FA2Interface.Build_balance_of_param [balance_of_request] (FA2Interface.Build_callback _ None) in
+    let op := call_to_token state.(tokenAddress) 0 (FA2Token.msg_balance_of balance_of_param) in
+      Some (state<| selfIsUpdatingTokenPool := true |>, [op]).
 
-(** ** Tokes to XTZ *)
-Definition token_to_xtz (chain : Chain) (ctx : ContractCallContext)
-                        (state : State) (param : token_to_xtz_param)
-                        : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (param.(ttx_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do xtz_bought <- div
-    (param.(tokensSold) * 997 * state.(xtzPool))
-      (state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) ; (* error_DIV_by_0 *)
-  do _ <- throwIf (xtz_bought <? param.(minXtzBought)) ; (* error_XTZ_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_XTZ_BOUGHT *)
-  do new_xtzPool <- sub state.(xtzPool) xtz_bought ; (* mutez subtraction run time error *)
-  let op_token := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) param.(tokensSold) in
-  do op_tez <- xtz_transfer param.(xtz_to) xtz_bought ;
-  let new_state := state<| tokenPool := state.(tokenPool) + param.(tokensSold) |>
-                        <| xtzPool := new_xtzPool |> in
-  Some (new_state, [op_token; op_tez]).
-
-(** ** Default entrypoint *)
-Definition default_ (chain : Chain) (ctx : ContractCallContext)
-                    (state : State) : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  let new_state := state<| xtzPool := state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> in
+  (** ** Update token pool internal *)
+  Definition update_token_pool_internal (chain : Chain) (ctx : ContractCallContext)
+                                        (state : State) (token_pool : update_token_pool_internal_)
+                                        : result :=
+    do _ <- throwIf ((negb state.(selfIsUpdatingTokenPool)) ||
+                      (negb (address_eqb ctx.(ctx_from) state.(tokenAddress)))) ; (* error_THIS_ENTRYPOINT_MAY_ONLY_BE_CALLED_BY_GETBALANCE_OF_TOKENADDRESS *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do token_pool <-
+      match token_pool with
+      | [] => None (* error_INVALID_FA2_BALANCE_RESPONSE *)
+      | x :: xs => Some x.(balance)
+      end ;
+    let new_state := state<| tokenPool := token_pool |><| selfIsUpdatingTokenPool := false |> in
     Some (new_state, []).
 
-(** ** Set baker *)
-Definition set_baker (chain : Chain) (ctx : ContractCallContext)
-                     (state : State) (param : set_baker_param)
+  Definition call_to_other_token (token_addr : Address) (amount : N)
+             (msg : @FA2Token.FA2ReceiverMsg _ DexterMsg _) :=
+    act_call token_addr (Z.of_N amount) (serialize msg).
+
+  (** ** Tokens to tokens *)
+  Definition token_to_token (chain : Chain) (ctx : ContractCallContext)
+                            (state : State) (param : token_to_token_param)
+                            : result :=
+    do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
+    do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
+    do _ <- throwIf (param.(ttt_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
+    do xtz_bought <- div
+      (param.(tokensSold_) * 997 * state.(xtzPool))
+        (state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) ; (* error_DIV_by_0 *)
+    do new_xtzPool <- sub state.(xtzPool) xtz_bought ; (* mutez subtraction run time error *)
+    let new_state := state<| tokenPool := state.(tokenPool) + param.(tokensSold_) |>
+                          <| xtzPool := new_xtzPool |> in
+    let op1 := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) param.(tokensSold_) in
+    let op2 := call_to_other_token
+                 param.(outputDexterContract)
+                 xtz_bought
+                 (FA2Token.other_msg (XtzToToken {|
+                                          tokens_to := param.(to_);
+                                          minTokensBought := param.(minTokensBought_);
+                                          xtt_deadline := param.(ttt_deadline)
+                                        |})) in 
+    Some (new_state, [op1; op2]).
+
+  (** ** Receive *)
+  Definition receive (chain : Chain)
+                     (ctx : ContractCallContext)
+                     (state : State)
+                     (maybe_msg : option Msg)
                      : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_BAKER *)
-  do _ <- throwIf (state.(freezeBaker)) ; (* error_BAKER_PERMANENTLY_FROZEN *)
-    Some (state<| freezeBaker := param.(freezeBaker_) |>, set_delegate_call param.(baker)).
-
-(** ** Set manager *)
-Definition set_manager (chain : Chain) (ctx : ContractCallContext)
-                       (state : State) (new_manager : Address)
-                       : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_MANAGER *)
-    Some (state<| manager := new_manager |>, []).
-
-(** ** Set liquidity address *)
-Definition set_lqt_address (chain : Chain) (ctx : ContractCallContext)
-                           (state : State) (new_lqt_address : Address)
-                           : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do _ <- throwIf (negb (address_eqb ctx.(ctx_from) state.(manager))) ; (* error_ONLY_MANAGER_CAN_SET_LQT_ADRESS *)
-  do _ <- throwIf (negb (address_eqb state.(lqtAddress) null_address)) ; (* error_LQT_ADDRESS_ALREADY_SET *)
-    Some (state<| lqtAddress := new_lqt_address |>, []).
-
-(** ** Update token pool *)
-Definition update_token_pool (chain : Chain) (ctx : ContractCallContext)
-                             (state : State) : result :=
-  do _ <- throwIf (negb (address_eqb ctx.(ctx_from) ctx.(ctx_origin))) ; (* error_CALL_NOT_FROM_AN_IMPLICIT_ACCOUNT *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_UNEXPECTED_REENTRANCE_IN_UPDATE_TOKEN_POOL *)
-  let balance_of_request :=
-    FA2Interface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
-  let balance_of_param :=
-    FA2Interface.Build_balance_of_param [balance_of_request] (FA2Interface.Build_callback _ None) in
-  let op := call_to_token state.(tokenAddress) 0 (FA2Token.msg_balance_of balance_of_param) in
-    Some (state<| selfIsUpdatingTokenPool := true |>, [op]).
-
-(** ** Update token pool internal *)
-Definition update_token_pool_internal (chain : Chain) (ctx : ContractCallContext)
-                                      (state : State) (token_pool : update_token_pool_internal_)
-                                      : result :=
-  do _ <- throwIf ((negb state.(selfIsUpdatingTokenPool)) ||
-                    (negb (address_eqb ctx.(ctx_from) state.(tokenAddress)))) ; (* error_THIS_ENTRYPOINT_MAY_ONLY_BE_CALLED_BY_GETBALANCE_OF_TOKENADDRESS *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do token_pool <-
-    match token_pool with
-    | [] => None (* error_INVALID_FA2_BALANCE_RESPONSE *)
-    | x :: xs => Some x.(balance)
-    end ;
-  let new_state := state<| tokenPool := token_pool |><| selfIsUpdatingTokenPool := false |> in
-  Some (new_state, []).
-
-Definition call_to_other_token (token_addr : Address) (amount : N)
-           (msg : @FA2Token.FA2ReceiverMsg _ DexterMsg _) :=
-  act_call token_addr (Z.of_N amount) (serialize msg).
-
-(** ** Tokens to tokens *)
-Definition token_to_token (chain : Chain) (ctx : ContractCallContext)
-                          (state : State) (param : token_to_token_param)
-                          : result :=
-  do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE *)
-  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
-  do _ <- throwIf (param.(ttt_deadline) <=? chain.(current_slot))%nat ; (* error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE *)
-  do xtz_bought <- div
-    (param.(tokensSold_) * 997 * state.(xtzPool))
-      (state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) ; (* error_DIV_by_0 *)
-  do new_xtzPool <- sub state.(xtzPool) xtz_bought ; (* mutez subtraction run time error *)
-  let new_state := state<| tokenPool := state.(tokenPool) + param.(tokensSold_) |>
-                        <| xtzPool := new_xtzPool |> in
-  let op1 := token_transfer state ctx.(ctx_from) ctx.(ctx_contract_address) param.(tokensSold_) in
-  let op2 := call_to_other_token
-               param.(outputDexterContract)
-               xtz_bought
-               (FA2Token.other_msg (XtzToToken {|
-                                        tokens_to := param.(to_);
-                                        minTokensBought := param.(minTokensBought_);
-                                        xtt_deadline := param.(ttt_deadline)
-                                      |})) in 
-  Some (new_state, [op1; op2]).
-
-(** ** Receive *)
-Definition receive (chain : Chain)
-                   (ctx : ContractCallContext)
-                   (state : State)
-                   (maybe_msg : option Msg)
-                   : result :=
-  match maybe_msg with
-  | Some (FA2Token.other_msg (AddLiquidity param)) =>
-      add_liquidity chain ctx state param
-  | Some (FA2Token.other_msg (RemoveLiquidity param)) =>
-      remove_liquidity chain ctx state param
-  | Some (FA2Token.other_msg (SetBaker param)) =>
-      set_baker chain ctx state param
-  | Some (FA2Token.other_msg (SetManager param)) =>
-      set_manager chain ctx state param
-  | Some (FA2Token.other_msg (SetLqtAddress param)) =>
-      set_lqt_address chain ctx state param
-  | None =>
-      default_ chain ctx state
-  | Some (FA2Token.other_msg UpdateTokenPool) =>
-      update_token_pool chain ctx state
-  | Some (FA2Token.other_msg (XtzToToken param)) =>
-      xtz_to_token chain ctx state param
-  | Some (FA2Token.other_msg (TokenToXtz param)) =>
-      token_to_xtz chain ctx state param
-  | Some (FA2Token.other_msg (TokenToToken param)) =>
-      token_to_token chain ctx state param
-  | Some (FA2Token.receive_balance_of_param responses) =>
-      update_token_pool_internal chain ctx state responses
-  | _ => None
-  end.
-
-(** ** Init *)
-Definition init (chain : Chain)
-                (ctx : ContractCallContext)
-                (setup : Setup) : option State :=
-  Some {|
-    tokenPool := 0;
-    xtzPool := 0;
-    lqtTotal := setup.(lqtTotal_);
-    selfIsUpdatingTokenPool := false;
-    freezeBaker := false;
-    manager := setup.(manager_);
-    tokenAddress := setup.(tokenAddress_);
-    tokenId := setup.(tokenId_);
-    lqtAddress := null_address
-  |}.
-
-Definition contract : Contract Setup Msg State :=
-  build_contract init receive.
-
-
-
-(** * Properties *)
-Section Theories.
-
-(* Tactics and facts about helper functions *)
-(* begin hide *)
-Transparent div.
-Transparent ceildiv.
-Transparent ceildiv_.
-Lemma div_eq : forall n m p,
-  div n m = Some p ->
-  n / m = p /\ m <> 0.
-Proof.
-  intros * div_some.
-  unfold div in div_some.
-  cbn in div_some.
-  destruct_match eqn:m_not_zero in div_some;
-    try congruence.
-  destruct_throw_if m_not_zero.
-  now apply N.eqb_neq in m_not_zero.
-Qed.
-
-Lemma div_zero : forall n m,
-  div n m = None ->
-  m = 0.
-Proof.
-  intros * div_some.
-  cbn in div_some.
-  destruct_match eqn:m_zero in div_some;
-    try congruence.
-  destruct_throw_if m_zero.
-  now apply N.eqb_eq in m_zero.
-Qed.
-Opaque div.
-
-Lemma ceildiv_eq : forall n m p,
-  ceildiv n m = Some p ->
-  ceildiv_ n m = p /\ m <> 0.
-Proof.
-  intros * ceildiv_some.
-  unfold ceildiv_.
-  unfold ceildiv in ceildiv_some.
-  destruct_match eqn:modulo_zero.
-  - now apply div_eq in ceildiv_some.
-  - cbn in ceildiv_some.
-    destruct_match eqn:div_some in ceildiv_some;
-      try congruence.
-    apply div_eq in div_some.
-    now inversion_clear ceildiv_some.
-Qed.
-
-Lemma ceildiv_zero : forall n m,
-  ceildiv n m = None ->
-  m = 0.
-Proof.
-  intros * ceildiv_some.
-  unfold ceildiv in ceildiv_some.
-  destruct_match eqn:modulo_zero in ceildiv_some.
-  - now apply div_zero in ceildiv_some.
-  - cbn in ceildiv_some.
-    destruct_match eqn:div_some in ceildiv_some;
-      try congruence.
-    now apply div_zero in div_some.
-Qed.
-Opaque ceildiv.
-Opaque ceildiv_.
-
-Transparent sub.
-Lemma sub_eq : forall n m p,
-  sub n m = Some p ->
-  n - m = p /\ m <= n.
-Proof.
-  intros * sub_some.
-  cbn in sub_some.
-  destruct_match eqn:m_le_n in sub_some;
-    try congruence.
-  destruct_throw_if m_le_n.
-  now rewrite <- N.ltb_ge.
-Qed.
-
-Lemma sub_fail : forall n m,
-  sub n m = None ->
-  n < m.
-Proof.
-  intros * sub_some.
-  cbn in sub_some.
-  destruct_match eqn:n_lt_m in sub_some;
-    try congruence.
-  destruct_throw_if n_lt_m.
-  now apply N.ltb_lt.
-Qed.
-Opaque sub.
-
-Lemma isSome_some : forall {A : Type} (x : option A) (y : A),
-  x = Some y -> isSome x = true.
-Proof.
-  intros.
-  now subst.
-Qed.
-
-Lemma isSome_none : forall {A : Type} (x : option A),
-  x = None -> isSome x = false.
-Proof.
-  intros.
-  now subst.
-Qed.
-
-Lemma isSome_exists : forall {A : Type} (x : option A),
-  isSome x = true <-> exists y : A, x = Some y.
-Proof.
-  split.
-  - now destruct x eqn:x_eq.
-  - intros (y & x_eq).
-    now eapply isSome_some.
-Qed.
-
-Lemma isSome_not_exists : forall {A : Type} (x : option A),
-  isSome x = false <-> forall y : A, x <> Some y.
-Proof.
-  split.
-  - now destruct x eqn:x_eq.
-  - intros x_eq.
-    eapply isSome_none.
-    now destruct x.
-Qed.
-
-Ltac math_convert_step :=
-  match goal with
-  | H : sub _ _ = Some _ |- _ => apply sub_eq in H as [<- H]
-  | H : sub _ _ = None |- _ => apply sub_fail in H
-  | H : div _ _ = Some _ |- _ => apply div_eq in H as [<- H]
-  | H : div _ _ = None |- _ => apply div_zero in H
-  | H : ceildiv _ _ = Some _ |- _ => apply ceildiv_eq in H as [<- H]
-  | H : ceildiv _ _ = None |- _ => apply ceildiv_zero in H
-  end.
-
-Tactic Notation "math_convert" := repeat math_convert_step.
-
-Ltac receive_simpl_step :=
-  match goal with
-  | H : Blockchain.receive _ _ _ _ _ = Some (_, _) |- _ =>
-      unfold Blockchain.receive in H; cbn in H
-  | H : receive _ _ _ _ = Some (_, _) |- _ =>
-      unfold receive in H;
-      cbn in H
-  | |- receive _ _ _ _ = _ =>
-      unfold receive; cbn
-  | H : Some _ = Some _ |- _ =>
-      inversion_clear H
-  | H : Some _ = None |- _ =>
-      inversion H
-  | H : None = Some _ |- _ =>
-      inversion H
-  | H : throwIf _ = None |- _ => destruct_throw_if H
-  | H : throwIf _ = Some ?u |- _ => destruct_throw_if H
-  | H : option_map (fun s : State => (s, _)) match ?m with | Some _ => _ | None => None end = Some _ |- _ =>
-    let a := fresh "H" in
-    destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-  | H : match ?m with | Some _ => _ | None => None end = Some _ |- _ =>
-    let a := fresh "H" in
-    destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-  | H : option_map (fun s : State => (s, _)) (if ?m then ?a else ?b) = Some _ |- _ =>
-    match a with
+    match maybe_msg with
+    | Some (FA2Token.other_msg (AddLiquidity param)) =>
+        add_liquidity chain ctx state param
+    | Some (FA2Token.other_msg (RemoveLiquidity param)) =>
+        remove_liquidity chain ctx state param
+    | Some (FA2Token.other_msg (SetBaker param)) =>
+        set_baker chain ctx state param
+    | Some (FA2Token.other_msg (SetManager param)) =>
+        set_manager chain ctx state param
+    | Some (FA2Token.other_msg (SetLqtAddress param)) =>
+        set_lqt_address chain ctx state param
     | None =>
-      let a := fresh "H" in
-      destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-    | _ => match b with
-           | None =>
-             let a := fresh "H" in
-             destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-           | _ => idtac
-    end end
-  | H : (if ?m then ?a else ?b) = Some _ |- _ =>
-    match a with
-    | None =>
-      let a := fresh "H" in
-      destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-    | _ => match b with
-           | None =>
-             let a := fresh "H" in
-             destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
-           | _ => idtac
-    end end
-  end.
-
-Tactic Notation "receive_simpl" := repeat (unfold call_to_token,call_to_other_token;receive_simpl_step).
-(* end hide *)
-
-
-
-(** ** Set baker correct *)
-(** [set_baker] only changes [freezeBaker] in state *)
-Lemma set_baker_state_eq : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
-    prev_state<| freezeBaker := param.(freezeBaker_) |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-Lemma set_baker_freeze_baker_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
-    new_state.(freezeBaker) = param.(freezeBaker_).
-Proof.
-  intros * receive_some.
-  apply set_baker_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [set_baker] produces no new_acts *)
-Lemma set_baker_new_acts_correct : forall chain ctx prev_state param new_state new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
-    new_acts = set_delegate_call param.(baker).
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on set_baker msg must succeed and
-    if receive on set_baker msg succeeds then requirements must hold *)
-Lemma set_baker_is_some : forall prev_state chain ctx param,
-  (ctx_amount ctx <= 0)%Z /\
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  ctx.(ctx_from) = prev_state.(manager) /\
-  prev_state.(freezeBaker) = false
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (amount_zero & not_updating & sender_is_manager & not_frozen).
-    do 2 eexists.
-    receive_simpl.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:sender_check.
-    destruct_match eqn:frozen_check.
-    + reflexivity.
-    + now rewrite not_frozen in frozen_check.
-    + now rewrite sender_is_manager, address_eq_refl in sender_check.
-    + receive_simpl.
-      now apply Z.ltb_ge in amount_zero.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    rename H0 into ctx_amount_zero.
-    apply Z.ltb_ge in ctx_amount_zero.
-    repeat split; auto.
-    now destruct_address_eq.
-Qed.
-
-
-
-(** ** Set manager correct *)
-(** [set_manager] only changes [manager] in state *)
-Lemma set_manager_state_eq : forall prev_state new_state chain ctx new_acts new_manager,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
-    prev_state<| manager := new_manager |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-Lemma set_manager_manager_correct : forall prev_state new_state chain ctx new_acts new_manager,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
-    new_state.(manager) = new_manager.
-Proof.
-  intros * receive_some.
-  apply set_manager_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [set_manager] produces no new_acts *)
-Lemma set_manager_new_acts_correct : forall chain ctx prev_state new_manager new_state new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
-    new_acts = [].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on set_manager msg must succeed and
-    if receive on set_manager msg succeeds then requirements must hold *)
-Lemma set_manager_is_some : forall prev_state chain ctx new_manager,
-  (ctx_amount ctx <= 0)%Z /\
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  ctx.(ctx_from) = prev_state.(manager)
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (amount_zero & not_updating & sender_is_manager).
-    do 2 eexists.
-    receive_simpl.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:sender_check.
-    + reflexivity.
-    + now rewrite sender_is_manager, address_eq_refl in sender_check.
-    + receive_simpl.
-      now apply Z.ltb_ge in amount_zero.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    rename H0 into ctx_amount_zero.
-    apply Z.ltb_ge in ctx_amount_zero.
-    repeat split; auto.
-    now destruct_address_eq.
-Qed.
-
-
-
-(** ** Set liquidity address correct *)
-(** [set_lqt_address] only changes [lqtAddress] in state *)
-Lemma set_lqt_address_state_eq : forall prev_state new_state chain ctx new_acts new_lqt_address,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
-    prev_state<| lqtAddress := new_lqt_address |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-Lemma set_lqt_address_correct : forall prev_state new_state chain ctx new_acts new_lqt_address,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
-    new_state.(lqtAddress) = new_lqt_address.
-Proof.
-  intros * receive_some.
-  apply set_lqt_address_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [set_lqt_address] produces no new_acts *)
-Lemma set_lqt_address_new_acts_correct : forall chain ctx prev_state new_lqt_address new_state new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
-    new_acts = [].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on set_lqt_address msg must succeed and
-    if receive on set_lqt_address msg succeeds then requirements must hold *)
-Lemma set_lqt_address_is_some : forall prev_state chain ctx new_lqt_address,
-  (ctx_amount ctx <= 0)%Z /\
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  ctx.(ctx_from) = prev_state.(manager) /\
-  prev_state.(lqtAddress) = null_address
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (amount_zero & not_updating & sender_is_manager & lqt_address_not_set).
-    do 2 eexists.
-    receive_simpl.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:sender_check.
-    destruct_match eqn:lqt_check.
-    + reflexivity.
-    + now rewrite lqt_address_not_set, address_eq_refl in lqt_check.
-    + now rewrite sender_is_manager, address_eq_refl in sender_check.
-    + receive_simpl.
-      now apply Z.ltb_ge in amount_zero.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    rename H0 into ctx_amount_zero.
-    rename H2 into lqt_address_not_set.
-    apply Z.ltb_ge in ctx_amount_zero.
-    repeat split; auto;
-      now destruct_address_eq.
-Qed.
-
-
-
-(** ** Default entrypoint correct *)
-(** [default_] only changes [xtzPool] in state *)
-Lemma default_state_eq : forall prev_state new_state chain ctx new_acts,
-  receive chain ctx prev_state None = Some (new_state, new_acts) ->
-    prev_state<| xtzPool := prev_state.(xtzPool) + Z.to_N (ctx.(ctx_amount)) |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-Lemma default_correct : forall prev_state new_state chain ctx new_acts,
-  receive chain ctx prev_state None = Some (new_state, new_acts) ->
-    new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N (ctx.(ctx_amount)).
-Proof.
-  intros * receive_some.
-  apply default_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [default_] produces no new_acts *)
-Lemma default_new_acts_correct : forall chain ctx prev_state new_state new_acts,
-  receive chain ctx prev_state None = Some (new_state, new_acts) ->
-    new_acts = [].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on None msg must succeed and
-    if receive on None msg succeeds then requirements must hold *)
-Lemma default_entrypoint_is_some : forall prev_state chain ctx,
-  prev_state.(selfIsUpdatingTokenPool) = false
-  <->
-  exists new_state new_acts, receive chain ctx prev_state None = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros not_updating.
-    do 2 eexists.
-    receive_simpl.
-    destruct_match eqn:updating_check.
-    + reflexivity.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-Qed.
-
-
-
-(** ** Update token pool correct *)
-(** [update_token_pool] only changes [selfIsUpdatingTokenPool] in state *)
-Lemma update_token_pool_state_eq : forall prev_state new_state chain ctx new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
-    prev_state<| selfIsUpdatingTokenPool := true |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-Lemma update_token_pool_correct : forall prev_state new_state chain ctx new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
-    new_state.(selfIsUpdatingTokenPool) = true.
-Proof.
-  intros * receive_some.
-  apply update_token_pool_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [update_token_pool] produces an call act with amount = 0, calling
-    the token contract with a balance of request *)
-Lemma update_token_pool_new_acts_correct : forall chain ctx prev_state new_state new_acts,
-  receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
-    new_acts = [
-      act_call prev_state.(tokenAddress) 0%Z (serialize
-        (msg_balance_of (Build_balance_of_param 
-          ([Build_balance_of_request ctx.(ctx_contract_address) prev_state.(tokenId)])
-          (FA2Interface.Build_callback _ None))))
-    ].
-Proof.
-  intros * receive_some.
-  now receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on update_token_pool msg must succeed and
-    if receive on update_token_pool msg succeeds then requirements must hold *)
-Lemma update_token_pool_is_some : forall prev_state chain ctx,
-  (ctx_amount ctx <= 0)%Z /\
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  ctx.(ctx_from) = ctx.(ctx_origin)
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (amount_zero & not_updating & sender_eq_origin).
-    do 2 eexists.
-    receive_simpl.
-    destruct_match eqn:sender_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:updating_check.
-    + reflexivity.
-    + now rewrite not_updating in updating_check.
-    + receive_simpl.
-      now apply Z.ltb_ge in amount_zero.
-    + now rewrite sender_eq_origin, address_eq_refl in sender_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    rename H0 into ctx_amount_zero.
-    rename H into sender_eq_origin.
-    apply Z.ltb_ge in ctx_amount_zero.
-    apply Bool.negb_false_iff in sender_eq_origin.
-    now destruct_address_eq.
-Qed.
-
-
-
-(** ** Update token pool internal correct *)
-(** [update_token_pool_internal] only changes [selfIsUpdatingTokenPool] and [tokenPool] in state *)
-Lemma update_token_pool_internal_state_eq : forall prev_state new_state chain ctx new_acts responses,
-  receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
-    prev_state<| selfIsUpdatingTokenPool := false |>
-              <| tokenPool := match responses with 
-                              | [] => 0
-                              | response :: t => response.(balance)
-                              end |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  rename H1 into response.
-  destruct_match eqn:resonses_empty_check in response;
-    try congruence.
-  now inversion_clear response.
-Qed.
-
-Lemma update_token_pool_internal_update_correct : forall prev_state new_state chain ctx new_acts responses,
-  receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
-    new_state.(selfIsUpdatingTokenPool) = false.
-Proof.
-  intros * receive_some.
-  apply update_token_pool_internal_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [update_token_pool_internal] produces no new actions *)
-Lemma update_token_pool_internal_new_acts_correct : forall chain ctx prev_state new_state new_acts responses,
-  receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
-    new_acts = [].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-Qed.
-
-(** If the requirements are met then then receive on update_token_pool_internal msg must succeed and
-    if receive on update_token_pool_internal msg succeeds then requirements must hold *)
-Lemma update_token_pool_internal_is_some : forall prev_state chain ctx responses,
-  (ctx_amount ctx <= 0)%Z /\
-  prev_state.(selfIsUpdatingTokenPool) = true /\
-  ctx.(ctx_from) = prev_state.(tokenAddress) /\
-  responses <> []
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (amount_zero & updating & sender_is_token_contract & responses_not_empty).
-    unfold receive. cbn.
-    destruct_match eqn:sender_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:response.
-    destruct_match eqn:response_check in response.
-    + congruence.
-    + eauto.
-    + now destruct_match in response.
-    + receive_simpl.
-      now apply Z.ltb_ge in amount_zero.
-    + now rewrite updating, sender_is_token_contract, address_eq_refl in sender_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    rename H0 into ctx_amount_zero.
-    rename H into sender_check.
-    rename H1 into responses_check.
-    apply Bool.orb_false_elim in sender_check as
-      (is_updating & sender_is_token_contract).
-    apply Z.ltb_ge in ctx_amount_zero.
-    destruct responses eqn:response in responses_check;
-      try congruence.
-    subst.
-    repeat split; auto.
-    + now apply Bool.negb_false_iff in is_updating.
-    + now destruct_address_eq.
-Qed.
-
-
-
-(** ** Add liquidity correct *)
-(** [add_liquidity] only changes [lqtTotal], [tokenPool] and [xtzPool] in state *)
-Lemma add_liquidity_state_eq : forall prev_state new_state chain ctx new_acts param,
-  let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
-  let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
-    prev_state<| lqtTotal := prev_state.(lqtTotal) +  lqt_minted |>
-              <| tokenPool := prev_state.(tokenPool) + tokens_deposited |>
-              <| xtzPool := prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-Lemma add_liquidity_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
-    new_state.(lqtTotal) = prev_state.(lqtTotal) + Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) /\
-    new_state.(tokenPool) = prev_state.(tokenPool) + ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) /\
-    new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount).
-Proof.
-  intros * receive_some.
-  apply add_liquidity_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** In the informal specification it is stated that tokens should be trasnfered from owner,
-    but in the implementation it is trasnfered from the sender.
-    For this we assume that the implementation is correct over the informal specification since
-    that is what other formalizations seem to have assumed *)
-Lemma add_liquidity_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
-  let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
-  let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
-    new_acts =
-    [
-      (act_call prev_state.(tokenAddress) 0%Z
-        (serialize (FA2Token.msg_transfer
-        [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) tokens_deposited None])));
-      (act_call prev_state.(lqtAddress) 0%Z
-        (serialize (Dexter2FA12.msg_mint_or_burn {| target := param.(owner); quantity := Z.of_N lqt_minted|})))
-    ].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-(** If the requirements are met then then receive on add_liquidity msg must succeed and
-    if receive on add_liquidity msg succeeds then requirements must hold *)
-Lemma add_liquidity_is_some : forall prev_state chain ctx param,
-  let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
-  let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  (current_slot chain < param.(add_deadline))%nat /\
-  tokens_deposited <= param.(maxTokensDeposited)  /\
-  param.(minLqtMinted) <= lqt_minted /\
-  prev_state.(xtzPool) <> 0 /\
-  prev_state.(lqtAddress) <> null_address
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (not_updating & deadline_not_hit & max_tokens_not_hit &
-            enough_minted & xtzPool_not_zero & lqt_addr_set).
-    unfold receive.
-    cbn.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:deadline_check.
-    destruct_match eqn:div_check; math_convert.
-    destruct_match eqn:ceildiv_check; math_convert.
-    destruct_match eqn:max_tokens_check.
-    destruct_match eqn:min_lqt_check.
-    destruct_match eqn:mint_act; try congruence;
-    destruct_match eqn:lqt_addr_set_check in mint_act; try congruence.
-    + eauto.
-    + now apply address_eq_ne in lqt_addr_set.
-    + now apply N.ltb_ge in enough_minted.
-    + now apply N.ltb_ge in max_tokens_not_hit.
-    + congruence.
-    + congruence.
-    + apply leb_correct_conv in deadline_not_hit.
-      now rewrite deadline_not_hit in deadline_check.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    math_convert.
-    rename H0 into deadline_not_hit.
-    rename H3 into max_not_hit.
-    rename H4 into min_not_hit.
-    apply leb_complete_conv in deadline_not_hit.
-    apply N.ltb_ge in max_not_hit.
-    apply N.ltb_ge in min_not_hit.
-    repeat split; auto.
-    now destruct_address_eq.
-Qed.
-
-
-
-(** ** Remove liquidity correct *)
-(** [remove_liquidity] only changes [lqtTotal], [tokenPool] and [xtzPool] in state *)
-Lemma remove_liquidity_state_eq : forall prev_state new_state chain ctx new_acts param,
-  let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
-  let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
-    prev_state<| lqtTotal := prev_state.(lqtTotal) - param.(lqtBurned) |>
-              <| tokenPool := prev_state.(tokenPool) - tokens_withdrawn |>
-              <| xtzPool := prev_state.(xtzPool) - xtz_withdrawn |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert;cbv.
-Qed.
-
-Lemma remove_liquidity_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
-    new_state.(lqtTotal) = prev_state.(lqtTotal) - param.(lqtBurned) /\
-    new_state.(tokenPool) = prev_state.(tokenPool) -  (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) /\
-    new_state.(xtzPool) = prev_state.(xtzPool) - (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal).
-Proof.
-  intros * receive_some.
-  apply remove_liquidity_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [remove_liquidity] should produce three acts
-- A call action to LQT contract burning [lqtBurned] from [sender]
-- A call action to token contract transferring [tokens_withdrawn] from this contract to [liquidity_to]
-- A transfer action transferring [xtz_withdrawn] from this contract to [liquidity_to]
- *)
-Lemma remove_liquidity_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
-  let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
-  let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
-    new_acts =
-    [
-      (act_call prev_state.(lqtAddress) 0%Z
-        (serialize (Dexter2FA12.msg_mint_or_burn {| target := ctx.(ctx_from); quantity := - Z.of_N param.(lqtBurned)|})));
-      (act_call prev_state.(tokenAddress) 0%Z
-        (serialize (FA2Token.msg_transfer
-        [build_transfer ctx.(ctx_contract_address) param.(liquidity_to) prev_state.(tokenId) tokens_withdrawn None])));
-      (act_transfer param.(liquidity_to) (Z.of_N xtz_withdrawn))
-    ].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  math_convert.
-  rename H10 into xtz_act.
-  unfold xtz_transfer in xtz_act.
-  destruct_match in xtz_act; try congruence.
-  now inversion_clear xtz_act.
-Qed.
-
-(** If the requirements are met then then receive on remove_liquidity msg must succeed and
-    if receive on remove_liquidity msg succeeds then requirements must hold *)
-Lemma remove_liquidity_is_some : forall prev_state chain ctx param,
-  let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
-  let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  (current_slot chain < param.(remove_deadline))%nat /\
-  (ctx.(ctx_amount) <= 0)%Z /\
-  prev_state.(lqtTotal) <> 0 /\
-  param.(minXtzWithdrawn) <= xtz_withdrawn /\
-  param.(minTokensWithdrawn) <= tokens_withdrawn /\
-  tokens_withdrawn <= prev_state.(tokenPool) /\
-  xtz_withdrawn <= prev_state.(xtzPool) /\
-  param.(lqtBurned) <= prev_state.(lqtTotal) /\
-  address_is_contract param.(liquidity_to) = false /\
-  prev_state.(lqtAddress) <> null_address
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (not_updating & deadline_not_hit & ctx_amount_zero &
-            lqtPool_not_zero & enough_xtz_withdrawn & enough_tokens_withdrawn &
-            tokens_withdrawn_le_total & xtz_withdrawn_le_total & lqt_burned_le_total &
-            to_not_contract & lqt_addr_set).
-    unfold receive.
-    cbn.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:deadline_check.
-    destruct_match eqn:ctx_amount_check.
-    destruct_match eqn:xtz_div_check; math_convert; try easy.
-    destruct_match eqn:tokens_div_check; math_convert; try easy.
-    destruct_match eqn:min_xtz_check.
-    destruct_match eqn:min_tokens_check.
-    destruct_match eqn:burned_check; math_convert; try easy.
-    destruct_match eqn:token_pool_check; math_convert; try easy.
-    destruct_match eqn:xtz_pool_check; math_convert; try easy.
-    destruct_match eqn:mint_act; try congruence;
-    destruct_match eqn:lqt_addr_set_check in mint_act; try congruence.
-    destruct_match eqn:transfer_act.
-    + eauto.
-    + unfold xtz_transfer in transfer_act.
-      now rewrite to_not_contract in transfer_act.
-    + now apply address_eq_ne in lqt_addr_set.
-    + now apply N.ltb_ge in enough_tokens_withdrawn.
-    + now apply N.ltb_ge in enough_xtz_withdrawn.
-    + now apply Z.ltb_ge in ctx_amount_zero.
-    + apply leb_correct_conv in deadline_not_hit.
-      now rewrite deadline_not_hit in deadline_check.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    math_convert.
-    rename H0 into deadline_not_hit.
-    rename H1 into ctx_amount_zero.
-    rename H4 into enough_xtz_withdrawn.
-    rename H5 into enough_tokens_withdrawn.
-    rename H10 into transfer_act.
-    apply leb_complete_conv in deadline_not_hit.
-    apply N.ltb_ge in enough_tokens_withdrawn.
-    apply N.ltb_ge in enough_xtz_withdrawn.
-    apply Z.ltb_ge in ctx_amount_zero.
-    unfold xtz_transfer in transfer_act.
-    destruct_match eqn:to_not_contract in transfer_act;
-      try congruence.
-    repeat split; auto.
-    now destruct_address_eq.
-Qed.
-
-
-
-(** ** XTZ to token correct *)
-(** [xtz_to_token] only changes [tokenPool] and [xtzPool] in state *)
-Lemma xtz_to_token_state_eq : forall prev_state new_state chain ctx new_acts param,
-  let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
-                          (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
-    prev_state<| tokenPool := prev_state.(tokenPool) - tokens_bought |>
-              <| xtzPool := prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-Lemma xtz_to_token_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
-    new_state.(tokenPool) = prev_state.(tokenPool) -  (((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
-                          (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) ) /\
-    new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount).
-Proof.
-  intros * receive_some.
-  apply xtz_to_token_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** [xtz_to_token] should produce one action
-- A call action to token contract transferring [tokens_bought] from this contract to [tokens_to]
-*)
-Lemma xtz_to_token_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
-  let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
-                          (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
-    new_acts =
-    [
-      (act_call prev_state.(tokenAddress) 0%Z
-        (serialize (FA2Token.msg_transfer
-        [build_transfer ctx.(ctx_contract_address) param.(tokens_to) prev_state.(tokenId) tokens_bought None])))
-    ].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-(** If the requirements are met then then receive on xtz_to_token msg must succeed and
-    if receive on xtz_to_token msg succeeds then requirements must hold *)
-Lemma xtz_to_token_is_some : forall prev_state chain ctx param,
-  let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
-                          (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  (current_slot chain < param.(xtt_deadline))%nat /\
-  (prev_state.(xtzPool) <> 0 \/ (0 < ctx.(ctx_amount))%Z) /\
-  param.(minTokensBought) <= tokens_bought /\
-  tokens_bought <= prev_state.(tokenPool)
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (not_updating & deadline_not_hit & not_zero &
-            enough_tokens_bought & tokens_bought_le_total).
-    unfold receive.
-    cbn.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:deadline_check.
-    destruct_match eqn:xtz_div_check; math_convert; try easy.
-    destruct_match eqn:min_tokens_check.
-    destruct_match eqn:token_pool_check; math_convert; try easy.
-    + now apply N.ltb_ge in enough_tokens_bought.
-    + apply leb_correct_conv in deadline_not_hit.
-      now rewrite deadline_not_hit in deadline_check.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    math_convert.
-    rename H0 into deadline_not_hit.
-    rename H2 into enough_tokens_bought.
-    apply leb_complete_conv in deadline_not_hit.
-    apply N.ltb_ge in enough_tokens_bought.
-    now repeat split.
-Qed.
-
-
-
-(** ** Token to xtz correct *)
-(** [token_to_xtz] only changes [tokenPool] and [xtzPool] in state *)
-Lemma token_to_xtz_state_eq : forall prev_state new_state chain ctx new_acts param,
-  let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
-    prev_state<| tokenPool := prev_state.(tokenPool) + param.(tokensSold) |>
-              <| xtzPool := prev_state.(xtzPool) - xtz_bought |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-Lemma token_to_xtz_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
-    new_state.(tokenPool) = prev_state.(tokenPool) + param.(tokensSold) /\
-    new_state.(xtzPool) = prev_state.(xtzPool) - ((param.(tokensSold) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997))).
-Proof.
-  intros * receive_some.
-  apply token_to_xtz_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** token_to_xtz should produce two actions
-- A call action to token contract transferring [tokens_sold] from [sender] to this contract
-- A transfer action transferring [xtz_bought] from this contract to [xtz_to]
- *)
-Lemma token_to_xtz_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
-  let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
-    new_acts =
-    [
-      (act_call prev_state.(tokenAddress) 0%Z
-        (serialize (FA2Token.msg_transfer
-        [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold) None])));
-      (act_transfer param.(xtz_to) (Z.of_N xtz_bought))
-    ].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  math_convert.
-  rename H5 into xtz_act.
-  unfold xtz_transfer in xtz_act.
-  destruct_match in xtz_act; try congruence.
-  now inversion_clear xtz_act.
-Qed.
-
-(** If the requirements are met then then receive on token_to_xtz msg must succeed and
-    if receive on token_to_xtz msg succeeds then requirements must hold *)
-Lemma token_to_xtz_is_some : forall prev_state chain ctx param,
-  let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  (current_slot chain < param.(ttx_deadline))%nat /\
-  (ctx.(ctx_amount) <= 0)%Z /\
-  param.(minXtzBought) <= xtz_bought /\
-  (prev_state.(tokenPool) <> 0 \/ param.(tokensSold) <> 0) /\
-  address_is_contract param.(xtz_to) = false /\
-  xtz_bought <= prev_state.(xtzPool)
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (not_updating & deadline_not_hit & ctx_amount_zero &
-            enough_xtz_bought & not_zero & to_not_contract &
-            xtz_bought_le_total).
-    unfold receive.
-    cbn.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:deadline_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:div_check; math_convert; try easy.
-    destruct_match eqn:min_xtz_check.
-    destruct_match eqn:xtz_pool_check; math_convert; try easy.
-    destruct_match eqn:transfer_act.
-    + eauto.
-    + unfold xtz_transfer in transfer_act.
-      now rewrite to_not_contract in transfer_act.
-    + now apply N.ltb_ge in enough_xtz_bought.
-    + now apply Z.ltb_ge in ctx_amount_zero.
-    + apply leb_correct_conv in deadline_not_hit.
-      now rewrite deadline_not_hit in deadline_check.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    math_convert.
-    rename H0 into deadline_not_hit.
-    rename H1 into ctx_amount_zero.
-    rename H3 into enough_xtz_bought.
-    rename H5 into transfer_act.
-    apply leb_complete_conv in deadline_not_hit.
-    apply N.ltb_ge in enough_xtz_bought.
-    apply Z.ltb_ge in ctx_amount_zero.
-    unfold xtz_transfer in transfer_act.
-    destruct_match eqn:to_not_contract in transfer_act;
-      try congruence.
-    now repeat split.
-Qed.
-
-
-
-(** ** Token to token correct *)
-(** [token_to_token] only changes [tokenPool] and [xtzPool] in state *)
-Lemma token_to_token_state_eq : forall prev_state new_state chain ctx new_acts param,
-  let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
-    prev_state<| tokenPool := prev_state.(tokenPool) + param.(tokensSold_) |>
-              <| xtzPool := prev_state.(xtzPool) - xtz_bought |> = new_state.
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-Lemma token_to_token_correct : forall prev_state new_state chain ctx new_acts param,
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
-    new_state.(tokenPool) = prev_state.(tokenPool) + param.(tokensSold_) /\
-    new_state.(xtzPool) = prev_state.(xtzPool) - ((param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997))).
-Proof.
-  intros * receive_some.
-  apply token_to_token_state_eq in receive_some.
-  now subst.
-Qed.
-
-(** token_to_token should produce two actions
-- A call action to token contract transferring [tokens_sold] from [sender] to this contract
-- A call action to [outputDexterContract] [xtz_to_token] entrypoint with [xtz_bought] amount attached
- *)
-Lemma token_to_token_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
-  let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
-  receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
-    new_acts =
-    [
-      (act_call prev_state.(tokenAddress) 0%Z
-        (serialize (FA2Token.msg_transfer
-        [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold_) None])));
-      (act_call param.(outputDexterContract) (Z.of_N xtz_bought)
-        (serialize ((FA2Token.other_msg (XtzToToken
-        {| tokens_to := param.(to_);
-           minTokensBought := param.(minTokensBought_);
-           xtt_deadline := param.(ttt_deadline) |})))))
-    ].
-Proof.
-  intros * receive_some.
-  receive_simpl.
-  now math_convert.
-Qed.
-
-(** If the requirements are met then then receive on token_to_token msg must succeed and
-    if receive on token_to_token msg succeeds then requirements must hold *)
-Lemma token_to_token_is_some : forall prev_state chain ctx param,
-  let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
-                          (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
-  prev_state.(selfIsUpdatingTokenPool) = false /\
-  (current_slot chain < param.(ttt_deadline))%nat /\
-  (ctx.(ctx_amount) <= 0)%Z /\
-  xtz_bought <= prev_state.(xtzPool) /\
-  (prev_state.(tokenPool) <> 0 \/ param.(tokensSold_) <> 0)
-  <->
-  exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts).
-Proof.
-  split.
-  - intros (not_updating & deadline_not_hit & ctx_amount_zero &
-            xtz_bought_le_total & not_zero).
-    unfold receive.
-    cbn.
-    destruct_match eqn:updating_check.
-    destruct_match eqn:amount_check.
-    destruct_match eqn:deadline_check.
-    destruct_match eqn:div_check; math_convert; try easy.
-    destruct_match eqn:xtz_pool_check; math_convert; try easy.
-    + apply leb_correct_conv in deadline_not_hit.
-      now rewrite deadline_not_hit in deadline_check.
-    + now apply Z.ltb_ge in ctx_amount_zero.
-    + now rewrite not_updating in updating_check.
-  - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    math_convert.
-    rename H1 into deadline_not_hit.
-    rename H0 into ctx_amount_zero.
-    apply leb_complete_conv in deadline_not_hit.
-    apply Z.ltb_ge in ctx_amount_zero.
-    now repeat split.
-Qed.
-
-
-
-(** ** Init correct *)
-Lemma init_state_eq : forall chain ctx setup state,
-  init chain ctx setup = Some state ->
-    state = {|
+        default_ chain ctx state
+    | Some (FA2Token.other_msg UpdateTokenPool) =>
+        update_token_pool chain ctx state
+    | Some (FA2Token.other_msg (XtzToToken param)) =>
+        xtz_to_token chain ctx state param
+    | Some (FA2Token.other_msg (TokenToXtz param)) =>
+        token_to_xtz chain ctx state param
+    | Some (FA2Token.other_msg (TokenToToken param)) =>
+        token_to_token chain ctx state param
+    | Some (FA2Token.receive_balance_of_param responses) =>
+        update_token_pool_internal chain ctx state responses
+    | _ => None
+    end.
+
+  (** ** Init *)
+  Definition init (chain : Chain)
+                  (ctx : ContractCallContext)
+                  (setup : Setup) : option State :=
+    Some {|
       tokenPool := 0;
       xtzPool := 0;
       lqtTotal := setup.(lqtTotal_);
@@ -1579,38 +472,1151 @@ Lemma init_state_eq : forall chain ctx setup state,
       freezeBaker := false;
       manager := setup.(manager_);
       tokenAddress := setup.(tokenAddress_);
-      lqtAddress := null_address;
-      tokenId := setup.(tokenId_)
+      tokenId := setup.(tokenId_);
+      lqtAddress := null_address
     |}.
-Proof.
-  intros * init_some.
-  now inversion init_some.
-Qed.
 
-Lemma init_correct : forall chain ctx setup state,
-  init chain ctx setup = Some state ->
-    tokenPool state = 0 /\
-    xtzPool state = 0 /\
-    lqtTotal state = setup.(lqtTotal_) /\
-    selfIsUpdatingTokenPool state = false /\
-    freezeBaker state = false /\
-    manager state = setup.(manager_) /\
-    tokenAddress state = setup.(tokenAddress_) /\
-    lqtAddress state = null_address /\
-    tokenId state = setup.(tokenId_).
-Proof.
-  intros * init_some.
-  apply init_state_eq in init_some.
-  now subst.
-Qed.
+  Definition contract : Contract Setup Msg State :=
+    build_contract init receive.
 
-(** Initialization should always succeed *)
-Lemma init_is_some : forall chain ctx setup,
-  exists state, init chain ctx setup = state.
-Proof.
-  intros.
-  eauto.
-Qed.
+  End DexterDefs.
+End Dexter2.
+
+Module DSInstances <: Dexter2Serializable.
+    (* Serialisation instances (omitted).
+
+       NOTE: we use [<:] to make the definitions transparent, so the
+       implementation details can be revealed, if needed *)
+    (* begin hide *)
+    Global Instance add_liquidity_param_serializable `{ChainBase} : Serializable add_liquidity_param :=
+      Derive Serializable add_liquidity_param_rect <build_add_liquidity_param>.
+
+    Global Instance remove_liquidity_param_serializable `{ChainBase} : Serializable remove_liquidity_param :=
+      Derive Serializable remove_liquidity_param_rect <build_remove_liquidity_param>.
+
+    Global Instance xtz_to_token_param_serializable `{ChainBase} : Serializable xtz_to_token_param :=
+      Derive Serializable xtz_to_token_param_rect <build_xtz_to_token_param>.
+
+    Global Instance token_to_xtz_param_serializable `{ChainBase} : Serializable token_to_xtz_param :=
+      Derive Serializable token_to_xtz_param_rect <build_token_to_xtz_param>.
+
+    Global Instance set_baker_param_serializable `{ChainBase} : Serializable set_baker_param :=
+      Derive Serializable set_baker_param_rect <build_set_baker_param>.
+
+    Global Instance token_to_token_param_serializable `{ChainBase} : Serializable token_to_token_param :=
+      Derive Serializable token_to_token_param_rect <build_token_to_token_param>.
+
+    Global Instance DexterMsg_serializable `{ChainBase} : Serializable DexterMsg :=
+        Derive Serializable DexterMsg_rect <AddLiquidity,
+                                            RemoveLiquidity,
+                                            XtzToToken,
+                                            TokenToXtz,
+                                            SetBaker,
+                                            SetManager,
+                                            SetLqtAddress,
+                                            UpdateTokenPool,
+                                            TokenToToken>.
+
+    Global Instance Dexter2FA12_Msg_serialize `{ChainBase} : Serializable Dexter2FA12.Msg :=
+      msg_serializable.
+
+    Global Instance setup_serializable `{ChainBase} : Serializable Setup :=
+      Derive Serializable Setup_rect <build_setup>.
+
+    Global Instance ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg BaseTypes DexterMsg _) :=
+      fun _ => @FA2Token.FA2ReceiverMsg_serializable _ _ _.
+
+    Global Instance state_serializable `{ChainBase} : Serializable State :=
+      Derive Serializable State_rect <build_state>.
+
+    Global Instance FA2Token_Msg_serializable `{ChainBase} : Serializable FA2Token.Msg :=
+      FA2Token.msg_serializable.
+
+End DSInstances.
+  (* end hide *)
+
+(** Instantiating the implementaion with required instances for serialisation/deserialisation *)
+Module DEX2 := Dexter2 DSInstances.
+
+Import DEX2.
+
+  (** * Properties *)
+Section Theories.
+  Context `{ChainBase}.
+  Open Scope N_scope.
+  (* Tactics and facts about helper functions (omitted) *)
+  (* begin hide *)
+  Transparent div.
+  Transparent ceildiv.
+  Transparent ceildiv_.
+  Lemma div_eq : forall n m p,
+      div n m = Some p ->
+      n / m = p /\ m <> 0.
+  Proof.
+    intros * div_some.
+    unfold div in div_some.
+    cbn in div_some.
+    destruct_match eqn:m_not_zero in div_some;
+      try congruence.
+    destruct_throw_if m_not_zero.
+    now apply N.eqb_neq in m_not_zero.
+  Qed.
+
+  Lemma div_zero : forall n m,
+    div n m = None ->
+    m = 0.
+  Proof.
+    intros * div_some.
+    cbn in div_some.
+    destruct_match eqn:m_zero in div_some;
+      try congruence.
+    destruct_throw_if m_zero.
+    now apply N.eqb_eq in m_zero.
+  Qed.
+  Opaque div.
+
+  Lemma ceildiv_eq : forall n m p,
+    ceildiv n m = Some p ->
+    ceildiv_ n m = p /\ m <> 0.
+  Proof.
+    intros * ceildiv_some.
+    unfold ceildiv_.
+    unfold ceildiv in ceildiv_some.
+    destruct_match eqn:modulo_zero.
+    - now apply div_eq in ceildiv_some.
+    - cbn in ceildiv_some.
+      destruct_match eqn:div_some in ceildiv_some;
+        try congruence.
+      apply div_eq in div_some.
+      now inversion_clear ceildiv_some.
+  Qed.
+
+  Lemma ceildiv_zero : forall n m,
+    ceildiv n m = None ->
+    m = 0.
+  Proof.
+    intros * ceildiv_some.
+    unfold ceildiv in ceildiv_some.
+    destruct_match eqn:modulo_zero in ceildiv_some.
+    - now apply div_zero in ceildiv_some.
+    - cbn in ceildiv_some.
+      destruct_match eqn:div_some in ceildiv_some;
+        try congruence.
+      now apply div_zero in div_some.
+  Qed.
+  Opaque ceildiv.
+  Opaque ceildiv_.
+
+  Transparent sub.
+  Lemma sub_eq : forall n m p,
+    sub n m = Some p ->
+    n - m = p /\ m <= n.
+  Proof.
+    intros * sub_some.
+    cbn in sub_some.
+    destruct_match eqn:m_le_n in sub_some;
+      try congruence.
+    destruct_throw_if m_le_n.
+    now rewrite <- N.ltb_ge.
+  Qed.
+
+  Lemma sub_fail : forall n m,
+    sub n m = None ->
+    n < m.
+  Proof.
+    intros * sub_some.
+    cbn in sub_some.
+    destruct_match eqn:n_lt_m in sub_some;
+      try congruence.
+    destruct_throw_if n_lt_m.
+    now apply N.ltb_lt.
+  Qed.
+  Opaque sub.
+
+  Lemma isSome_some : forall {A : Type} (x : option A) (y : A),
+    x = Some y -> isSome x = true.
+  Proof.
+    intros.
+    now subst.
+  Qed.
+
+  Lemma isSome_none : forall {A : Type} (x : option A),
+    x = None -> isSome x = false.
+  Proof.
+    intros.
+    now subst.
+  Qed.
+
+  Lemma isSome_exists : forall {A : Type} (x : option A),
+    isSome x = true <-> exists y : A, x = Some y.
+  Proof.
+    split.
+    - now destruct x eqn:x_eq.
+    - intros (y & x_eq).
+      now eapply isSome_some.
+  Qed.
+
+  Lemma isSome_not_exists : forall {A : Type} (x : option A),
+    isSome x = false <-> forall y : A, x <> Some y.
+  Proof.
+    split.
+    - now destruct x eqn:x_eq.
+    - intros x_eq.
+      eapply isSome_none.
+      now destruct x.
+  Qed.
+
+  Ltac math_convert_step :=
+    match goal with
+    | H : sub _ _ = Some _ |- _ => apply sub_eq in H as [<- H]
+    | H : sub _ _ = None |- _ => apply sub_fail in H
+    | H : div _ _ = Some _ |- _ => apply div_eq in H as [<- H]
+    | H : div _ _ = None |- _ => apply div_zero in H
+    | H : ceildiv _ _ = Some _ |- _ => apply ceildiv_eq in H as [<- H]
+    | H : ceildiv _ _ = None |- _ => apply ceildiv_zero in H
+    end.
+
+  Tactic Notation "math_convert" := repeat math_convert_step.
+
+  Ltac receive_simpl_step :=
+    match goal with
+    | H : Blockchain.receive _ _ _ _ _ = Some (_, _) |- _ =>
+        unfold Blockchain.receive in H; cbn in H
+    | H : receive _ _ _ _ = Some (_, _) |- _ =>
+        unfold receive in H;
+        cbn in H
+    | |- receive _ _ _ _ = _ =>
+        unfold receive; cbn
+    | H : Some _ = Some _ |- _ =>
+        inversion_clear H
+    | H : Some _ = None |- _ =>
+        inversion H
+    | H : None = Some _ |- _ =>
+        inversion H
+    | H : throwIf _ = None |- _ => destruct_throw_if H
+    | H : throwIf _ = Some ?u |- _ => destruct_throw_if H
+    | H : option_map (fun s : State => (s, _)) match ?m with | Some _ => _ | None => None end = Some _ |- _ =>
+      let a := fresh "H" in
+      destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+    | H : match ?m with | Some _ => _ | None => None end = Some _ |- _ =>
+      let a := fresh "H" in
+      destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+    | H : option_map (fun s : State => (s, _)) (if ?m then ?a else ?b) = Some _ |- _ =>
+      match a with
+      | None =>
+        let a := fresh "H" in
+        destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+      | _ => match b with
+             | None =>
+               let a := fresh "H" in
+               destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+             | _ => idtac
+      end end
+    | H : (if ?m then ?a else ?b) = Some _ |- _ =>
+      match a with
+      | None =>
+        let a := fresh "H" in
+        destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+      | _ => match b with
+             | None =>
+               let a := fresh "H" in
+               destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
+             | _ => idtac
+      end end
+    end.
+
+  Tactic Notation "receive_simpl" := repeat (unfold call_to_token,call_to_other_token;receive_simpl_step).
+  (* end hide *)
+
+
+
+  (** ** Set baker correct *)
+  (** [set_baker] only changes [freezeBaker] in state *)
+  Lemma set_baker_state_eq : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
+      prev_state<| freezeBaker := param.(freezeBaker_) |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  Lemma set_baker_freeze_baker_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
+      new_state.(freezeBaker) = param.(freezeBaker_).
+  Proof.
+    intros * receive_some.
+    apply set_baker_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [set_baker] produces no new_acts *)
+  Lemma set_baker_new_acts_correct : forall chain ctx prev_state param new_state new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts) ->
+      new_acts = set_delegate_call param.(baker).
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on set_baker msg must succeed and
+      if receive on set_baker msg succeeds then requirements must hold *)
+  Lemma set_baker_is_some : forall prev_state chain ctx param,
+    (ctx_amount ctx <= 0)%Z /\
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    ctx.(ctx_from) = prev_state.(manager) /\
+    prev_state.(freezeBaker) = false
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetBaker param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (amount_zero & not_updating & sender_is_manager & not_frozen).
+      do 2 eexists.
+      receive_simpl.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:sender_check.
+      destruct_match eqn:frozen_check.
+      + reflexivity.
+      + now rewrite not_frozen in frozen_check.
+      + now rewrite sender_is_manager, address_eq_refl in sender_check.
+      + receive_simpl.
+        now apply Z.ltb_ge in amount_zero.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      rewrite Z.ltb_ge in *.
+      repeat split; auto.
+      now destruct_address_eq.
+  Qed.
+
+
+
+  (** ** Set manager correct *)
+  (** [set_manager] only changes [manager] in state *)
+  Lemma set_manager_state_eq : forall prev_state new_state chain ctx new_acts new_manager,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
+      prev_state<| manager := new_manager |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  Lemma set_manager_manager_correct : forall prev_state new_state chain ctx new_acts new_manager,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
+      new_state.(manager) = new_manager.
+  Proof.
+    intros * receive_some.
+    apply set_manager_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [set_manager] produces no new_acts *)
+  Lemma set_manager_new_acts_correct : forall chain ctx prev_state new_manager new_state new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts) ->
+      new_acts = [].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on set_manager msg must succeed and
+      if receive on set_manager msg succeeds then requirements must hold *)
+  Lemma set_manager_is_some : forall prev_state chain ctx new_manager,
+    (ctx_amount ctx <= 0)%Z /\
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    ctx.(ctx_from) = prev_state.(manager)
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetManager new_manager))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (amount_zero & not_updating & sender_is_manager).
+      do 2 eexists.
+      receive_simpl.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:sender_check.
+      + reflexivity.
+      + now rewrite sender_is_manager, address_eq_refl in sender_check.
+      + receive_simpl.
+        now apply Z.ltb_ge in amount_zero.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      rewrite Z.ltb_ge in *.
+      repeat split; auto.
+      now destruct_address_eq.
+  Qed.
+
+
+
+  (** ** Set liquidity address correct *)
+  (** [set_lqt_address] only changes [lqtAddress] in state *)
+  Lemma set_lqt_address_state_eq : forall prev_state new_state chain ctx new_acts new_lqt_address,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
+      prev_state<| lqtAddress := new_lqt_address |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  Lemma set_lqt_address_correct : forall prev_state new_state chain ctx new_acts new_lqt_address,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
+      new_state.(lqtAddress) = new_lqt_address.
+  Proof.
+    intros * receive_some.
+    apply set_lqt_address_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [set_lqt_address] produces no new_acts *)
+  Lemma set_lqt_address_new_acts_correct : forall chain ctx prev_state new_lqt_address new_state new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts) ->
+      new_acts = [].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on set_lqt_address msg must succeed and
+      if receive on set_lqt_address msg succeeds then requirements must hold *)
+  Lemma set_lqt_address_is_some : forall prev_state chain ctx new_lqt_address,
+    (ctx_amount ctx <= 0)%Z /\
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    ctx.(ctx_from) = prev_state.(manager) /\
+    prev_state.(lqtAddress) = null_address
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (SetLqtAddress new_lqt_address))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (amount_zero & not_updating & sender_is_manager & lqt_address_not_set).
+      do 2 eexists.
+      receive_simpl.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:sender_check.
+      destruct_match eqn:lqt_check.
+      + reflexivity.
+      + now rewrite lqt_address_not_set, address_eq_refl in lqt_check.
+      + now rewrite sender_is_manager, address_eq_refl in sender_check.
+      + receive_simpl.
+        now apply Z.ltb_ge in amount_zero.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      rewrite Z.ltb_ge in *.
+      repeat split; auto;
+        now destruct_address_eq.
+  Qed.
+
+
+  (** ** Default entrypoint correct *)
+  (** [default_] only changes [xtzPool] in state *)
+  Lemma default_state_eq : forall prev_state new_state chain ctx new_acts,
+    receive chain ctx prev_state None = Some (new_state, new_acts) ->
+      prev_state<| xtzPool := prev_state.(xtzPool) + Z.to_N (ctx.(ctx_amount)) |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  Lemma default_correct : forall prev_state new_state chain ctx new_acts,
+    receive chain ctx prev_state None = Some (new_state, new_acts) ->
+      new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N (ctx.(ctx_amount)).
+  Proof.
+    intros * receive_some.
+    apply default_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [default_] produces no new_acts *)
+  Lemma default_new_acts_correct : forall chain ctx prev_state new_state new_acts,
+    receive chain ctx prev_state None = Some (new_state, new_acts) ->
+      new_acts = [].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on None msg must succeed and
+      if receive on None msg succeeds then requirements must hold *)
+  Lemma default_entrypoint_is_some : forall prev_state chain ctx,
+    prev_state.(selfIsUpdatingTokenPool) = false
+    <->
+    exists new_state new_acts, receive chain ctx prev_state None = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros not_updating.
+      do 2 eexists.
+      receive_simpl.
+      destruct_match eqn:updating_check.
+      + reflexivity.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+  Qed.
+
+
+
+  (** ** Update token pool correct *)
+  (** [update_token_pool] only changes [selfIsUpdatingTokenPool] in state *)
+  Lemma update_token_pool_state_eq : forall prev_state new_state chain ctx new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
+      prev_state<| selfIsUpdatingTokenPool := true |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  Lemma update_token_pool_correct : forall prev_state new_state chain ctx new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
+      new_state.(selfIsUpdatingTokenPool) = true.
+  Proof.
+    intros * receive_some.
+    apply update_token_pool_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [update_token_pool] produces an call act with amount = 0, calling
+      the token contract with a balance of request *)
+  Lemma update_token_pool_new_acts_correct : forall chain ctx prev_state new_state new_acts,
+    receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts) ->
+      new_acts = [
+        act_call prev_state.(tokenAddress) 0%Z (serialize
+          (msg_balance_of (Build_balance_of_param 
+            ([Build_balance_of_request ctx.(ctx_contract_address) prev_state.(tokenId)])
+            (FA2Interface.Build_callback _ None))))
+      ].
+  Proof.
+    intros * receive_some.
+    now receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on update_token_pool msg must succeed and
+      if receive on update_token_pool msg succeeds then requirements must hold *)
+  Lemma update_token_pool_is_some : forall prev_state chain ctx,
+    (ctx_amount ctx <= 0)%Z /\
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    ctx.(ctx_from) = ctx.(ctx_origin)
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg UpdateTokenPool)) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (amount_zero & not_updating & sender_eq_origin).
+      do 2 eexists.
+      receive_simpl.
+      destruct_match eqn:sender_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:updating_check.
+      + reflexivity.
+      + now rewrite not_updating in updating_check.
+      + receive_simpl.
+        now apply Z.ltb_ge in amount_zero.
+      + now rewrite sender_eq_origin, address_eq_refl in sender_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      rewrite Z.ltb_ge in *.
+      rewrite Bool.negb_false_iff in *.
+      now destruct_address_eq.
+  Qed.
+
+    Tactic Notation "invert_responses_Some" :=
+      match goal with
+      | [H : match ?rs with
+             | [] => _
+             | _ => _
+             end = Some _ |- _] =>
+          match type of rs with
+          | list balance_of_response =>
+              destruct rs;inversion H;clear H
+          | _ => fail "No match on list of balance_of_response"
+          end
+      end.
+
+
+  (** ** Update token pool internal correct *)
+  (** [update_token_pool_internal] only changes [selfIsUpdatingTokenPool] and [tokenPool] in state *)
+  Lemma update_token_pool_internal_state_eq : forall prev_state new_state chain ctx new_acts responses,
+    receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
+      prev_state<| selfIsUpdatingTokenPool := false |>
+                <| tokenPool := match responses with 
+                                | [] => 0
+                                | response :: t => response.(balance)
+                                end |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now invert_responses_Some.
+  Qed.
+
+  Lemma update_token_pool_internal_update_correct : forall prev_state new_state chain ctx new_acts responses,
+    receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
+      new_state.(selfIsUpdatingTokenPool) = false.
+  Proof.
+    intros * receive_some.
+    apply update_token_pool_internal_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [update_token_pool_internal] produces no new actions *)
+  Lemma update_token_pool_internal_new_acts_correct : forall chain ctx prev_state new_state new_acts responses,
+    receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts) ->
+      new_acts = [].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+  Qed.
+
+  (** If the requirements are met then then receive on update_token_pool_internal msg must succeed and
+      if receive on update_token_pool_internal msg succeeds then requirements must hold *)
+  Lemma update_token_pool_internal_is_some : forall prev_state chain ctx responses,
+    (ctx_amount ctx <= 0)%Z /\
+    prev_state.(selfIsUpdatingTokenPool) = true /\
+    ctx.(ctx_from) = prev_state.(tokenAddress) /\
+    responses <> []
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.receive_balance_of_param responses)) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (amount_zero & updating & sender_is_token_contract & responses_not_empty).
+      unfold receive. cbn.
+      destruct_match eqn:sender_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:response.
+      destruct_match eqn:response_check in response.
+      + congruence.
+      + eauto.
+      + now destruct_match in response.
+      + receive_simpl.
+        now apply Z.ltb_ge in amount_zero.
+      + now rewrite updating, sender_is_token_contract, address_eq_refl in sender_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      rewrite Bool.orb_false_iff in *.
+      rewrite Bool.negb_false_iff in *.
+      rewrite Z.ltb_ge in *.
+      invert_responses_Some;subst.
+      repeat split;auto.
+      + easy.
+      + now destruct_address_eq.
+  Qed.
+
+
+
+  (** ** Add liquidity correct *)
+  (** [add_liquidity] only changes [lqtTotal], [tokenPool] and [xtzPool] in state *)
+  Lemma add_liquidity_state_eq : forall prev_state new_state chain ctx new_acts param,
+    let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
+    let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
+      prev_state<| lqtTotal := prev_state.(lqtTotal) +  lqt_minted |>
+                <| tokenPool := prev_state.(tokenPool) + tokens_deposited |>
+                <| xtzPool := prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  Lemma add_liquidity_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
+      new_state.(lqtTotal) = prev_state.(lqtTotal) + Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) /\
+      new_state.(tokenPool) = prev_state.(tokenPool) + ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) /\
+      new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount).
+  Proof.
+    intros * receive_some.
+    apply add_liquidity_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** In the informal specification it is stated that tokens should be trasnfered from owner,
+      but in the implementation it is trasnfered from the sender.
+      For this we assume that the implementation is correct over the informal specification since
+      that is what other formalizations seem to have assumed *)
+  Lemma add_liquidity_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
+    let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
+    let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts) ->
+      new_acts =
+      [
+        (act_call prev_state.(tokenAddress) 0%Z
+          (serialize (FA2Token.msg_transfer
+          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) tokens_deposited None])));
+        (act_call prev_state.(lqtAddress) 0%Z
+          (serialize (Dexter2FA12.msg_mint_or_burn {| target := param.(owner); quantity := Z.of_N lqt_minted|})))
+      ].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  (** If the requirements are met then then receive on add_liquidity msg must succeed and
+      if receive on add_liquidity msg succeeds then requirements must hold *)
+  Lemma add_liquidity_is_some : forall prev_state chain ctx param,
+    let lqt_minted := Z.to_N ctx.(ctx_amount) * prev_state.(lqtTotal) / prev_state.(xtzPool) in
+    let tokens_deposited := ceildiv_ (Z.to_N ctx.(ctx_amount) * prev_state.(tokenPool)) prev_state.(xtzPool) in
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    (current_slot chain < param.(add_deadline))%nat /\
+    tokens_deposited <= param.(maxTokensDeposited)  /\
+    param.(minLqtMinted) <= lqt_minted /\
+    prev_state.(xtzPool) <> 0 /\
+    prev_state.(lqtAddress) <> null_address
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (AddLiquidity param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (not_updating & deadline_not_hit & max_tokens_not_hit &
+              enough_minted & xtzPool_not_zero & lqt_addr_set).
+      unfold receive.
+      cbn.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:deadline_check.
+      destruct_match eqn:div_check; math_convert.
+      destruct_match eqn:ceildiv_check; math_convert.
+      destruct_match eqn:max_tokens_check.
+      destruct_match eqn:min_lqt_check.
+      destruct_match eqn:mint_act; try congruence;
+      destruct_match eqn:lqt_addr_set_check in mint_act; try congruence.
+      + eauto.
+      + now apply address_eq_ne in lqt_addr_set.
+      + now apply N.ltb_ge in enough_minted.
+      + now apply N.ltb_ge in max_tokens_not_hit.
+      + congruence.
+      + congruence.
+      + apply leb_correct_conv in deadline_not_hit.
+        now rewrite deadline_not_hit in deadline_check.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      math_convert.
+      rewrite leb_iff_conv,N.ltb_ge in *.
+      repeat split; auto.
+      now destruct_address_eq.
+  Qed.
+
+
+
+  (** ** Remove liquidity correct *)
+  (** [remove_liquidity] only changes [lqtTotal], [tokenPool] and [xtzPool] in state *)
+  Lemma remove_liquidity_state_eq : forall prev_state new_state chain ctx new_acts param,
+    let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
+    let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
+      prev_state<| lqtTotal := prev_state.(lqtTotal) - param.(lqtBurned) |>
+                <| tokenPool := prev_state.(tokenPool) - tokens_withdrawn |>
+                <| xtzPool := prev_state.(xtzPool) - xtz_withdrawn |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert;cbv.
+  Qed.
+
+  Lemma remove_liquidity_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
+      new_state.(lqtTotal) = prev_state.(lqtTotal) - param.(lqtBurned) /\
+      new_state.(tokenPool) = prev_state.(tokenPool) -  (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) /\
+      new_state.(xtzPool) = prev_state.(xtzPool) - (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal).
+  Proof.
+    intros * receive_some.
+    apply remove_liquidity_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [remove_liquidity] should produce three acts
+  - A call action to LQT contract burning [lqtBurned] from [sender]
+  - A call action to token contract transferring [tokens_withdrawn] from this contract to [liquidity_to]
+  - A transfer action transferring [xtz_withdrawn] from this contract to [liquidity_to]
+   *)
+  Lemma remove_liquidity_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
+    let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
+    let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts) ->
+      new_acts =
+      [
+        (act_call prev_state.(lqtAddress) 0%Z
+          (serialize (Dexter2FA12.msg_mint_or_burn {| target := ctx.(ctx_from); quantity := - Z.of_N param.(lqtBurned)|})));
+        (act_call prev_state.(tokenAddress) 0%Z
+          (serialize (FA2Token.msg_transfer
+          [build_transfer ctx.(ctx_contract_address) param.(liquidity_to) prev_state.(tokenId) tokens_withdrawn None])));
+        (act_transfer param.(liquidity_to) (Z.of_N xtz_withdrawn))
+      ].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    math_convert.
+    unfold xtz_transfer in *.
+    destruct_match in *; try congruence.
+    match goal with
+      [ H : Some _ = Some _ |- _ ] => now inversion H
+    end.
+  Qed.
+
+  (** If the requirements are met then then receive on remove_liquidity msg must succeed and
+      if receive on remove_liquidity msg succeeds then requirements must hold *)
+  Lemma remove_liquidity_is_some : forall prev_state chain ctx param,
+    let xtz_withdrawn := (param.(lqtBurned) * prev_state.(xtzPool)) / prev_state.(lqtTotal) in
+    let tokens_withdrawn := (param.(lqtBurned) * prev_state.(tokenPool)) / prev_state.(lqtTotal) in
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    (current_slot chain < param.(remove_deadline))%nat /\
+    (ctx.(ctx_amount) <= 0)%Z /\
+    prev_state.(lqtTotal) <> 0 /\
+    param.(minXtzWithdrawn) <= xtz_withdrawn /\
+    param.(minTokensWithdrawn) <= tokens_withdrawn /\
+    tokens_withdrawn <= prev_state.(tokenPool) /\
+    xtz_withdrawn <= prev_state.(xtzPool) /\
+    param.(lqtBurned) <= prev_state.(lqtTotal) /\
+    address_is_contract param.(liquidity_to) = false /\
+    prev_state.(lqtAddress) <> null_address
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (RemoveLiquidity param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (not_updating & deadline_not_hit & ctx_amount_zero &
+              lqtPool_not_zero & enough_xtz_withdrawn & enough_tokens_withdrawn &
+              tokens_withdrawn_le_total & xtz_withdrawn_le_total & lqt_burned_le_total &
+              to_not_contract & lqt_addr_set).
+      unfold receive.
+      cbn.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:deadline_check.
+      destruct_match eqn:ctx_amount_check.
+      destruct_match eqn:xtz_div_check; math_convert; try easy.
+      destruct_match eqn:tokens_div_check; math_convert; try easy.
+      destruct_match eqn:min_xtz_check.
+      destruct_match eqn:min_tokens_check.
+      destruct_match eqn:burned_check; math_convert; try easy.
+      destruct_match eqn:token_pool_check; math_convert; try easy.
+      destruct_match eqn:xtz_pool_check; math_convert; try easy.
+      destruct_match eqn:mint_act; try congruence;
+      destruct_match eqn:lqt_addr_set_check in mint_act; try congruence.
+      destruct_match eqn:transfer_act.
+      + eauto.
+      + unfold xtz_transfer in transfer_act.
+        now rewrite to_not_contract in transfer_act.
+      + now apply address_eq_ne in lqt_addr_set.
+      + now apply N.ltb_ge in enough_tokens_withdrawn.
+      + now apply N.ltb_ge in enough_xtz_withdrawn.
+      + now apply Z.ltb_ge in ctx_amount_zero.
+      + apply leb_correct_conv in deadline_not_hit.
+        now rewrite deadline_not_hit in deadline_check.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      math_convert.
+      rewrite leb_iff_conv,N.ltb_ge,Z.ltb_ge in *.
+      unfold xtz_transfer in *.
+      destruct_match in *; try congruence.
+      repeat split; auto.
+      now destruct_address_eq.
+  Qed.
+
+
+  (** ** XTZ to token correct *)
+  (** [xtz_to_token] only changes [tokenPool] and [xtzPool] in state *)
+  Lemma xtz_to_token_state_eq : forall prev_state new_state chain ctx new_acts param,
+    let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
+                            (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
+      prev_state<| tokenPool := prev_state.(tokenPool) - tokens_bought |>
+                <| xtzPool := prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount) |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  Lemma xtz_to_token_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
+      new_state.(tokenPool) = prev_state.(tokenPool) -  (((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
+                            (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) ) /\
+      new_state.(xtzPool) = prev_state.(xtzPool) + Z.to_N ctx.(ctx_amount).
+  Proof.
+    intros * receive_some.
+    apply xtz_to_token_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** [xtz_to_token] should produce one action
+  - A call action to token contract transferring [tokens_bought] from this contract to [tokens_to]
+  *)
+  Lemma xtz_to_token_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
+    let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
+                            (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts) ->
+      new_acts =
+      [
+        (act_call prev_state.(tokenAddress) 0%Z
+          (serialize (FA2Token.msg_transfer
+          [build_transfer ctx.(ctx_contract_address) param.(tokens_to) prev_state.(tokenId) tokens_bought None])))
+      ].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  (** If the requirements are met then then receive on xtz_to_token msg must succeed and
+      if receive on xtz_to_token msg succeeds then requirements must hold *)
+  Lemma xtz_to_token_is_some : forall prev_state chain ctx param,
+    let tokens_bought := ((Z.to_N ctx.(ctx_amount)) * 997 * prev_state.(tokenPool)) /
+                            (prev_state.(xtzPool) * 1000 + ((Z.to_N ctx.(ctx_amount)) * 997)) in
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    (current_slot chain < param.(xtt_deadline))%nat /\
+    (prev_state.(xtzPool) <> 0 \/ (0 < ctx.(ctx_amount))%Z) /\
+    param.(minTokensBought) <= tokens_bought /\
+    tokens_bought <= prev_state.(tokenPool)
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (XtzToToken param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (not_updating & deadline_not_hit & not_zero &
+              enough_tokens_bought & tokens_bought_le_total).
+      unfold receive.
+      cbn.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:deadline_check.
+      destruct_match eqn:xtz_div_check; math_convert; try easy.
+      destruct_match eqn:min_tokens_check.
+      destruct_match eqn:token_pool_check; math_convert; try easy.
+      + now apply N.ltb_ge in enough_tokens_bought.
+      + apply leb_correct_conv in deadline_not_hit.
+        now rewrite deadline_not_hit in deadline_check.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      math_convert.
+      rewrite leb_iff_conv,N.ltb_ge in *.
+      now repeat split.
+  Qed.
+
+
+  (** ** Token to xtz correct *)
+  (** [token_to_xtz] only changes [tokenPool] and [xtzPool] in state *)
+  Lemma token_to_xtz_state_eq : forall prev_state new_state chain ctx new_acts param,
+    let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
+      prev_state<| tokenPool := prev_state.(tokenPool) + param.(tokensSold) |>
+                <| xtzPool := prev_state.(xtzPool) - xtz_bought |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  Lemma token_to_xtz_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
+      new_state.(tokenPool) = prev_state.(tokenPool) + param.(tokensSold) /\
+      new_state.(xtzPool) = prev_state.(xtzPool) - ((param.(tokensSold) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997))).
+  Proof.
+    intros * receive_some.
+    apply token_to_xtz_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** token_to_xtz should produce two actions
+  - A call action to token contract transferring [tokens_sold] from [sender] to this contract
+  - A transfer action transferring [xtz_bought] from this contract to [xtz_to]
+   *)
+  Lemma token_to_xtz_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
+    let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts) ->
+      new_acts =
+      [
+        (act_call prev_state.(tokenAddress) 0%Z
+          (serialize (FA2Token.msg_transfer
+          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold) None])));
+        (act_transfer param.(xtz_to) (Z.of_N xtz_bought))
+      ].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    math_convert.
+    unfold xtz_transfer in *. 
+    destruct_match in *; try congruence.
+    match goal with
+      [H : Some _ = Some _ |- _] => now inversion H
+    end.
+  Qed.
+
+  (** If the requirements are met then then receive on token_to_xtz msg must succeed and
+      if receive on token_to_xtz msg succeeds then requirements must hold *)
+  Lemma token_to_xtz_is_some : forall prev_state chain ctx param,
+    let xtz_bought := (param.(tokensSold) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold) * 997)) in
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    (current_slot chain < param.(ttx_deadline))%nat /\
+    (ctx.(ctx_amount) <= 0)%Z /\
+    param.(minXtzBought) <= xtz_bought /\
+    (prev_state.(tokenPool) <> 0 \/ param.(tokensSold) <> 0) /\
+    address_is_contract param.(xtz_to) = false /\
+    xtz_bought <= prev_state.(xtzPool)
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToXtz param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (not_updating & deadline_not_hit & ctx_amount_zero &
+              enough_xtz_bought & not_zero & to_not_contract &
+              xtz_bought_le_total).
+      unfold receive.
+      cbn.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:deadline_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:div_check; math_convert; try easy.
+      destruct_match eqn:min_xtz_check.
+      destruct_match eqn:xtz_pool_check; math_convert; try easy.
+      destruct_match eqn:transfer_act.
+      + eauto.
+      + unfold xtz_transfer in transfer_act.
+        now rewrite to_not_contract in transfer_act.
+      + now apply N.ltb_ge in enough_xtz_bought.
+      + now apply Z.ltb_ge in ctx_amount_zero.
+      + apply leb_correct_conv in deadline_not_hit.
+        now rewrite deadline_not_hit in deadline_check.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      math_convert.
+      rewrite leb_iff_conv,N.ltb_ge,Z.ltb_ge in *.
+      unfold xtz_transfer in *.
+      destruct_match in *;
+        try congruence.
+      now repeat split.
+  Qed.
+
+
+
+  (** ** Token to token correct *)
+  (** [token_to_token] only changes [tokenPool] and [xtzPool] in state *)
+  Lemma token_to_token_state_eq : forall prev_state new_state chain ctx new_acts param,
+    let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
+      prev_state<| tokenPool := prev_state.(tokenPool) + param.(tokensSold_) |>
+                <| xtzPool := prev_state.(xtzPool) - xtz_bought |> = new_state.
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  Lemma token_to_token_correct : forall prev_state new_state chain ctx new_acts param,
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
+      new_state.(tokenPool) = prev_state.(tokenPool) + param.(tokensSold_) /\
+      new_state.(xtzPool) = prev_state.(xtzPool) - ((param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997))).
+  Proof.
+    intros * receive_some.
+    apply token_to_token_state_eq in receive_some.
+    now subst.
+  Qed.
+
+  (** token_to_token should produce two actions
+  - A call action to token contract transferring [tokens_sold] from [sender] to this contract
+  - A call action to [outputDexterContract] [xtz_to_token] entrypoint with [xtz_bought] amount attached
+   *)
+  Lemma token_to_token_new_acts_correct : forall chain ctx prev_state new_state new_acts param,
+    let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
+    receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts) ->
+      new_acts =
+      [
+        (act_call prev_state.(tokenAddress) 0%Z
+          (serialize (FA2Token.msg_transfer
+          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold_) None])));
+        (act_call param.(outputDexterContract) (Z.of_N xtz_bought)
+          (serialize ((FA2Token.other_msg (XtzToToken
+          {| tokens_to := param.(to_);
+             minTokensBought := param.(minTokensBought_);
+             xtt_deadline := param.(ttt_deadline) |})))))
+      ].
+  Proof.
+    intros * receive_some.
+    receive_simpl.
+    now math_convert.
+  Qed.
+
+  (** If the requirements are met then then receive on token_to_token msg must succeed and
+      if receive on token_to_token msg succeeds then requirements must hold *)
+  Lemma token_to_token_is_some : forall prev_state chain ctx param,
+    let xtz_bought := (param.(tokensSold_) * 997 * prev_state.(xtzPool)) /
+                            (prev_state.(tokenPool) * 1000 + (param.(tokensSold_) * 997)) in
+    prev_state.(selfIsUpdatingTokenPool) = false /\
+    (current_slot chain < param.(ttt_deadline))%nat /\
+    (ctx.(ctx_amount) <= 0)%Z /\
+    xtz_bought <= prev_state.(xtzPool) /\
+    (prev_state.(tokenPool) <> 0 \/ param.(tokensSold_) <> 0)
+    <->
+    exists new_state new_acts, receive chain ctx prev_state (Some (FA2Token.other_msg (TokenToToken param))) = Some (new_state, new_acts).
+  Proof.
+    split.
+    - intros (not_updating & deadline_not_hit & ctx_amount_zero &
+              xtz_bought_le_total & not_zero).
+      unfold receive.
+      cbn.
+      destruct_match eqn:updating_check.
+      destruct_match eqn:amount_check.
+      destruct_match eqn:deadline_check.
+      destruct_match eqn:div_check; math_convert; try easy.
+      destruct_match eqn:xtz_pool_check; math_convert; try easy.
+      + apply leb_correct_conv in deadline_not_hit.
+        now rewrite deadline_not_hit in deadline_check.
+      + now apply Z.ltb_ge in ctx_amount_zero.
+      + now rewrite not_updating in updating_check.
+    - intros (new_state & new_acts & receive_some).
+      receive_simpl.
+      math_convert.
+      rewrite leb_iff_conv,Z.ltb_ge in *.
+      now repeat split.
+  Qed.
+
+
+
+  (** ** Init correct *)
+  Lemma init_state_eq : forall chain ctx setup state,
+    init chain ctx setup = Some state ->
+      state = {|
+        tokenPool := 0;
+        xtzPool := 0;
+        lqtTotal := setup.(lqtTotal_);
+        selfIsUpdatingTokenPool := false;
+        freezeBaker := false;
+        manager := setup.(manager_);
+        tokenAddress := setup.(tokenAddress_);
+        lqtAddress := null_address;
+        tokenId := setup.(tokenId_)
+      |}.
+  Proof.
+    intros * init_some.
+    now inversion init_some.
+  Qed.
+
+  Lemma init_correct : forall chain ctx setup state,
+    init chain ctx setup = Some state ->
+      tokenPool state = 0 /\
+      xtzPool state = 0 /\
+      lqtTotal state = setup.(lqtTotal_) /\
+      selfIsUpdatingTokenPool state = false /\
+      freezeBaker state = false /\
+      manager state = setup.(manager_) /\
+      tokenAddress state = setup.(tokenAddress_) /\
+      lqtAddress state = null_address /\
+      tokenId state = setup.(tokenId_).
+  Proof.
+    intros * init_some.
+    apply init_state_eq in init_some.
+    now subst.
+  Qed.
+
+  (** Initialization should always succeed *)
+  Lemma init_is_some : forall chain ctx setup,
+    exists state, init chain ctx setup = state.
+  Proof.
+    intros.
+    eauto.
+  Qed.
 
 End Theories.
-End Dexter.

--- a/extraction/Makefile
+++ b/extraction/Makefile
@@ -77,7 +77,7 @@ $(LIQUIDITY_SRC_DIR)/%.tz:
 test-ligo: clean-comiped-ligo $(LIGO_DIST)
 
 $(LIGO_SRC_DIR)/%.tz:
-	ligo compile-contract $(LIGO_SRC_DIR)/$*.mligo main --output-file=$@ --warn=false
+	ligo compile contract $(LIGO_SRC_DIR)/$*.mligo -e main -o $@ --warn false
 
 clean-comiped-ligo:
 	rm ./examples/extracted-code/cameligo-extract/tests/*.tz -f

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -48,6 +48,7 @@ theories/WcbvEvalAux.v
 
 -Q examples ConCert.Extraction.Examples
 examples/Ack.v
+examples/Dexter2Extract.v
 examples/BoardroomVotingExtractionCameLIGO.v
 examples/BoardroomVotingExtractionLiquidity.v
 examples/CameLIGOExtractionTests.v

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -48,7 +48,6 @@ theories/WcbvEvalAux.v
 
 -Q examples ConCert.Extraction.Examples
 examples/Ack.v
-examples/Dexter2Extract.v
 examples/BoardroomVotingExtractionCameLIGO.v
 examples/BoardroomVotingExtractionLiquidity.v
 examples/CameLIGOExtractionTests.v
@@ -56,6 +55,7 @@ examples/CounterCertifiedExtraction.v
 examples/CounterDepCertifiedExtraction.v
 examples/CounterSubsetTypes.v
 examples/CrowdfundingCertifiedExtraction.v
+examples/Dexter2Extract.v
 examples/ElmExtractExamples.v
 examples/ElmExtractTests.v
 examples/ElmForms.v

--- a/extraction/examples/CameLIGOExtractionTests.v
+++ b/extraction/examples/CameLIGOExtractionTests.v
@@ -30,7 +30,8 @@ Local Open Scope string_scope.
 Import MonadNotation.
 Open Scope Z.
 
-Definition PREFIX := "".
+Existing Instance PrintConfShortNames.PrintWithShortNames.
+
 Definition bindOptCont {A B} (a : option A) (f : A -> option B) : option B :=
   match a with
   | Some a => f a
@@ -77,7 +78,6 @@ Module SafeHead.
 
     Time MetaCoq Run
          (t <- CameLIGO_extract_single
-                PREFIX
                 safe_head_inline
                 TT_consts TT_ctors
                 ""
@@ -144,7 +144,6 @@ Module Counter.
 
         (* and a test address *)
         lmd_prelude := CameLIGOPrelude ++ nl
-                       ++ dummy_chain ++ nl
                        ++ "let test_account : address = (""tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"" : address)";
 
         (* initial storage *)
@@ -160,7 +159,7 @@ Module Counter.
 
         (* code for the entry point *)
         lmd_entry_point :=
-          CameLIGOPretty.printWrapper (PREFIX ++ "counter") "msg" "storage" ++ nl
+          CameLIGOPretty.printWrapper ("counter") "msg" "storage" ++ nl
           ++ CameLIGOPretty.printMain "storage" |}.
 
 End Counter.
@@ -179,10 +178,10 @@ Section CounterExtraction.
       It uses the certified erasure from [MetaCoq] and the certified deboxing procedure
       that removes application of boxes to constants and constructors. *)
 
-  (* NOTE: running computations inside [TemplateMonad] is quite slow. That's why we comment out this code and use a different way below *)
+  (** NOTE: running computations inside [TemplateMonad] is quite slow. That's why we comment out this code and use a different way below *)
 
   (* Time MetaCoq Run *)
-  (*     (t <- CameLIGO_extract PREFIX [] TT_remap_counter [] CameLIGO_call_ctx LIGO_COUNTER_MODULE ;; *)
+  (*     (t <- CameLIGO_extract [] TT_remap_counter [] CameLIGO_call_ctx LIGO_COUNTER_MODULE ;; *)
   (*       tmDefinition LIGO_COUNTER_MODULE.(lmd_module_name) t). *)
 
 
@@ -192,7 +191,7 @@ Section CounterExtraction.
   (** This command adds [cameLIGO_counter_prepared] to the environment,
       which can be evaluated later *)
   Time MetaCoq Run
-       (CameLIGO_prepare_extraction PREFIX [] TT_remap_counter [] "cctx_instance" LIGO_COUNTER_MODULE).
+       (CameLIGO_prepare_extraction [] TT_remap_counter TT_rename_ctors_default "cctx_instance" LIGO_COUNTER_MODULE).
 
   Time Definition cameLIGO_counter_1 := Eval vm_compute in cameLIGO_counter_prepared.
 
@@ -255,8 +254,6 @@ Defined.
       lmd_prelude :=
         CameLIGOPrelude
           ++ nl
-          ++ dummy_chain
-          ++ nl
           ++ nl
           ++ "let test_account : address = (""tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"" : address)"
           ++ nl
@@ -276,7 +273,7 @@ Defined.
 
       (* code for the entry point *)
       lmd_entry_point :=
-        "type storage = ((time_coq * (tez * address)) * ((address,tez) map * bool))" ++ CameLIGOPretty.printWrapper (PREFIX ++ "crowdfunding_receive")
+        "type storage = ((time_coq * (tez * address)) * ((address,tez) map * bool))" ++ CameLIGOPretty.printWrapper ("crowdfunding_receive")
                                     "msg_coq"
                                     "storage"
                                     ++ nl
@@ -313,14 +310,8 @@ Section CrowdfundingExtraction.
   ; remap <%% lookup_map' %%> "Map.find_opt"
   ].
 
-  Definition TT_rename_crowdfunding :=
-    [ ("mnil", "(Map.empty : (address,tez) map)")
-    ; ("true", "true")
-    ; ("false", "false")
-    ; ("tt", "()")].
-
   Time MetaCoq Run
-       (CameLIGO_prepare_extraction PREFIX [] TT_remap_crowdfunding TT_rename_crowdfunding "cctx_instance" CF_MODULE).
+       (CameLIGO_prepare_extraction [] TT_remap_crowdfunding TT_rename_ctors_default "cctx_instance" CF_MODULE).
 
   Time Definition cameLIGO_crowdfunding := Eval vm_compute in cameLIGO_crowdfunding_prepared.
 
@@ -411,17 +402,17 @@ Section EIP20TokenExtraction.
     ].
 
 
-  Definition TT_rename_eip20token :=
-    [ ("Z0" ,"0tez")
-    ; ("N0", "0")
-    ; ("N1", "1")
-    ; ("nil", "[]")
-    ; ("true", "true")
-    ; ("false", "false")
-    ; ("tt", "()") ].
+  (* Definition TT_rename_eip20token := *)
+  (*   [ ("Z0" ,"0tez") *)
+  (*   ; ("N0", "0") *)
+  (*   ; ("N1", "1") *)
+  (*   ; ("nil", "[]") *)
+  (*   ; ("true", "true") *)
+  (*   ; ("false", "false") *)
+  (*   ; ("tt", "()") ]. *)
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction PREFIX TT_inlines_eip20token TT_remap_eip20token TT_rename_eip20token "cctx_instance" LIGO_EIP20Token_MODULE).
+  (CameLIGO_prepare_extraction TT_inlines_eip20token TT_remap_eip20token TT_rename_ctors_default "cctx_instance" LIGO_EIP20Token_MODULE).
 
   Time Definition cameLIGO_eip20token := Eval vm_compute in cameLIGO_eip20token_prepared.
 

--- a/extraction/examples/Dexter2Extract.v
+++ b/extraction/examples/Dexter2Extract.v
@@ -1,0 +1,212 @@
+(** * Extraction of Dexter 2 to CameLIGO *)
+
+From Coq Require Import PeanoNat ZArith Notations.
+From Coq Require Import List Ascii String Bool.
+
+From MetaCoq.Template Require Import All.
+
+From ConCert.Embedding Require Import Notations.
+From ConCert.Embedding Require Import MyEnv CustomTactics.
+From ConCert.Embedding Require Import Notations.
+From ConCert.Extraction Require Import Common Optimize.
+From ConCert.Extraction Require Import CameLIGOPretty CameLIGOExtract.
+From ConCert.Execution Require Import Serializable.
+From ConCert.Execution Require Import Blockchain.
+From ConCert.Execution.Examples Require Dexter2CPMM.
+From ConCert.Execution Require Import Containers.
+From ConCert.Utils Require Import RecordUpdate.
+From ConCert.Utils Require Import StringExtra.
+
+From stdpp Require gmap.
+
+
+Local Open Scope string_scope.
+
+Import MonadNotation.
+Open Scope Z.
+
+(** Exposing a printing configuration *)
+Existing Instance PrintConfAddModuleNames.PrintWithModuleNames.
+
+Section Dexter2Extraction.
+
+  Context `{ChainBase}.
+
+  Import Dexter2CPMM.
+  Import RecordSetNotations.
+
+  Open Scope Z_scope.
+
+  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
+    let ctx_ := ctx in
+    Some {|
+        tokenPool := 0;
+        xtzPool := 0;
+        lqtTotal := setup.(lqtTotal_);
+        selfIsUpdatingTokenPool := false;
+        freezeBaker := false;
+        manager := setup.(manager_);
+        tokenAddress := setup.(tokenAddress_);
+        tokenId := setup.(tokenId_);
+        lqtAddress := null_address
+      |}.
+
+  Definition receive_ (chain : Chain)
+       (ctx : ContractCallContext)
+       (state : State)
+       (maybe_msg : option Msg)
+    : option (list ActionBody * State) :=
+    match receive chain ctx state maybe_msg with
+    | Some x => Some (x.2, x.1)
+    | None => None
+    end.
+  Close Scope Z_scope.
+
+  Definition call_to_token_ligo : string :=
+    <$ "let call_to_token (addr : address) (amt : nat) (msg : _msg) : operation =" ;
+       "  let token_ : _msg contract =";
+       "  match (Tezos.get_contract_opt (addr) : _msg contract option) with";
+       "    Some contract -> contract";
+       "  | None -> (failwith ""Contract not found."" : _msg contract) in";
+       "  Tezos.transaction msg (natural_to_mutez amt) token_" $>.
+
+  (** Next two definition are borrowed from the actual Dexter 2 implementation
+       https://gitlab.com/dexter2tz/dexter2tz/-/blob/master/dexter.mligo *)
+  Definition natural_to_mutez_ligo : string :=
+    "[@inline] let natural_to_mutez (a: nat): tez = a * 1mutez".
+
+  Definition mutez_to_natural_ligo : string :=
+    "[@inline] let mutez_to_natural (a: tez): nat = a / 1mutez".
+
+  (** We change the signature of the original definition slightly, so it takes a [nat] and converts
+      in to [tez]. We also return [operation option] instead of failing *)
+  Definition xtz_transfer_ligo : string :=
+    <$ "let xtz_transfer (to_ : address) (amount_ : nat) : operation option =";
+       "  match (Tezos.get_contract_opt to_ : unit contract option) with";
+       "    | None -> None";
+       "    | Some c -> Some (Tezos.transaction () (natural_to_mutez amount_) c)" $>.
+
+  Definition subNatTruncated_ligo : string :=
+    "let subNTruncated (n : nat) (m : nat) : nat = if n < m then 0n else abs (n-m)".
+
+  Definition LIGO_DEXTER2_MODULE : CameLIGOMod Msg ContractCallContext Setup State ActionBody :=
+  {| (* a name for the definition with the extracted code *)
+     lmd_module_name := "cameLIGO_dexter2" ;
+
+      (* definitions of operations on pairs and ints *)
+     lmd_prelude := CameLIGOPrelude ++ nl ++ nl ++
+                    <$ call_to_token_ligo;
+                       "";
+                       natural_to_mutez_ligo;
+                       "";
+                       mutez_to_natural_ligo;
+                       "";
+                       xtz_transfer_ligo;
+                       "";
+                       subNatTruncated_ligo $>;
+
+      (* initial storage *)
+      lmd_init := init ;
+
+      (* NOTE: printed as local [let]-bound definitions in the init *)
+      lmd_init_prelude := "";
+
+      (* TODO: maybe not needed, [lmd_prelude] should be enough *)
+      lmd_receive_prelude := "";
+
+      (* the main functionality *)
+      lmd_receive := receive_ ;
+
+      (* code for the entry point *)
+    lmd_entry_point := print_default_entry_point <%% @State %%>
+                                                 <%% @receive_ %%>
+                                                 <%% @Msg %%> |}.
+
+  Definition TT_remap_arith : list (kername * string) :=
+[   remap <%% Z %%> "int"
+  ; remap <%% N %%> "nat"
+  ; remap <%% nat %%> "nat"
+
+  ; remap <%% Nat.add %%> "addN"
+  ; remap <%% Nat.leb %%> "lebN"
+  ; remap <%% Nat.ltb %%> "ltbN"
+  ; remap <%% Nat.mul %%> "multN"
+
+  ; remap <%% Pos.add %%> "addN"
+  ; remap <%% Pos.sub %%> "subN"
+  ; remap <%% Pos.mul %%> "multN"
+  ; remap <%% Pos.leb %%> "leN"
+  ; remap <%% Pos.eqb %%> "eqN"
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.mul %%> "multInt"
+  ; remap <%% Z.div %%> "divInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z.eqb %%> "eqInt"
+  ; remap <%% Z.gtb %%> "gtbInt"
+  ; remap <%% Z.even %%> "evenInt"
+  ; remap <%% N.add %%> "addN"
+  ; remap <%% N.sub %%> "subNTruncated"
+  ; remap <%% N.mul %%> "multN"
+  ; remap <%% N.leb %%> "lebN"
+  ; remap <%% N.ltb %%> "ltbN"
+  ; remap <%% N.eqb %%> "eqN"
+  ; remap <%% Dexter2CPMM.div %%> "divN_opt"
+  ; remap <%% N.modulo %%> "moduloN"
+  ; remap <%% N.sub %%> "subOption"
+  ; remap <%% Z.to_N %%> "mutez_to_natural"
+  ; remap <%% Z.of_N %%> "z_of_N"
+  ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
+].
+
+  Definition TT_remap_dexter2 : list (kername * string) :=
+   [
+    remap <%% @ContractCallContext %%> CameLIGO_call_ctx_type_name
+  ; remap <%% @FMap %%> "map"
+  ; remap <%% @Common.AddressMap.add %%> "Map.add"
+  ; remap <%% @Common.AddressMap.find %%> "Map.find_opt"
+  ; remap <%% @Common.AddressMap.empty %%> "Map.empty"
+  ; remap <%% @FMap.add %%> "Map.add"
+  ; remap <%% @FMap.find %%> "Map.find_opt"
+  ; remap <%% @FMap.empty %%> "Map.empty"
+
+  ; remap <%% @call_to_token %%> "call_to_token"
+  ; remap <%% @call_to_other_token %%> "call_to_token"
+  ; remap <%% @xtz_transfer %%> "xtz_transfer"
+  ; remap <%% @call_liquidity_token %%> "call_to_token"
+  ; remap <%% token_id %%> "nat"
+
+  ; remap <%% @null_address %%> "(""tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU"" : address)"
+  ; remap <%% @Serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+  ; remap <%% @DexterMsg_serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+   ].
+
+  Definition TT_remap_all :=
+    (TT_remap_arith ++ TT_remap_dexter2)%list.
+
+  Definition TT_inlines_dexter2 : list kername :=
+    [
+      <%% Monads.Monad_option %%>
+    ; <%% @Monads.bind %%>
+    ; <%% @Monads.ret %%>
+    ; <%% @Extras.with_default %%>
+
+    ; <%% @SetterFromGetter %%> ].
+
+  Time MetaCoq Run
+  (CameLIGO_prepare_extraction TT_inlines_dexter2 TT_remap_all TT_rename_ctors_default "cctx_instance" LIGO_DEXTER2_MODULE).
+
+  (* Time MetaCoq Run *)
+  (* (CameLIGO_prepare_extraction [] TT_remap_dexter2 TT_rename_dexter2 "cctx_instance" LIGO_DEXTER2_MODULE). *)
+
+
+  Time Definition cameLIGO_dexter2 := Eval vm_compute in cameLIGO_dexter2_prepared.
+
+  MetaCoq Run (tmMsg cameLIGO_dexter2).
+
+  (** We redirect the extraction result for later processing and compiling with the CameLIGO compiler *)
+  (* Redirect "examples/extracted-code/cameligo-extract/dexter2CertifiedExtraction.mligo" *)
+  (* MetaCoq Run (tmMsg cameLIGO_dexter2). *)
+
+End Dexter2Extraction.

--- a/extraction/examples/Dexter2Extract.v
+++ b/extraction/examples/Dexter2Extract.v
@@ -167,7 +167,8 @@ Section Dexter2Extraction.
   ; remap <%% div %%> "divN_opt"
   ; remap <%% N.modulo %%> "moduloN"
   ; remap <%% N.sub %%> "subOption"
-  ; remap <%% Z.to_N %%> "mutez_to_natural"
+  ; remap <%% N_to_amount %%> "natural_to_mutez"
+  ; remap <%% amount_to_N %%> "mutez_to_natural"
   ; remap <%% Z.of_N %%> "z_of_N"
   ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
 ].

--- a/extraction/examples/EscrowExtract.v
+++ b/extraction/examples/EscrowExtract.v
@@ -40,7 +40,7 @@ Import CameLIGOPretty.
 Open Scope Z.
 Local Open Scope string_scope.
 
-Definition PREFIX := "".
+Existing Instance PrintConfShortNames.PrintWithShortNames.
 
 Definition escrow_init_wrapper (cctx : ContractCallContext) (s : Setup * Chain) : option State :=
     Examples.Escrow.init (snd s) cctx (fst s).
@@ -80,7 +80,7 @@ Module EscrowCameLIGOExtraction.
       lmd_receive_prelude := "";
       (* code for the entry point *)
       lmd_entry_point :=
-        printWrapper (PREFIX ++ "escrow_receive") (PREFIX ++"msg") "state" 
+        printWrapper "escrow_receive" "msg" "state" 
                      ++ nl
                      ++ CameLIGOPretty.printMain "state" |}.
 
@@ -110,7 +110,7 @@ Module EscrowCameLIGOExtraction.
     ].
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction PREFIX to_inline [] TT_rename_ligo "cctx_instance" ESCROW_MODULE_LIGO).
+  (CameLIGO_prepare_extraction to_inline [] TT_rename_ligo "cctx_instance" ESCROW_MODULE_LIGO).
 
   Time Definition cameLIGO_escrow := Eval vm_compute in cameligo_escrow_prepared.
 
@@ -120,6 +120,8 @@ Module EscrowCameLIGOExtraction.
 End EscrowCameLIGOExtraction.
 
 Module EscrowLiquidityExtraction.
+  Definition PREFIX := "".
+  
   From ConCert.Extraction Require Import LPretty LiquidityExtract.
   (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
 

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -29,8 +29,67 @@ Notation "f <| x" := (f x) (at level 32, left associativity, only parsing).
 Notation "x |> f" := (f x) (at level 31, left associativity, only parsing).
 (* i.e. x |> f |> g = (x |> f) |> g, and means g (f x) *)
 
+Class CameLIGOPrintConfig :=
+  { (* cosnstructors start with an uppercase letter *)
+    print_ctor_name : kername -> string;
 
-Section print_term.
+    (* types start with a lowercase letter  *)
+    print_type_name : kername -> string;
+
+    (* constants start with a lowercase letter *)
+    print_const_name : kername -> string }.
+
+(** Prepend the last module name all global declaration names to avoid name clashes.  Due
+    to limitations for constructors, use only part of the module name and cut the first
+    31 letters *)
+Module PrintConfAddModuleNames.
+
+  Definition last_module_name (mp : modpath) : string :=
+    match mp with
+    | MPdot mp' nm => nm
+    | MPfile (nm :: _) => nm
+    | _ => ""
+    end.
+
+  Definition print_ctor_name_ (kn : kername) :=
+    let lmn := last_module_name kn.1 in
+    let nm := kn.2 in
+    (* NOTE: CameLIGO has a limitation for the constructor name length, so we try our best to fit and don't get clashes *)
+    let ctor_name := if lmn =? "" then nm else substring 0 4 lmn ^ "_" ^ nm in
+    capitalize (substring 0 31 ctor_name).
+
+  Definition print_ind_type_name_ (ind_kn : kername) :=
+    let lmn := last_module_name ind_kn.1 in
+    let nm := ind_kn.2 in
+    let ty_name := if lmn =? "" then nm else lmn ^ "_" ^ nm in
+    uncapitalize ty_name.
+
+  Definition print_const_name_ (ind_kn : kername) :=
+    let lmn := last_module_name ind_kn.1 in
+    let nm := ind_kn.2 in
+    let ty_name := if lmn =? "" then nm else lmn ^ "_" ^ nm in
+    uncapitalize ty_name.
+  
+  Local Instance PrintWithModuleNames : CameLIGOPrintConfig :=
+    {| print_ctor_name := print_ctor_name_;
+       print_type_name := print_ind_type_name_;
+       print_const_name := print_const_name_ |}.
+
+End PrintConfAddModuleNames.
+
+(** Print names only, don't prepend module names or any other parts of the fully qualified path.
+    Gives more readable code, but might lead to name clashes *)
+Module PrintConfShortNames.
+
+  Local Instance PrintWithShortNames : CameLIGOPrintConfig :=
+    {| print_ctor_name := fun kn => capitalize kn.2;
+       print_type_name := fun kn => uncapitalize kn.2;
+       print_const_name := fun kn => uncapitalize kn.2 |}.
+
+End PrintConfShortNames.
+
+Section PPTerm.
+  Context `{CameLIGOPrintConfig}.
   Context (Σ : ExAst.global_env).
 
   Definition look (e : MyEnv.env string) (s : string) : option string :=
@@ -66,13 +125,17 @@ Section print_term.
                     | _ => []
                     end.
 
+  
   Fixpoint get_tapp_hd (bt : box_type) : box_type :=
     match bt with
     | TApp t1 t2 => get_tapp_hd t1
     | _ => bt
     end.
 
-  Definition print_box_type (prefix : string) (TT : env string)
+  Definition print_type_var (i : nat) :=
+        "'a" ++ string_of_nat i.
+
+  Definition print_box_type (TT : env string)
     : box_type -> string :=
     fix go  (bt : box_type) :=
   match bt with
@@ -91,60 +154,61 @@ Section print_term.
       else print_uncurried "" args ++ " " ++ go hd
     | _ => print_uncurried "" args ++ " " ++ go hd
     end
-  | TVar i => "a" ++ string_of_nat i (* TODO: pass context with type variables *)
+  | TVar i => print_type_var i (* TODO: pass context with type variables *)
   | TInd s =>
     let full_ind_name := string_of_kername s.(inductive_mind) in
-    uncapitalize (from_option (look TT full_ind_name) (prefix ++ s.(inductive_mind).2))
+    from_option (look TT full_ind_name)
+                (print_type_name s.(inductive_mind))
   | TConst s =>
     let full_cst_name := string_of_kername s in
-    uncapitalize (from_option (look TT full_cst_name) (prefix ++ s.2))
-
+    from_option (look TT full_cst_name) (print_type_name s)
   | TAny => "UnknownType"
   end.
 
-  Definition print_ctor_name (prefix : string) (nm : string) :=
-    capitalize (prefix ^ nm).
-
   Definition print_ctor
-             (prefix : string)
              (TT : env string)
+             (ind_kn : kername)
              (ctor : ident × list (name × box_type)) :=
     let (nm,tys) := ctor in
-    (* cameligo constructors must start with a capital letter *)
-    let nm := print_ctor_name prefix nm in
+    let nm := print_ctor_name (ind_kn.1, nm) in
     match tys with
     | [] => nm
-    | _ => let ctor_type := parens false <| concat " * " (map (print_box_type prefix TT ∘ snd) tys)
+    | _ => let ctor_type := parens false <| concat " * " (map (print_box_type TT ∘ snd) tys)
           in nm ^ " of " ^ ctor_type
     end.
 
-  Definition print_proj (prefix : string) (TT : env string) (proj : ident × box_type) : string :=
+  Definition print_proj (TT : env string) (proj : ident × box_type) : string :=
     let (nm, ty) := proj in
-    let nm := prefix ^ nm in
-    nm ^ " : " ^ print_box_type prefix TT ty.
+    nm ^ " : " ^ print_box_type TT ty.
 
-  Definition print_inductive (prefix : string) (TT : env string)
+  Definition print_type_params (vs : list type_var_info) : string :=
+    if (Nat.eqb #|vs| 0) then ""
+      else (let ps := concat "," (mapi (fun i _ => print_type_var i) vs) in
+            (parens (Nat.eqb #|vs| 1) ps ^ " ")).
+
+  Definition print_type_declaration (nm : string) (params : list type_var_info) (body : string) : string :=
+    "type " ^ print_type_params params ^ nm ^ " = " ^ body.
+  
+  Definition print_inductive (ind_kn : kername) (TT : env string)
              (oib : ExAst.one_inductive_body) :=
     let ind_nm := from_option (lookup TT oib.(ExAst.ind_name))
-                              (prefix ++ oib.(ExAst.ind_name)) in
-    let print_type_var (i : nat) :=
-        "'a" ++ string_of_nat i in
-    let params :=
-      if (Nat.eqb #|oib.(ind_type_vars)| 0) then ""
-      else let ps := concat "," (mapi (fun i _ => print_type_var i) oib.(ind_type_vars)) in
-           (parens (Nat.eqb #|oib.(ind_type_vars)| 1) ps) ++ " " in
+                              (print_type_name (ind_kn.1, oib.(ExAst.ind_name))) in
     (* one-constructor inductives are interpreted/printed as records *)
     match oib.(ExAst.ind_ctors), oib.(ExAst.ind_projs) with
     | [build_record_ctor], _::_ =>
       let '(_, ctors) := build_record_ctor in
       let projs_and_ctors := combine oib.(ExAst.ind_projs) ctors in
-      let projs_and_ctors_printed := map (fun '(p, (na, ty)) => print_proj prefix TT (p.1, ty)) projs_and_ctors in
-      "type " ++ params ++ uncapitalize ind_nm ++ " = {" ++ nl
-              ++ concat (";" ++ nl) projs_and_ctors_printed ++ nl
-              ++  "}"
-    | _,_ => "type " ++ params ++ uncapitalize ind_nm ++ " = "
-                   ++ nl ++ "  "
-                   ++ concat "| " (map (fun p => print_ctor prefix TT p ++ nl) oib.(ExAst.ind_ctors))
+      let projs_and_ctors_printed := map (fun '(p, (na, ty)) => print_proj TT (p.1, ty)) projs_and_ctors in
+      let body :=
+        <$ "{";
+             concat (";" ^ nl) projs_and_ctors_printed;
+           "}" $> in
+      print_type_declaration ind_nm oib.(ind_type_vars) body
+    | _,_ =>
+        let body :=
+          <$ "";
+             "  " ^ concat "| " (map (fun p => print_ctor TT ind_kn p ^ nl) oib.(ExAst.ind_ctors)) $> in
+        print_type_declaration ind_nm oib.(ind_type_vars) body
     end.
 
   Definition is_sort (t : Ast.term) :=
@@ -363,12 +427,12 @@ Section print_term.
         ++ nl
         ++ print_term (ctx ++ ctx' ++ ctx)%list true false (lam_body fdef.(dbody)).
 
-  Definition print_pat (prefix : string) (TT : env string) (ctor : string) (infix : bool) (pt : list string * string) :=
+  Definition print_pat (TT : env string) (ind_kn : kername) (ctor : string) (infix : bool) (pt : list string * string) :=
     let vars := rev pt.1 in
     if infix then
       concat (" " ++ ctor ++ " ") vars ++ " -> " ++ pt.2
     else
-      let ctor_nm := from_option (look TT ctor) (print_ctor_name prefix ctor) in
+      let ctor_nm := from_option (look TT ctor) (print_ctor_name (ind_kn.1, ctor)) in
       let ctor_nm := if ctor_nm =? "Pair" then "" else ctor_nm in
       let print_parens := (Nat.ltb 1 (List.length pt.1)) in
       print_uncurried ctor_nm vars ++ " -> " ++ pt.2.
@@ -411,8 +475,7 @@ Section print_term.
 
   (** ** The pretty-printer *)
 
-  (** [prefix] - a sting pre-pended to the constants' and constructors' names to avoid clashes
-      [FT] - list of fixpoint names. Used to determine if uncurrying is needed for an applied variable (if it corresponds to a recursive call). The initial value is an empty list. Once we fit a fixpoint case, we add the fixpoint name to [FT], so all the recursive calls in the fixpoint body are packed into a tuple.
+  (** [FT] - list of fixpoint names. Used to determine if uncurrying is needed for an applied variable (if it corresponds to a recursive call). The initial value is an empty list. Once we fit a fixpoint case, we add the fixpoint name to [FT], so all the recursive calls in the fixpoint body are packed into a tuple.
 
       [TT] - translation table allowing for remapping constants and constructors to CameLIGO primitives, if required.
 
@@ -423,8 +486,7 @@ Section print_term.
       [t] - a term to be printed.
    *)
 
-  Fixpoint print_term (prefix : string)
-                      (FT : list string)
+  Fixpoint print_term (FT : list string)
                       (TT : env string)
                       (ctx : context)
                       (top : bool)
@@ -448,30 +510,31 @@ Section print_term.
       let na' := fresh_name ctx na t in
       let (dom_tys, _) := ExAst.decompose_arr bt in
       let dom_ty := match nth_error dom_tys 0 with
-                    | Some ty => print_box_type prefix TT ty
+                    | Some ty => print_box_type TT ty
                     | None => "LambdaError(NotAnArrowType)"
                     end in
       parens top ("fun (" ++ string_of_name ctx na' ++ " : "
                           ++ dom_ty ++ ")"
-                          ++ " -> " ++ print_term prefix FT TT (vass na' :: ctx) true false body a)
+                          ++ " -> " ++ print_term  FT TT (vass na' :: ctx) true false body a)
     | tLetIn na def body => fun '(bt, (vala, bodya)) =>
       let na' := fresh_name ctx na t in
       parens top ("let " ++ string_of_name ctx na' ++
-                        " = " ++ print_term prefix FT TT ctx true false def vala ++ " in " ++ nl ++
-                        print_term prefix FT TT (vdef na' def :: ctx) true false body bodya)
+                        " = " ++ print_term  FT TT ctx true false def vala ++ " in " ++ nl ++
+                        print_term  FT TT (vdef na' def :: ctx) true false body bodya)
     | tApp f l as t => fun '(bt, (fa, la)) =>
       let is_not_empty_const := fun t =>
         match t with
         | tApp t1 (tConst c as t2) =>
           let cst_name := string_of_kername c in
-          let nm := from_option (look TT cst_name) (prefix ++ c.2) in
+          let nm := from_option (look TT cst_name) c.2 in
           if nm =? "" then false
           else true
         | _ => true end in
-      let apps := rev (app_args_annot_empty_filtered (fun '(t; a) => print_term prefix FT TT ctx false false t a) (fun '(t';_) => is_not_empty_const t') t (bt, (fa, la))) in
+      (* FIXME: remove filtering of the arguments *)
+      let apps := rev (app_args_annot_empty_filtered (fun '(t; a) => print_term  FT TT ctx false false t a) (fun '(t';_) => is_not_empty_const t') t (bt, (fa, la))) in
       let '((b;ba),argas) := Edecompose_app_annot f fa in
       match apps with
-      | [] => print_term prefix FT TT ctx false true f fa
+      | [] => print_term  FT TT ctx false true f fa
       | _ =>
         match b with
           (* if the variable corresponds to a fixpoint, we pack the arguments into a tuple *)
@@ -481,27 +544,17 @@ Section print_term.
             let nm := (string_of_name ctx d.(decl_name)) in
             if List.in_dec String.string_dec nm FT
             then parens top (print_uncurried nm apps)
-            else parens (top || inapp) (print_term prefix FT TT ctx false true f fa ++ " " ++ print_term prefix FT TT ctx false false l la)
+            else parens (top || inapp) (print_term  FT TT ctx false true f fa ++ " " ++ print_term  FT TT ctx false false l la)
           | None => "UnboundRel(" ++ string_of_nat i ++ ")"
           end
         | tConst c =>
           let cst_name := string_of_kername c in
-          let nm := from_option (look TT cst_name) (prefix ++ c.2) in
+          let nm := from_option (look TT cst_name) (print_const_name c) in
           (* primitive projections instead of 'fst' and 'snd' *)
           if nm =? "fst" then
             (concat " " (map (parens true) apps)) ++ ".0"
           else if nm =? "snd" then
             (concat " " (map (parens true) apps)) ++ ".1"
-          (* Map Chain fields to record projections *)
-          else if (nm =? "chain_height") || (nm =? "current_slot") || (nm =? "finalized_height")  then
-            (concat " " (map (parens true) apps)) ++ "." ++ nm
-          (* ContractCallContext remappings *)
-          else if (nm =? "ctx_from") then
-            "Tezos.sender"
-          else if (nm =? "ctx_contract_address") then
-            "Tezos.self_address"
-          else if (nm =? "ctx_amount") then
-            "Tezos.amount"
           else parens (top || inapp) (nm ++ " " ++ (concat " " (map (parens true) apps)))
         | tConstruct (mkInd mind j as ind) i =>
           let nm := get_constr_name ind i in
@@ -526,24 +579,24 @@ Section print_term.
                   let projs_and_apps := combine (map fst oib.(ExAst.ind_projs)) apps in 
                   let field_decls_printed := projs_and_apps |> map (fun '(proj, e) => proj ++ " = " ++ e)
                                                           |> concat "; " in
-                  "({" ++ field_decls_printed ++ "}: " ++ print_box_type prefix TT bt ++ ")"
+                  "({" ++ field_decls_printed ++ "}: " ++ print_box_type  TT bt ++ ")"
                 | _,_ => 
                   (* constructors must be capitalized *)
-                  let nm' := from_option (look TT nm) (print_ctor_name prefix nm) in
+                  let nm' := from_option (look TT nm) (print_ctor_name (mind.1, nm)) in
                   parens top (print_uncurried nm' apps)
                 end
               end
         | _ => if is_not_empty_const l then
-                parens (top || inapp) (print_term prefix FT TT ctx false true f fa ++ " " ++ print_term prefix FT TT ctx false false l la)
-               else print_term prefix FT TT ctx false true f fa
+                parens (top || inapp) (print_term  FT TT ctx false true f fa ++ " " ++ print_term  FT TT ctx false false l la)
+               else print_term  FT TT ctx false true f fa
         end
       end
     | tConst c => fun bt =>
       let cst_name := string_of_kername c in
-      let nm_tt := from_option (look TT cst_name) (prefix ++ c.2) in
+      let nm_tt := from_option (look TT cst_name) (print_const_name c) in
       (* empty maps require type annotations *)
       if (nm_tt =? "Map.empty") || (nm_tt =? "AddressMap.empty") then
-        "(Map.empty: " ++ print_box_type prefix TT bt ++ ")"
+        "(Map.empty: " ++ print_box_type  TT bt ++ ")"
       else
         nm_tt
     | tConstruct ind l => fun bt =>
@@ -551,12 +604,12 @@ Section print_term.
       match print_num_literal TT t with
       | Some lit => lit
       | None =>
-        let nm_tt := from_option (look TT nm) (print_ctor_name prefix nm) in
+        let nm_tt := from_option (look TT nm) (print_ctor_name (ind.(inductive_mind).1, nm)) in
      (* NOTE: print annotations for 0-ary constructors of polymorphic types (like [], None, and Map.empty) *)
         if (uncapitalize nm =? "nil") && (eq_kername ind.(inductive_mind) <%% list %%>) then
-        "([]:" ++ print_box_type prefix TT bt ++ ")"
+        "([]:" ++ print_box_type  TT bt ++ ")"
         else if (nm =? "None") && (eq_kername ind.(inductive_mind) <%% option %%>) then
-               "(" ++ nm_tt ++ ":" ++ print_box_type prefix TT bt ++ ")"
+               "(" ++ nm_tt ++ ":" ++ print_box_type  TT bt ++ ")"
              else nm_tt
       end
     | tCase (mkInd mind i as ind, nparam) t brs =>
@@ -571,20 +624,20 @@ Section print_term.
               (* Assuming all case-branches have been expanded this should never happen: *)
               | t => fun btt => (params , "ERROR: unexpected wildcard branch - currently not supported")
             end
-            | 0 => fun bt => (params , print_term prefix FT TT ctx false false br bt)
+            | 0 => fun bt => (params , print_term FT TT ctx false false br bt)
             end in
 
       match brs with
-      | [] => fun '(bt, (ta, trs)) => (parens false ("failwith 0 : " ^ print_box_type prefix TT bt) ^ " (* absurd case *)")
+      | [] => fun '(bt, (ta, trs)) => (parens false ("failwith 0 : " ^ print_box_type  TT bt) ^ " (* absurd case *)")
       | _ =>
         (* [if-then-else] is a special case *)
         if eq_kername mind <%% bool %%> then
           match brs with
           | [b1;b2] => fun '(bt, (ta, (b1a, (b2a, _)))) =>
             parens top
-                    ("if " ++ print_term prefix FT TT ctx true false t ta
-                           ++ " then " ++ print_term prefix FT TT ctx true false (snd b1) b1a
-                           ++ " else " ++ print_term prefix FT TT ctx true false (snd b2) b2a)
+                    ("if " ++ print_term  FT TT ctx true false t ta
+                           ++ " then " ++ print_term  FT TT ctx true false (snd b1) b1a
+                           ++ " else " ++ print_term  FT TT ctx true false (snd b2) b2a)
           | _ => fun bt => "Error (Malformed pattern-mathing on bool: given "
                    ++ string_of_nat (List.length brs) ++ " branches " ++ ")"
           end
@@ -601,14 +654,14 @@ Section print_term.
               print_list (fun '(b, (na, _)) =>
                             (* [list] is a special case *)
                             if (eq_kername mind <%% list %%>) && (na =? "cons") then
-                              print_pat prefix TT "::" true b
-                            else if (eq_kername mind <%% list %%>) && (na =? "nil") then
-                              print_pat "" TT "[]" false b
+                              print_pat  TT mind "::" true b
+                            (* else if (eq_kername mind <%% list %%>) && (na =? "nil") then *)
+                            (*   print_pat "" TT mind "[]" false b *)
                             else
-                            print_pat prefix TT na false b)
+                            print_pat TT mind na false b)
                          (nl ++ " | ") brs_ in
            parens top
-                  ("match " ++ print_term prefix FT TT ctx true false t ta
+                  ("match " ++ print_term  FT TT ctx true false t ta
                             ++ " with " ++ nl
                             ++ brs_printed)
         | None =>
@@ -620,19 +673,19 @@ Section print_term.
       match lookup_ind_decl mind i with
       | Some oib =>
         match nth_error oib.(ExAst.ind_projs) k with
-        | Some (na, _) => print_term prefix FT TT ctx false false c bt.2 ++ "." ++ na
+        | Some (na, _) => print_term  FT TT ctx false false c bt.2 ++ "." ++ na
         | None => "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ","
-                  ++ print_term prefix FT TT ctx true false c bt.2 ++ ")"
+                  ++ print_term  FT TT ctx true false c bt.2 ++ ")"
         end
       | None =>
         "UnboundProj(" ++ string_of_inductive ind ++ "," ++ string_of_nat i ++ "," ++ string_of_nat k ++ ","
-                       ++ print_term prefix FT TT ctx true false c bt.2 ++ ")"
+                       ++ print_term  FT TT ctx true false c bt.2 ++ ")"
       end
     | tFix [fix_decl] n => fun '(bt, (fixa, _)) => (* NOTE: We assume that the fixpoints are not mutual *)
         (* Given an arrow type, prints the arguments in a curried way *)
-        let print_args_curried prefix TT ctx bt args :=
+        let print_args_curried  TT ctx bt args :=
           let (tys,_) := decompose_arr bt  in
-          let targs := combine args (map (print_box_type prefix TT) tys) in
+          let targs := combine args (map (print_box_type  TT) tys) in
           targs
             |> map (fun '(x,ty) => parens false (string_of_name ctx x ++ " : " ++ ty) )
             |> concat " " in
@@ -641,7 +694,7 @@ Section print_term.
         let '(args, (lam_body; body_annot)) := Edecompose_lam_annot body fixa in
 
         let sargs := map (string_of_name ctx) args in
-        let sargs_typed := print_args_curried prefix TT ctx bt args in
+        let sargs_typed := print_args_curried  TT ctx bt args in
         let fix_call :=
             "fun " ++ sargs_typed ++ " -> "
                    ++ print_uncurried fix_name sargs in
@@ -655,13 +708,13 @@ Section print_term.
           let '(args,(lam_body; body_annot)) := Edecompose_lam_annot (fdef.(dbody)) btt in
           let ctx := rev (map vass args) in
           let sargs := map (string_of_name ctx) args in
-          let tys_printed := map (print_box_type prefix TT) tys in
+          let tys_printed := map (print_box_type  TT) tys in
           let sargs_uncurried := parens false (concat ", " sargs ++ " : " ++ concat " * " tys_printed) in
-          let ret_ty_printed := print_box_type prefix TT ret_ty in
+          let ret_ty_printed := print_box_type  TT ret_ty in
               string_of_name ctx fdef.(dname) ++ " " ++ sargs_uncurried  ++
               " : " ++ ret_ty_printed ++ " = "
               ++ nl
-              ++ lam_body_annot_cont (fun body body_annot => print_term prefix FT' TT (ctx ++ ctx' ++ ctx)%list true false body body_annot) fdef.(dbody) btt
+              ++ lam_body_annot_cont (fun body body_annot => print_term  FT' TT (ctx ++ ctx' ++ ctx)%list true false body body_annot) fdef.(dbody) btt
         in
         parens top ("let rec " ++ print_def_annot ctx fix_decl fixa ++ nl ++
                                " in " ++ fix_call)
@@ -671,334 +724,341 @@ Section print_term.
     | tPrim _ => fun _ => "NotSupportedCoqPrimitive"
   end.
 
-End print_term.
+End PPTerm.
 
-Fixpoint get_fix_names (t : term) : list name :=
-  match t with
-  | tEvar _ args => List.concat (map get_fix_names args)
-  | tLambda _ b => get_fix_names b
-  | tLetIn _ t1 t2 => get_fix_names t1 ++ get_fix_names t2
-  | tApp t1 t2 => get_fix_names t1 ++ get_fix_names t2
-  | tCase _ t1 brs => get_fix_names t1
-                        ++ List.concat (map (get_fix_names ∘ snd) brs)
-  | tProj _ t1 => get_fix_names t1
-  | tFix mfix _ => map dname mfix ++ List.concat (map (get_fix_names ∘ dbody) mfix)
-  | tCoFix mfix _ => map dname mfix ++ List.concat (map (get_fix_names ∘ dbody) mfix)
-  | _ => []
-  end.
+Section PPLigo.
 
-Definition print_decl (prefix : string)
-           (TT : MyEnv.env string) (* translation table *)
-           (env : ExAst.global_env)
-           (decl_name : string)
-           (modifier : option string)
-           (wrap : string -> string)
-           (ty : box_type)
-           (t : term)
-           (ta : annots box_type t)
-            :=
-  let (tys,_) := decompose_arr ty in
-  let '(args,(lam_body; body_annot)) := Edecompose_lam_annot t ta in
-  let (ctx, args) := fresh_names [] args in
-  let targs := combine args (map (print_box_type prefix TT) tys) in
-  let printed_targs :=
-      map (fun '(x,ty) => parens false (string_of_name ctx x ++ " : " ++ ty)) targs in
-  let decl := prefix ++ decl_name ++ " " ++ concat " " printed_targs in
-    "let" ++ " " ++ decl ++ " = "
-          ++ wrap (CameLIGOPretty.print_term env prefix [] TT ctx true false lam_body body_annot).
+  Context `{CameLIGOPrintConfig}.
 
-Definition print_init (prefix : string)
-           (TT : MyEnv.env string) (* translation table *)
-           (build_call_ctx : string) (* a string that corresponds to a call contex *)
-           (init_prelude : string) (* operations available in the [init] as local definitions.
-                                      CameLIGO does not allow to refer to global definitions in [init]*)
-           (env : ExAst.global_env)
-           (cst : ExAst.constant_body)
-           : (constant_body_annots box_type cst) -> option string :=
+  Definition print_decl
+             (TT : MyEnv.env string) (* translation table *)
+             (env : ExAst.global_env)
+             (decl_kn : kername)
+             (wrap : string -> string)
+             (ty : box_type)
+             (t : term)
+             (ta : annots box_type t)
+    :=
+    let (tys,_) := decompose_arr ty in
+    let '(args,(lam_body; body_annot)) := Edecompose_lam_annot t ta in
+    let (ctx, args) := fresh_names [] args in
+    let targs := combine args (map (print_box_type TT) tys) in
+    let printed_targs :=
+        map (fun '(x,ty) => parens false (string_of_name ctx x ++ " : " ++ ty)) targs in
+    let decl := print_const_name decl_kn ++ concat " " printed_targs in
+      "let" ++ " " ++ decl ++ " = "
+            ++ wrap (print_term env [] TT ctx true false lam_body body_annot).
+
+  Definition print_init
+             (TT : MyEnv.env string) (* translation table *)
+             (build_call_ctx : string) (* a string that corresponds to a call contex *)
+             (init_prelude : string) (* operations available in the [init] as local definitions.
+                                        CameLIGO does not allow to refer to global definitions in [init]*)
+             (env : ExAst.global_env)
+             (cst : ExAst.constant_body)
+             : (constant_body_annots box_type cst) -> option string :=
+      match cst.(ExAst.cst_body) as body return match body with
+                                                | Some body => annots box_type body
+                                                | None => unit
+                                                end -> option string with
+      | Some b => fun cstAnnot =>
+      let '(args,(lam_body; body_annot)) := Edecompose_lam_annot b cstAnnot in
+      let ty := cst.(ExAst.cst_type) in
+      let (tys,inner_ret_ty) := decompose_arr ty.2 in
+      let targs_inner := combine args (map (print_box_type TT) tys) in
+      let ctx := map (fun x => Build_context_decl x None) (rev args) in
+      let printed_targs_inner :=
+          map (fun '(x,ty) => parens false (string_of_name ctx x ++ " : " ++ ty)) targs_inner in
+      let decl_inner := "inner " ++ concat " " printed_targs_inner in
+      let printed_inner_ret_ty := print_box_type TT inner_ret_ty in
+      let printed_outer_ret_ty :=
+        match inner_ret_ty with
+        | TApp (TInd ind) t1 =>
+          if eq_kername <%% option %%> ind.(inductive_mind) then
+            print_box_type TT t1
+          else print_box_type TT inner_ret_ty
+        | _ => print_box_type TT inner_ret_ty
+        end in
+      let wrap t :=
+        "match " ++ t ++ " with" ++ nl ++
+        "  Some v -> v"++ nl ++
+        "| None -> (failwith (""""): " ++ printed_outer_ret_ty ++ ")" in
+      let let_inner :=
+          "let " ++ decl_inner ++ " :" ++ printed_inner_ret_ty ++ " = " ++ nl
+                ++ print_term env [] TT ctx true false lam_body body_annot
+                ++ " in" in
+      (* if init takes no parameters, we give it a unit parameter  *)
+      let printed_targs_outer := match printed_targs_inner with
+                                 | _::[] | [] => let arg_name := fresh_name ctx nAnon tBox in
+                                         [parens false (string_of_name ctx arg_name ++ " : unit")]
+                                 | _::xs => xs
+                                 end in
+      (* ignore the first argument because it's a call context *)
+      let decl_outer :=
+        "init " ++ concat " " printed_targs_outer ++ " : " ++ printed_outer_ret_ty in
+      let let_ctx := "let ctx = " ++ build_call_ctx ++ " in" in
+      let inner_app := "inner " ++ concat " " ( "ctx" :: map (string_of_name ctx) (tl args)) in
+      let init_args_ty := "type init_args_ty = " ++
+        match tys with
+        | _::[] => "unit"
+        | [] => "unit"
+        | _::_ => tl tys |> map (print_box_type TT)
+                         |> concat " * "
+      end in
+      let init_wrapper_args_printed tys :=
+        match tys with
+        | [] => "()"
+        | [ty] => " args"
+        | tys => tys |> fold_right (fun _ '(i,s) => (i+1,s ++ " args." ++ string_of_nat i)) (0, "")
+                     |> snd
+        end in
+      let init_wrapper :=
+           "let init_wrapper (args : init_args_ty) ="
+        ++ nl
+        ++ "  init" ++ (tl tys |> init_wrapper_args_printed) in
+      ret ("let " ++ decl_outer ++ " = "
+                      ++ nl
+                      ++ init_prelude
+                      ++ nl
+                      ++ let_inner
+                      ++ nl
+                      ++ let_ctx
+                      ++ nl
+                      ++ wrap (parens false inner_app)
+                      ++ nl
+                      ++ init_args_ty
+                      ++ nl
+                      ++ init_wrapper
+                      ++ nl)
+    | None => fun _ => None
+    end.
+
+  Definition print_cst
+             (TT : MyEnv.env string) (* translation table *)
+             (env : ExAst.global_env)
+             (kn : kername)
+             (cst : ExAst.constant_body)
+             : (constant_body_annots box_type cst) -> option string :=
     match cst.(ExAst.cst_body) as body return match body with
                                               | Some body => annots box_type body
                                               | None => unit
                                               end -> option string with
-    | Some b => fun cstAnnot =>
-    let '(args,(lam_body; body_annot)) := Edecompose_lam_annot b cstAnnot in
-    let ty := cst.(ExAst.cst_type) in
-    let (tys,inner_ret_ty) := decompose_arr ty.2 in
-    let targs_inner := combine args (map (print_box_type prefix TT) tys) in
-    let ctx := map (fun x => Build_context_decl x None) (rev args) in
-    let printed_targs_inner :=
-        map (fun '(x,ty) => parens false (string_of_name ctx x ++ " : " ++ ty)) targs_inner in
-    let decl_inner := "inner " ++ concat " " printed_targs_inner in
-    let printed_inner_ret_ty := print_box_type prefix TT inner_ret_ty in
-    let printed_outer_ret_ty :=
-      match inner_ret_ty with
-      | TApp (TInd ind) t1 =>
-        if eq_kername <%% option %%> ind.(inductive_mind) then
-          print_box_type prefix TT t1
-        else print_box_type prefix TT inner_ret_ty
-      | _ => print_box_type prefix TT inner_ret_ty
-      end in
-    let wrap t :=
-      "match " ++ t ++ " with" ++ nl ++
-      "  Some v -> v" ++ nl ++
-      "| None -> (failwith (""""): " ++ printed_outer_ret_ty ++ ")" in
-    let let_inner :=
-        "let " ++ decl_inner ++ " :" ++ printed_inner_ret_ty ++ " = " ++ nl
-              ++ CameLIGOPretty.print_term env prefix [] TT ctx true false lam_body body_annot
-              ++ " in" in
-    (* if init takes no parameters, we give it a unit parameter  *)
-    let printed_targs_outer := match printed_targs_inner with
-                               | _::[] | [] => let arg_name := fresh_name ctx nAnon tBox in
-                                       [parens false (string_of_name ctx arg_name ++ " : unit")]
-                               | _::xs => xs
-                               end in
-    (* ignore the first argument because it's a call context *)
-    let decl_outer :=
-      "init " ++ concat " " printed_targs_outer ++ " : " ++ printed_outer_ret_ty in
-    let let_ctx := "let ctx = " ++ build_call_ctx ++ " in" in
-    let inner_app := "inner " ++ concat " " ( "ctx" :: map (string_of_name ctx) (tl args)) in
-    let init_args_ty := "type init_args_ty = " ++
-      match tys with
-      | _::[] => "unit"
-      | [] => "unit"
-      | _::_ => tl tys |> map (print_box_type prefix TT)
-                       |> concat " * "
-    end in
-    let init_wrapper_args_printed tys :=
-      match tys with
-      | [] => "()"
-      | [ty] => " args"
-      | tys => tys |> fold_right (fun _ '(i,s) => (i+1,s ++ " args." ++ string_of_nat i)) (0, "")
-                   |> snd
-      end in
-    let init_wrapper :=
-         "let init_wrapper (args : init_args_ty) ="
-      ++ nl
-      ++ "  init" ++ (tl tys |> init_wrapper_args_printed) in
-    ret ("let " ++ decl_outer ++ " = "
-                    ++ nl
-                    ++ init_prelude
-                    ++ nl
-                    ++ let_inner
-                    ++ nl
-                    ++ let_ctx
-                    ++ nl
-                    ++ wrap (parens false inner_app)
-                    ++ nl
-                    ++ init_args_ty
-                    ++ nl
-                    ++ init_wrapper
-                    ++ nl)
-  | None => fun _ => None
+    | Some cst_body => fun annot =>
+      (* NOTE: ignoring the path part *)
+      Some <| print_decl TT env kn id cst.(ExAst.cst_type).2 cst_body annot
+    | None => fun _ => None
+    end.
+
+  (* A wrapper type to separate declarations into type declarations ("type ... = ...")
+     and constant declarations ("let x = ...") *)
+  Inductive Decl a : Type :=
+    | TyDecl : a -> Decl a
+    | ConstDecl : a -> Decl a.
+  Global Arguments TyDecl {_}.
+  Global Arguments ConstDecl {_}.
+
+  Definition print_global_decl (TT : MyEnv.env string)
+             (nm : kername)
+             (env : ExAst.global_env)
+             (d : ExAst.global_decl) :
+             (global_decl_annots box_type d) -> Decl (kername * string) :=
+    match d return (global_decl_annots box_type d) -> Decl (kername * string) with
+    | ExAst.ConstantDecl cst => fun annot =>
+      match print_cst TT env nm cst annot with
+      | Some r => ConstDecl (nm, r)
+      | None =>  ConstDecl (nm, "print_global_decl ConstantDecl ERROR: " ++ string_of_kername nm)
+      end
+    | ExAst.InductiveDecl mib as d => fun annot =>
+      match mib.(ExAst.ind_bodies) with
+      | [oib] => TyDecl (nm, print_inductive nm TT oib)
+      | _ => TyDecl (nm,"Only non-mutual inductives are supported; " ++ string_of_kername nm)
+      end
+    | TypeAliasDecl (Some (params, ty)) => fun annot =>
+      let ta_nm := from_option (lookup TT (string_of_kername nm)) (print_type_name nm) in
+      TyDecl (nm, print_type_declaration ta_nm params (print_box_type TT ty))
+    | TypeAliasDecl None => fun _ => TyDecl (nm, "")
   end.
 
-Definition print_cst (prefix : string)
-           (TT : MyEnv.env string) (* translation table *)
-           (env : ExAst.global_env)
-           (kn : kername)
-           (cst : ExAst.constant_body)
-           : (constant_body_annots box_type cst) -> option string :=
-  match cst.(ExAst.cst_body) as body return match body with
-                                            | Some body => annots box_type body
-                                            | None => unit
-                                            end -> option string with
-  | Some cst_body => fun annot =>
-    (* NOTE: ignoring the path part *)
-    let (_, decl_name) := kn in
-    Some <| print_decl prefix TT env decl_name None id cst.(ExAst.cst_type).2 cst_body annot
-  | None => fun _ => None
-  end.
+  Fixpoint print_global_env (TT : MyEnv.env string)
+             (env : ExAst.global_env)
+             : (env_annots box_type env) -> list (Decl (kername * string)) :=
+    match env return (env_annots box_type env) -> list (Decl (kername * string)) with
+    | (kn, has_deps, decl) :: env' =>
+      fun '(a,b) =>
+        (* Filtering out empty type declarations *)
+        (* TODO: possibly, move to extraction (requires modifications of the correctness proof) *)
+        if is_empty_type_decl decl then print_global_env TT env' b
+        else
+          let printed :=
+          (* only print decls for which the environment includes dependencies *)
+          if has_deps then
+            print_global_decl TT kn env' decl a
+          else ConstDecl (kn, "") in
+      printed :: print_global_env TT env' b
+    | [] => fun _ => []
+    end.
 
-(* Wrapper type to separate declarations into type declarations ("type ... = ...")
-   and constant declarations ("let x = ...") *)
-Inductive Decl a : Type :=
-  | TyDecl : a -> Decl a
-  | ConstDecl : a -> Decl a.
-Arguments TyDecl {_}.
-Arguments ConstDecl {_}.
+  Local Open Scope string_scope.
 
-Definition print_global_decl (prefix : string) (TT : MyEnv.env string)
-           (nm : kername)
-           (env : ExAst.global_env)
-           (d : ExAst.global_decl) :
-           (global_decl_annots box_type d) -> Decl (kername * string) :=
-  match d return (global_decl_annots box_type d) -> Decl (kername * string) with
-  | ExAst.ConstantDecl cst => fun annot =>
-    match print_cst prefix TT env nm cst annot with
-    | Some r => ConstDecl (nm, r)
-    | None =>  ConstDecl (nm, "print_global_decl ConstantDecl ERROR?")
-    end
-  | ExAst.InductiveDecl mib as d => fun annot =>
-    match mib.(ExAst.ind_bodies) with
-    | [oib] => TyDecl (nm, print_inductive prefix TT oib)
-    | _ => TyDecl (nm,"Only non-mutual inductives are supported; " ++ string_of_kername nm)
-    end
-  | TypeAliasDecl (Some (params, ty)) => fun annot =>
-    let ta_nm := from_option (lookup TT (string_of_kername nm))
-                             (prefix ++ nm.2) in
-    TyDecl (nm, "type " ++ uncapitalize ta_nm ++ concat " " (map ((string_of_name []) ∘ tvar_name) params) ++  " = "
-            ++ print_box_type prefix TT ty)
-  | TypeAliasDecl None => fun _ => TyDecl (nm, "")
-end.
+  (** We un-overload operations and add definitions that are more convenient to use during the pretty-printing phase. These part should be included when printing contracts that use the corresponding operations. *)
 
-Fixpoint print_global_env (prefix : string) (TT : MyEnv.env string)
-           (env : ExAst.global_env)
-           : (env_annots box_type env) -> list (Decl (kername * string)) :=
-  match env return (env_annots box_type env) -> list (Decl (kername * string)) with
-  | (kn, has_deps, decl) :: env' =>
-    fun '(a,b) =>
-      (* Filtering out empty type declarations *)
-      (* TODO: possibly, move to extraction (requires modifications of the correctness proof) *)
-      if is_empty_type_decl decl then print_global_env prefix TT env' b
-      else
-        let printed :=
-        (* only print decls for which the environment includes dependencies *)
-        if has_deps then
-          print_global_decl prefix TT kn env' decl a
-        else ConstDecl (kn, "") in
-    printed :: print_global_env prefix TT env' b
-  | [] => fun _ => []
-  end.
+  Definition int_ops :=
+    <$
+    "[@inline] let addInt (i : int) (j : int) = i + j" ;
+    "[@inline] let subInt (i : int) (j : int) = i - j" ;
+    "[@inline] let subIntTruncated (a : int) (b : int) = let res = a - b in if res < 0 then 0 else res" ;
+    "[@inline] let multInt (i : int) (j : int) = i * j" ;
+    "[@inline] let divInt (i : int) (j : int) = i / j" ;
+    "[@inline] let modInt (a : int)(b : int) : int = int (a mod b)" ;
+    "[@inline] let leInt (i : int) (j : int) = i <= j" ;
+    "[@inline] let ltInt (i : int) (j : int) = i < j" ;
+    "[@inline] let eqInt (i : int) (j : int) = i = j"
+    $>.
 
+  Definition tez_ops :=
+    <$
+    "[@inline] let addTez (n : tez) (m : tez) = n + m" ;
+    "[@inline] let subTez (n : tez) (m : tez) = n - m" ;
+    "[@inline] let leTez (a : tez ) (b : tez ) = a <= b" ;
+    "[@inline] let ltTez (a : tez ) (b : tez ) =  a < b" ;
+    "[@inline] let gtbTez (a : tez ) (b : tez ) =  a > b" ;
+    "[@inline] let eqTez (a : tez ) (b : tez ) = a = b" ;
+    "[@inline] let natural_to_mutez (a: nat): tez = a * 1mutez" ;
+    "[@inline] let divTez (a : tez) (b : tez) : tez = natural_to_mutez (a/b)" ;
+    "[@inline] let multTez (n : tez) (m : tez) = (n/1tez) * m";
+    "[@inline] let evenTez (i : tez) = (i mod 2n) = 0tez"
+    $>.
+  Definition nat_ops :=
+    <$
+    "[@inline] let addN (a : nat ) (b : nat ) = a + b" ;
+    "[@inline] let multN (a : nat ) (b : nat ) = a * b" ;
+    "[@inline] let modN (a : nat ) (b : nat ) = a mod b" ;
+    "[@inline] let divN (a : nat ) (b : nat ) = a / b" ;
+    "[@inline] let eqN (a : nat ) (b : nat ) = a = b" ;
+    "[@inline] let lebN (a : nat ) (b : nat ) = a <= b" ;
+    "[@inline] let ltbN (a : nat ) (b : nat ) = a < b";
+    "let divN_opt (n : nat) (m : nat) : nat option = match ediv n m with | Some (q,_) -> Some q | None -> None";
+    "let moduloN (n : nat) (m : nat) : nat = match ediv n m with | Some (_,r) -> r | None -> 0n";
+    "let subOption (n : nat) (m : nat) : nat option = if n < m then None else Some (abs (n-m))";
+    "let z_to_N (i : int) : nat = if i < 0 then 0n else abs i";
+    "let z_of_N (n : nat) : int = int (n)"
+    $>.
 
-Local Open Scope string_scope.
+  Definition bool_ops :=
+    <$
+    "[@inline] let andb (a : bool ) (b : bool ) = a && b" ;
+    "[@inline] let orb (a : bool ) (b : bool ) = a || b"
+    $>.
 
-(** We un-overload operations and add definitions that are more convenient to use during the pretty-printing phase. These part should be included when printing contracts that use the corresponding operations. *)
+  Definition time_ops :=
+    <$
+    "[@inline] let eqb_time (a1 : timestamp) (a2 : timestamp) = a1 = a2" ;
+    "[@inline] let leb_time (a1 : timestamp) (a2 : timestamp) = a1 <= a2" ;
+    "[@inline] let ltb_time (a1 : timestamp) (a2 : timestamp) = a1 < a2"
+    $>.
 
-Definition int_ops :=
-  <$
-  "[@inline] let addInt (i : int) (j : int) = i + j" ;
-  "[@inline] let subInt (i : int) (j : int) = i - j" ;
-  "[@inline] let subIntTruncated (a : int) (b : int) = let res = a - b in if res < 0 then 0 else res" ;
-  "[@inline] let multInt (i : int) (j : int) = i * j" ;
-  "[@inline] let divInt (i : int) (j : int) = i / j" ;
-  "[@inline] let modInt (a : int)(b : int) : int = int (a mod b)" ;
-  "[@inline] let leInt (i : int) (j : int) = i <= j" ;
-  "[@inline] let ltInt (i : int) (j : int) = i < j" ;
-  "[@inline] let eqInt (i : int) (j : int) = i = j"
+  Definition address_ops :=
+    "[@inline] let eq_addr (a1 : address) (a2 : address) = a1 = a2".
+
+  Definition get_contract_def :=
+    <$
+    "let get_contract_unit (a : address) : unit contract  =" ;
+    "  match (Tezos.get_contract_opt a : unit contract option) with" ;
+    "    Some c -> c" ;
+    "  | None -> (failwith (""Contract not found."") : unit contract)"
+    $>.
+
+  Definition CameLIGO_call_ctx_type_name : string := "cctx".
+
+  Definition CameLIGO_call_ctx_type :=
+  <$ "(* ConCert's call context *)"
+  ; "type " ^ CameLIGO_call_ctx_type_name ^ " = {"
+  ; "  ctx_origin_ : address;"
+  ; "  ctx_from_ : address;"
+  ; "  ctx_contract_address_ : address;"
+  ; "  ctx_contract_balance_ : tez;"
+  ; "  ctx_amount_ : tez"
+  ; "}"
   $>.
 
-Definition tez_ops :=
-  <$
-  "[@inline] let addTez (n : tez) (m : tez) = n + m" ;
-  "[@inline] let subTez (n : tez) (m : tez) = n - m" ;
-  "[@inline] let leTez (a : tez ) (b : tez ) = a <= b" ;
-  "[@inline] let ltTez (a : tez ) (b : tez ) =  a < b" ;
-  "[@inline] let gtbTez (a : tez ) (b : tez ) =  a > b" ;
-  "[@inline] let eqTez (a : tez ) (b : tez ) = a = b" ;
-  "[@inline] let natural_to_mutez (a: nat): tez = a * 1mutez" ;
-  "[@inline] let divTez (a : tez) (b : tez) : tez = natural_to_mutez (a/b)" ;
-  "[@inline] let multTez (n : tez) (m : tez) = (n/1tez) * m";
-  "[@inline] let evenTez (i : tez) = (i mod 2n) = 0tez"
-  $>.
-Definition nat_ops :=
-  <$
-  "[@inline] let addN (a : nat ) (b : nat ) = a + b" ;
-  "[@inline] let multN (a : nat ) (b : nat ) = a * b" ;
-  "[@inline] let modN (a : nat ) (b : nat ) = a mod b" ;
-  "[@inline] let divN (a : nat ) (b : nat ) = a / b" ;
-  "[@inline] let eqN (a : nat ) (b : nat ) = a = b" ;
-  "[@inline] let lebN (a : nat ) (b : nat ) = a <= b" ;
-  "[@inline] let ltbN (a : nat ) (b : nat ) = a < b"
+  Definition CameLIGO_call_ctx_instance :=
+  <$"(* a call context instance with fields filled in with required data *)"
+  ; "let cctx_instance : " ^ CameLIGO_call_ctx_type_name ^ "= "
+  ; "{ ctx_origin_ = Tezos.source;"
+  ; "  ctx_from_ = Tezos.sender;"
+  ; "  ctx_contract_address_ = Tezos.self_address;"
+  ; "  ctx_contract_balance_ = Tezos.balance;"
+  ; "  ctx_amount_ = Tezos.balance"
+  ; "}"
+  ; ""
+  ; "(* context projections as functions *)"
+  ; "let ctx_from (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_from_"
+  ; "let ctx_origin (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_origin_"
+  ; "let ctx_contract_address (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_contract_address_"
+  ; "let ctx_contract_balance (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_contract_balance_"
+  ; "let ctx_amount (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_amount_"
   $>.
 
-Definition bool_ops :=
-  <$
-  "[@inline] let andb (a : bool ) (b : bool ) = a && b" ;
-  "[@inline] let orb (a : bool ) (b : bool ) = a || b"
+  Definition CameLIGO_chain_instance :=
+  <$ (* ConCert's Chain type and its instance. Currently we map all fields to Tezos.level *)
+  "type chain = {"
+  ; "  chain_height_     : nat;"
+  ; "  current_slot_     : nat;"
+  ; "  finalized_height_ : nat;"
+  ; "}"
+  ; ""
+  ; "let dummy_chain : chain = {"
+  ; "chain_height_     = Tezos.level;"
+  ; "current_slot_     = Tezos.level;"
+  ; "finalized_height_ = Tezos.level;"
+  ; "}"
+  ; ""
+  ; "(* chain projections as functions *)"
+  ; "let chain_height (c : chain ) = c.chain_height_"
+  ; "let current_slot (c : chain ) = c.current_slot_"
+  ; "let finalized_height (c : chain) = c.finalized_height_"
   $>.
 
-Definition time_ops :=
-  <$
-  "[@inline] let eqb_time (a1 : timestamp) (a2 : timestamp) = a1 = a2" ;
-  "[@inline] let leb_time (a1 : timestamp) (a2 : timestamp) = a1 <= a2" ;
-  "[@inline] let ltb_time (a1 : timestamp) (a2 : timestamp) = a1 < a2"
+  
+  Definition CameLIGO_Chain_CallContext :=
+  <$ CameLIGO_call_ctx_type
+   ; CameLIGO_call_ctx_instance
+   ; CameLIGO_chain_instance
   $>.
 
-Definition address_ops :=
-  "[@inline] let eq_addr (a1 : address) (a2 : address) = a1 = a2".
+  Definition CameLIGOPrelude :=
+    print_list id (nl ++ nl)
+               [int_ops; tez_ops; nat_ops;
+                bool_ops; time_ops; address_ops;
+                get_contract_def; CameLIGO_Chain_CallContext].
 
-Definition get_contract_def :=
-  <$
-  "let get_contract_unit (a : address) : unit contract  =" ;
-  "  match (Tezos.get_contract_opt a : unit contract option) with" ;
-  "    Some c -> c" ;
-  "  | None -> (failwith (""Contract not found."") : unit contract)"
-  $>.
+  Definition printWrapper (contract parameter_name storage_name : string): string :=
+    <$
+    "type return = (operation) list * (" ++ storage_name ++ " option)" ;
+    "type parameter_wrapper =" ;
+    "  Init of init_args_ty" ;
+    "| Call of " ++ parameter_name ++ " option" ;
+    "";
+    "let wrapper (param, st : parameter_wrapper * (" ++ storage_name ++ ") option) : return =" ;
+    "  match param with  " ;
+    "    Init init_args -> (([]: operation list), Some (init init_args))" ;
+    "  | Call p -> (" ;
+    "    match st with" ;
+    "      Some st -> (match (" ++ contract ++ " dummy_chain cctx_instance " ++ " st p) with   " ;
+    "                    Some v -> (v.0, Some v.1)" ;
+    "                  | None -> (failwith ("""") : return))" ;
+    "    | None -> (failwith (""cannot call this endpoint before Init has been called""): return))"
+    $>.
 
-Definition CameLIGO_call_ctx_type_name : string := "cctx".
+  Definition printMain (storage_name : string) :=
+    "let main (action, st : parameter_wrapper * " ++ storage_name ++ " option) : return = wrapper (action, st)".
 
-Definition CameLIGO_call_ctx_type :=
-<$ "(* ConCert's call context *)"
-; "type " ^ CameLIGO_call_ctx_type_name ^ " = {"
-; "  ctx_origin_ : address;"
-; "  ctx_from_ : address;"
-; "  ctx_contract_address_ : address;"
-; "  ctx_contract_balance_ : tez;"
-; "  ctx_amount_ : tez"
-; "}"
-$>.
+    Definition print_default_entry_point (state_nm : kername) (receive_nm : kername) (msg_nm : kername) :=
+  let st := print_type_name state_nm in
+  let rec := print_const_name receive_nm in
+  let msg := print_type_name msg_nm in
+  <$ printWrapper rec msg st;
+     "";
+     printMain st $>.
 
-Definition CameLIGO_call_ctx_instance :=
-<$"(* a call context instance with fields filled in with required data *)"
-; "let cctx_instance : " ^ CameLIGO_call_ctx_type_name ^ "= "
-; "{ ctx_origin_ = Tezos.source;"
-; "  ctx_from_ = Tezos.sender;"
-; "  ctx_contract_address_ = Tezos.self_address;"
-; "  ctx_contract_balance_ = Tezos.balance;"
-; "  ctx_amount_ = Tezos.balance"
-; "}"
-; ""
-; "(* projections as functions *)"
-; "let ctx_from (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_from_"
-; "let ctx_contract_address (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_contract_address_"
-; "let ctx_contract_balance (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_contract_balance_"
-; "let ctx_amount_ (c : " ^ CameLIGO_call_ctx_type_name ^ ") = c.ctx_amount_"
-$>.
-
-Definition dummy_chain :=
-<$ (* ConCert's Chain type and its isntance. Currently we map all fields to Tezos.level *)
-"type chain = {"
-; "  chain_height     : nat;"
-; "  current_slot     : nat;"
-; "  finalized_height : nat;"
-; "}"
-; ""
-; "let dummy_chain : chain = {"
-; "chain_height     = Tezos.level;"
-; "current_slot     = Tezos.level;"
-; "finalized_height = Tezos.level;"
-; "}"
-$>.
-
-Definition CameLIGO_Chain_CallContext :=
-<$ CameLIGO_call_ctx_type
-; CameLIGO_call_ctx_instance
-; dummy_chain
-$>.
-
-Definition CameLIGOPrelude :=
-  print_list id (nl ++ nl)
-             [int_ops; tez_ops; nat_ops;
-              bool_ops; time_ops; address_ops;
-              get_contract_def; CameLIGO_Chain_CallContext].
-
-Definition printWrapper (contract parameter_name storage_name : string): string :=
-  <$
-  "type return = (operation) list * (" ++ storage_name ++ " option)" ;
-  "type parameter_wrapper =" ;
-  "  Init of init_args_ty" ;
-  "| Call of " ++ parameter_name ++ " option" ;
-  "";
-  "let wrapper (param, st : parameter_wrapper * (" ++ storage_name ++ ") option) : return =" ;
-  "  match param with  " ;
-  "    Init init_args -> (([]: operation list), Some (init init_args))" ;
-  "  | Call p -> (" ;
-  "    match st with" ;
-  "      Some st -> (match (" ++ contract ++ " dummy_chain cctx_instance " ++ " st p) with   " ;
-  "                    Some v -> (v.0, Some v.1)" ;
-  "                  | None -> (failwith ("""") : return))" ;
-  "    | None -> (failwith (""cannot call this endpoint before Init has been called""): return))"
-  $>.
-
-Definition printMain (storage_name : string) :=
-  "let main (action, st : parameter_wrapper * " ++ storage_name ++ " option) : return = wrapper (action, st)".
+End PPLigo.


### PR DESCRIPTION
* extraction setup for Dexter 2 CPMM (the main contract)
* add polymorphism support to CameLIGO extraction
* Wrap Dexter 2 CPMM contract into a module, which is parameterised with required `Serialize` instances. We instantiate the CPMM contract in an opaque way, so the `Serialize` instances do not slow down extraction.
* Misc fixes in proofs to make them more robust (avoid using automatically generated names of hypotheses).