### PR TITLE
Extract Dexter 2 Liquidity token FA1.2

### DIFF
--- a/execution/examples/BoardroomVoting.v
+++ b/execution/examples/BoardroomVoting.v
@@ -350,7 +350,6 @@ Lemma Permutation_modify k vold vnew (m : AddrMap VoterInfo) :
     (seq 0 (FMap.size m)).
 Proof.
   intros find_some index old_perm.
-  unfold AddrMap in *.
   rewrite <- old_perm.
   rewrite <- (FMap.add_id _ _ _ find_some) at 2.
   rewrite <- (FMap.add_remove k vold).
@@ -477,6 +476,8 @@ Proof.
     now rewrite elmeqb_refl.
 Qed.
 
+Local Set Keyed Unification.
+
 Definition has_tallied (calls : list (ContractCallInfo Msg)) : bool :=
   existsb (fun c => match Blockchain.call_msg c with
                     | Some tally_votes => true
@@ -536,7 +537,7 @@ Theorem boardroom_voting_correct_strong
          tally cstate = Some (sumnat (fun party => if svi_sv (parties party) then 1 else 0)%nat
                                      (map fst (signups inc_calls)))))).
 Proof.
-  contract_induction; intros; unfold AddrMap in *.
+  contract_induction; intros.
   - [AddBlockFacts]: exact (fun _ old_slot _ _ new_slot _ => old_slot < new_slot).
     subst AddBlockFacts.
     cbn in facts.
@@ -556,7 +557,6 @@ Proof.
     split; [lia|].
     intros _ _ _.
     unfold FMap.keys.
-    unfold AddrMap in *.
     unfold AddressMap.empty in *.
     rewrite @FMap.elements_empty.
     split; [auto|].
@@ -583,7 +583,6 @@ Proof.
       split; [lia|].
       split; [tauto|].
       split.
-      unfold AddrMap in *.
       { rewrite app_length, FMap.size_add_new by auto; cbn; lia. }
       apply Z.ltb_lt in lt.
       rewrite app_length in *.
@@ -606,7 +605,6 @@ Proof.
       * split.
         { destruct IH as (perm & _).
           cbn.
-          unfold AddrMap in *.
           rewrite FMap.elements_add by auto.
           cbn.
           rewrite seq_app.
@@ -618,7 +616,7 @@ Proof.
           unfold FMap.keys.
           rewrite FMap.elements_add by auto.
           cbn.
-          perm_simplify. }
+          now perm_simplify. }
 
         split; cycle 1.
         {
@@ -629,7 +627,6 @@ Proof.
         }
         intros addr inf find_add.
         destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
-        unfold AddrMap in *.
         -- rewrite (FMap.find_add (ctx_from ctx)) in find_add.
            inversion_clear find_add.
            cbn.
@@ -644,8 +641,7 @@ Proof.
            split; [symmetry; tauto|].
            split; [congruence|].
            left; easy.
-        -- unfold AddrMap in *.
-           rewrite FMap.find_add_ne in find_add by auto.
+        -- rewrite FMap.find_add_ne in find_add by auto.
            destruct IH as (_ & _ & IH & _).
            specialize (IH _ _ find_add).
            split; [lia|].
@@ -660,7 +656,6 @@ Proof.
       split; [tauto|].
       split.
       unfold AddressMap.add.
-      unfold AddrMap in *.
       {  rewrite FMap.size_add_existing by congruence; tauto. }
       split; [tauto|].
       split; [tauto|].
@@ -680,10 +675,10 @@ Proof.
       unfold AddressMap.add in *.
       destruct IH as (_ & _ & IH & _).
       destruct (address_eqb_spec addr (ctx_from ctx)) as [->|].
-      * unfold AddrMap in *.  rewrite FMap.find_add in find_add.
+      * rewrite FMap.find_add in find_add.
         inversion_clear find_add; cbn.
         auto.
-      * unfold AddrMap in *; rewrite FMap.find_add_ne in find_add by auto.
+      * rewrite FMap.find_add_ne in find_add by auto.
         auto.
     + (* submit_vote *)
       destruct (_ <? _); cbn -[Nat.ltb] in *; [congruence|].
@@ -694,8 +689,7 @@ Proof.
       inversion_clear receive_some; cbn.
       split; [lia|].
       split; [tauto|].
-      unfold AddressMap.add in *.
-      unfold AddrMap in *; rewrite FMap.size_add_existing by congruence.
+      rewrite FMap.size_add_existing by congruence.
       split; [tauto|].
       split; [tauto|].
       split; [tauto|].
@@ -760,9 +754,9 @@ Proof.
                     (fun '(_, v) => public_vote v)) in bruteforce.
       * inversion bruteforce.
         rewrite <- (sumnat_map fst (fun a => if svi_sv (parties a) then 1 else 0))%nat.
-        now rewrite perm'.
-      * unfold AddrMap in *; now rewrite FMap.length_elements, <- len_pks.
-      * unfold AddrMap in *; now rewrite FMap.length_elements, <- len_pks.
+        now setoid_rewrite perm'.
+      * now rewrite FMap.length_elements, <- len_pks.
+      * now rewrite FMap.length_elements, <- len_pks.
       * auto.
       * intros [k v] kvpin.
         apply FMap.In_elements in kvpin.

--- a/execution/examples/BoardroomVotingZ.v
+++ b/execution/examples/BoardroomVotingZ.v
@@ -391,7 +391,6 @@ Lemma Permutation_modify k vold vnew (m : AddrMap VoterInfo) :
     (seq 0 (FMap.size m)).
 Proof.
   intros find_some index old_perm.
-  unfold AddrMap in *.
   rewrite <- old_perm.
   rewrite <- (FMap.add_id _ _ _ find_some) at 2.
   rewrite <- (FMap.add_remove k vold).

--- a/execution/examples/Common.v
+++ b/execution/examples/Common.v
@@ -12,7 +12,9 @@ This definitions is more extraction-friendly. *)
 
 Module AddressMap.
 
-  Definition AddrMap `{ChainBase} := FMap Address.
+  Notation AddrMap := (FMap Address).
+
+  (* Definition AddrMap `{ChainBase} := FMap Address. *)
 
   Definition find `{ChainBase} {V : Type} (addr : Address) (m : AddrMap V) : option V :=
     FMap.find addr m.
@@ -25,11 +27,14 @@ Module AddressMap.
 
   Definition keys  `{ChainBase} {V : Type} (m : AddrMap V) : list Address :=
     FMap.keys m.
-      
+
   Definition of_list  `{ChainBase} {V : Type} (l : list (Address * V)) : AddrMap V :=
     FMap.of_list l.
 
   Definition empty  `{ChainBase} {V : Type} : AddrMap V := FMap.empty.
+
+  Definition update `{ChainBase} {V : Type} (addr : Address) (val : option V) (m : AddrMap V) : AddrMap V :=
+    FMap.update addr val m.
 
 End AddressMap.
 

--- a/execution/examples/Dexter2CPMM.v
+++ b/execution/examples/Dexter2CPMM.v
@@ -524,7 +524,7 @@ Module DSInstances <: Dexter2Serializable.
                                             TokenToToken>.
 
     Global Instance Dexter2FA12_Msg_serialize `{ChainBase} : Serializable Dexter2FA12.Msg :=
-      msg_serializable.
+      D2LqtSInstances.msg_serializable.
 
     Global Instance setup_serializable `{ChainBase} : Serializable Setup :=
       Derive Serializable Setup_rect <build_setup>.

--- a/execution/examples/Dexter2FA12.v
+++ b/execution/examples/Dexter2FA12.v
@@ -22,9 +22,11 @@ From ConCert.Execution.Examples Require Import Common.
 From Coq Require Import ZArith Bool List Lia.
 Import ListNotations.
 
+Definition non_zero_amount (amt : Z) : bool:= (0 <? amt)%Z.
 
 (** * Contract types *)
-Section LQTFA12.
+
+Section LQTFA12Types.
 Context {BaseTypes : ChainBase}.
 Set Primitive Projections.
 Set Nonrecursive Elimination Schemes.
@@ -115,54 +117,123 @@ MetaCoq Run (make_setters getTotalSupply_param).
 MetaCoq Run (make_setters State).
 MetaCoq Run (make_setters Setup).
 
-Section Serialization.
+End LQTFA12Types.
 
-Instance callback_serializable {A : Type} `{serA : Serializable A} : Serializable (callback A) :=
-Derive Serializable (callback_rect A) <(Build_callback A)>.
+Module Type Dexter2LqtSerializable.
 
-Global Instance transfer_param_serializable : Serializable transfer_param :=
-  Derive Serializable transfer_param_rect <build_transfer_param>.
+  Section D2LqtSerializable.
 
-Global Instance approve_param_serializable : Serializable approve_param :=
-  Derive Serializable approve_param_rect <build_approve_param>.
+    Context `{ChainBase}.
 
-Global Instance mintOrBurn_param_serializable : Serializable mintOrBurn_param :=
-  Derive Serializable mintOrBurn_param_rect <build_mintOrBurn_param>.
+    Axiom callback_serializable : forall {A : Type} `{serA : Serializable A}, Serializable (callback A).
 
-Global Instance getAllowance_param_serializable : Serializable getAllowance_param :=
-  Derive Serializable getAllowance_param_rect <build_getAllowance_param>.
+    Axiom transfer_param_serializable : Serializable transfer_param.
 
-Global Instance getBalance_param_serializable : Serializable getBalance_param :=
-  Derive Serializable getBalance_param_rect <build_getBalance_param>.
+    Axiom approve_param_serializable : Serializable approve_param.
 
-Global Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
-  Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
+    Axiom mintOrBurn_param_serializable : Serializable mintOrBurn_param.
 
-Global Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg serMsg) :=
-  Derive Serializable (@FA12ReceiverMsg_rect Msg serMsg) <
-    (@receive_allowance Msg serMsg),
-    (@receive_balance_of Msg serMsg),
-    (@receive_total_supply Msg serMsg),
-    (@other_msg Msg serMsg)>.
+    Axiom getAllowance_param_serializable : Serializable getAllowance_param.
 
-Global Instance msg_serializable : Serializable Msg :=
-  Derive Serializable Msg_rect <msg_transfer,
-                                msg_approve,
-                                msg_mint_or_burn,
-                                msg_get_allowance,
-                                msg_get_balance,
-                                msg_get_total_supply>.
+    Axiom getBalance_param_serializable : Serializable getBalance_param.
 
-Global Instance state_serializable : Serializable State :=
-  Derive Serializable State_rect <build_state>.
+    Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-Global Instance setup_serializable : Serializable Setup :=
-  Derive Serializable Setup_rect <build_setup>.
+    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg serMsg).
 
-End Serialization.
+    Axiom msg_serializable : Serializable Msg.
+
+    Axiom state_serializable : Serializable State.
+
+    Axiom setup_serializable : Serializable Setup.
+
+  End D2LqtSerializable.
+End Dexter2LqtSerializable.
+
+Module D2LqtSInstances <: Dexter2LqtSerializable.
+
+  Section Serialization.
+
+    Context `{ChainBase}.
+
+    Instance  callback_serializable {A : Type} `{serA : Serializable A} : Serializable (callback A) :=
+    Derive Serializable (callback_rect A) <(Build_callback A)>.
+
+    Instance transfer_param_serializable : Serializable transfer_param :=
+      Derive Serializable transfer_param_rect <build_transfer_param>.
+
+    Instance approve_param_serializable : Serializable approve_param :=
+      Derive Serializable approve_param_rect <build_approve_param>.
+
+    Instance mintOrBurn_param_serializable : Serializable mintOrBurn_param :=
+      Derive Serializable mintOrBurn_param_rect <build_mintOrBurn_param>.
+
+    Instance getAllowance_param_serializable : Serializable getAllowance_param :=
+      Derive Serializable getAllowance_param_rect <build_getAllowance_param>.
+
+    Instance getBalance_param_serializable : Serializable getBalance_param :=
+      Derive Serializable getBalance_param_rect <build_getBalance_param>.
+
+    Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
+      Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
+
+    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg serMsg) :=
+      Derive Serializable (@FA12ReceiverMsg_rect Msg serMsg) <
+        (@receive_allowance Msg serMsg),
+        (@receive_balance_of Msg serMsg),
+        (@receive_total_supply Msg serMsg),
+        (@other_msg Msg serMsg)>.
+
+    Instance msg_serializable : Serializable Msg :=
+      Derive Serializable Msg_rect <msg_transfer,
+                                  msg_approve,
+                                  msg_mint_or_burn,
+                                  msg_get_allowance,
+                                  msg_get_balance,
+                                  msg_get_total_supply>.
+
+  Instance state_serializable : Serializable State :=
+    Derive Serializable State_rect <build_state>.
+
+  Instance setup_serializable : Serializable Setup :=
+    Derive Serializable Setup_rect <build_setup>.
+  End Serialization.
+
+End D2LqtSInstances.
+
 (* end hide *)
 
 (** * Contract functions *)
+Module Dexter2Lqt (SI : Dexter2LqtSerializable).
+
+Import SI.
+
+(* begin hide *)
+Existing Instance callback_serializable.
+Existing Instance transfer_param_serializable.
+Existing Instance approve_param_serializable.
+Existing Instance mintOrBurn_param_serializable.
+Existing Instance getAllowance_param_serializable.
+Existing Instance getBalance_param_serializable.
+Existing Instance getTotalSupply_param_serializable.
+Existing Instance  FA12ReceiverMsg_serializable.
+Existing Instance msg_serializable.
+Existing Instance state_serializable.
+Existing Instance setup_serializable.
+(* end hide *)
+
+Section DexterLqtDefs.
+Context `{BaseTypes : ChainBase}.
+Open Scope N_scope.
+
+Definition find_allowance (k : Address * Address) (m : FMap (Address * Address) N) : option N :=
+  FMap.find k m.
+
+Definition update_allowance (k : Address * Address) (val : option N) (m : FMap (Address * Address) N) :=
+  FMap.update k val m.
+
+Definition empty_allowance : FMap (Address * Address) N := FMap.empty.
+
 (** ** Transfer *)
 (** Transfers [amount] tokens, if [from] has enough tokens to transfer
     and [sender] is allowed to send that much on behalf of [from] *)
@@ -174,18 +245,18 @@ Definition try_transfer (sender : Address) (param : transfer_param) (state : Sta
     then Some allowances_
     else
       let allowance_key := (param.(from), sender) in
-      let authorized_value := with_default 0 (FMap.find allowance_key allowances_) in
+      let authorized_value := with_default 0 (find_allowance allowance_key allowances_) in
         do _ <- throwIf (authorized_value <? param.(value)) ; (* NotEnoughAllowance *)
-        Some (FMap.update allowance_key (maybe (authorized_value - param.(value))) allowances_)
+        Some (update_allowance allowance_key (maybe (authorized_value - param.(value))) allowances_)
     ) ;
   do tokens_ <- (* Update from balance *)
-    (let from_balance := with_default 0 (FMap.find param.(from) tokens_) in
+    (let from_balance := with_default 0 (AddressMap.find param.(from) tokens_) in
       do _ <- throwIf (from_balance <? param.(value)) ; (* NotEnoughBalance *)
-      Some (FMap.update param.(from) (maybe (from_balance - param.(value))) tokens_)
+      Some (AddressMap.update param.(from) (maybe (from_balance - param.(value))) tokens_)
     ) ;
   let tokens_ :=
-    let to_balance := with_default 0 (FMap.find param.(to) tokens_) in
-      FMap.update param.(to) (maybe (to_balance + param.(value))) tokens_ in
+    let to_balance := with_default 0 (AddressMap.find param.(to) tokens_) in
+      AddressMap.update param.(to) (maybe (to_balance + param.(value))) tokens_ in
     Some (state<|tokens := tokens_|>
                <|allowances := allowances_|>).
 
@@ -194,9 +265,9 @@ Definition try_transfer (sender : Address) (param : transfer_param) (state : Sta
 Definition try_approve (sender : Address) (param : approve_param) (state : State) : option State :=
   let allowances_ := state.(allowances) in
   let allowance_key := (sender, param.(spender)) in
-  let previous_value := with_default 0 (FMap.find allowance_key allowances_) in
+  let previous_value := with_default 0 (find_allowance allowance_key allowances_) in
   do _ <- throwIf (andb (0 <? previous_value) (0 <? param.(value_))) ; (* UnsafeAllowanceChange *)
-  let allowances_ := FMap.update allowance_key (maybe param.(value_)) allowances_ in
+  let allowances_ := update_allowance allowance_key (maybe param.(value_)) allowances_ in
     Some (state<|allowances := allowances_|>).
 
 (** ** Mint or burn *)
@@ -207,38 +278,45 @@ Definition try_approve (sender : Address) (param : approve_param) (state : State
 Definition try_mint_or_burn (sender : Address) (param : mintOrBurn_param) (state : State) : option State :=
   do _ <- throwIf (negb (address_eqb sender state.(admin))) ;
   let tokens_ := state.(tokens) in
-  let old_balance := with_default 0 (FMap.find param.(target) tokens_) in
+  let old_balance := with_default 0 (AddressMap.find param.(target) tokens_) in
   let new_balance := (Z.of_N old_balance + param.(quantity))%Z in
   do _ <- throwIf (new_balance <? 0)%Z ; (* Cannot burn more than the target's balance. *)
-  let tokens_ := FMap.update param.(target) (maybe (Z.to_N new_balance)) tokens_ in
+  let tokens_ := AddressMap.update param.(target) (maybe (Z.to_N new_balance)) tokens_ in
   let total_supply_ := Z.abs_N (Z.of_N state.(total_supply) + param.(quantity))%Z in
     Some (state<|tokens := tokens_|>
                <|total_supply := total_supply_|>).
 
+Definition mk_callback (to_addr : Address) (msg : @FA12ReceiverMsg unit _) :=
+  act_call to_addr 0 (serialize msg).
+
+Definition receive_allowance_ n := @receive_allowance unit _ n.
+Definition receive_balance_of_ n := @receive_balance_of unit _ n.
+Definition receive_total_supply_ n := @receive_total_supply unit _ n.
+
 (** ** Get allowance *)
 (** Get the quantity that [snd request] is allowed to spend on behalf of [fst request] *)
 Definition try_get_allowance (sender : Address) (param : getAllowance_param) (state : State) : list ActionBody :=
-  let value := with_default 0 (FMap.find param.(request) state.(allowances)) in
-    [act_call sender 0 (serialize (receive_allowance value))].
+  let value := with_default 0 (find_allowance param.(request) state.(allowances)) in
+    [mk_callback sender (receive_allowance_ value)].
 
 (** ** Get balance *)
 (** Get the quantity of tokens belonging to [owner] *)
 Definition try_get_balance (sender : Address) (param : getBalance_param) (state : State) : list ActionBody :=
-  let value := with_default 0 (FMap.find param.(owner_) state.(tokens)) in
-    [act_call sender 0 (serialize (receive_balance_of value))].
+  let value := with_default 0 (AddressMap.find param.(owner_) state.(tokens)) in
+    [mk_callback sender (receive_balance_of_ value)].
 
 (** ** Get total supply *)
 (** Get the total supply of tokens *)
 Definition try_get_total_supply (sender : Address) (param : getTotalSupply_param) (state : State) : list ActionBody :=
   let value := state.(total_supply) in
-    [act_call sender 0 (serialize (receive_total_supply value))].
+    [mk_callback sender (receive_total_supply_ value)].
 
 (** ** Init *)
 (** Initalize contract storage *)
 Definition init (chain : Chain) (ctx : ContractCallContext) (setup : Setup) : option State :=
   Some {|
-    tokens := FMap.add setup.(lqt_provider) setup.(initial_pool) FMap.empty;
-    allowances := FMap.empty;
+    tokens := AddressMap.add setup.(lqt_provider) setup.(initial_pool) AddressMap.empty;
+    allowances := empty_allowance;
     admin := setup.(admin_);
     total_supply := setup.(initial_pool);
   |}.
@@ -252,9 +330,8 @@ Definition receive (chain : Chain) (ctx : ContractCallContext)
   let sender := ctx.(ctx_from) in
   let without_actions := option_map (fun new_state => (new_state, [])) in
   let without_statechange acts := Some (state, acts) in
-  if 0 <? ctx.(ctx_amount)
-  then None (* DontSendTez *)
-  else match maybe_msg with
+  do _ <- throwIf (non_zero_amount ctx.(ctx_amount)); (* DontSendTez *)
+  match maybe_msg with
   | Some (msg_transfer param) => without_actions (try_transfer sender param state)
   | Some (msg_approve param) => without_actions (try_approve sender param state)
   | Some (msg_mint_or_burn param) => without_actions (try_mint_or_burn sender param state)
@@ -268,10 +345,33 @@ Close Scope Z_scope.
 Definition contract : Contract Setup Msg State :=
   build_contract init receive.
 
+  End DexterLqtDefs.
+End Dexter2Lqt.
 
+Module DEX2LQT := Dexter2Lqt D2LqtSInstances.
+
+Import DEX2LQT.
 
 (** * Properties *)
 Section Theories.
+
+Context `{ChainBase}.
+
+Open Scope N_scope.
+
+(* begin hide *)
+(* always unfold, if applied *)
+Arguments AddressMap.update _ _ _ _ _ /.
+Arguments AddressMap.find _ _ _ _/.
+Arguments AddressMap.empty _ _/.
+
+Arguments find_allowance _ _ _ /.
+Arguments update_allowance _ _ _ _ /.
+
+Arguments non_zero_amount _ /.
+
+Set Keyed Unification.
+(* end hide *)
 
 (** ** Contract rejects money *)
 (** [receive] only returns Some if the sender amount is zero *)
@@ -280,8 +380,8 @@ Lemma contract_not_payable : forall prev_state new_state chain ctx msg new_acts,
     ((ctx_amount ctx) <= 0)%Z.
 Proof.
   intros * receive_some.
-  unfold receive in receive_some.
-  destruct_match eqn:amount in receive_some.
+  unfold receive, throwIf in receive_some;cbn in receive_some.
+  destruct (0 <? _)%Z eqn:amount in receive_some.
   - (* case: ctx_amount > 0 *)
     congruence.
   - (* case: ctx_amount <= 0 *)
@@ -293,8 +393,8 @@ Lemma contract_not_payable' : forall prev_state chain ctx msg,
     receive chain ctx prev_state msg = None.
 Proof.
   intros * ctx_amount_positive.
-  unfold receive.
-  destruct_match eqn:amount.
+  unfold receive,throwIf;cbn.
+  destruct (0 <? _)%Z eqn:amount.
   - (* case: ctx_amount > 0 *)
     reflexivity.
   - (* case: ctx_amount <= 0 *)
@@ -307,10 +407,9 @@ Ltac receive_simpl_step :=
   | H : Blockchain.receive _ _ _ _ _ = Some (_, _) |- _ =>
       unfold Blockchain.receive in H; cbn in H
   | H : receive _ _ _ _ = Some (_, _) |- _ =>
-      apply contract_not_payable in H as ctx_amount_zero;
-      apply Z.ltb_ge in ctx_amount_zero;
-      unfold receive in H;
-      rewrite ctx_amount_zero in H;
+      (* apply contract_not_payable in H as ctx_amount_zero; *)
+      (* apply Z.ltb_ge in ctx_amount_zero; *)
+      (* unfold receive in H; *)
       cbn in H
   | |- receive _ _ _ _ = _ =>
       unfold receive; cbn
@@ -322,6 +421,7 @@ Ltac receive_simpl_step :=
       inversion H
   | H : throwIf _ = None |- _ => destruct_throw_if H
   | H : throwIf _ = Some ?u |- _ => destruct_throw_if H
+  | H : (0 <? ctx_amount _)%Z = false |- _ => apply Z.ltb_ge in H as ctx_amount_zero
   | H : option_map (fun s : State => (s, _)) match ?m with | Some _ => _ | None => None end = Some _ |- _ =>
     let a := fresh "H" in
     destruct m eqn:a in H; try setoid_rewrite a; cbn in *; try congruence
@@ -360,7 +460,6 @@ Lemma admin_constant : forall prev_state new_state chain ctx new_acts msg,
     admin prev_state = admin new_state.
 Proof.
   intros * receive_some.
-  receive_simpl.
   destruct msg. destruct m.
   all : now receive_simpl.
 Qed.
@@ -402,7 +501,9 @@ Lemma try_transfer_balance_correct : forall prev_state new_state chain ctx new_a
 Proof.
   intros * receive_some.
   receive_simpl.
-  rename H1 into enough_balance.
+  match goal with
+    [ H : with_default 0 _ <? _ = false |- _ ] => rename H into enough_balance
+  end.
   rewrite N.ltb_ge in enough_balance.
   unfold transfer_balance_update_correct.
   cbn.
@@ -410,21 +511,20 @@ Proof.
   - (* from = to *)
     destruct (address_eqb_spec param.(from) param.(to)) as [<-|]; auto.
     rewrite !FMap.map_update_idemp.
-    rewrite !FMap.find_update_eq.
-    destruct (FMap.find (from param) (tokens prev_state)) eqn:from_prev; cbn.
-    + cbn in enough_balance.
-      now apply maybe_sub_add in enough_balance as [[-> ->] | ->]; rewrite N.eqb_refl.
+    rewrite !FMap.find_update_eq with (map:=prev_state.(tokens)).
+    destruct (FMap.find (from param) _) eqn:from_prev; cbn in *.
+    + now apply maybe_sub_add in enough_balance as [[-> ->] | ->]; rewrite N.eqb_refl.
     + rewrite N.add_0_l.
       apply N.le_0_r in enough_balance.
       now rewrite enough_balance.
   - (* from <> to *)
     destruct (address_eqb_spec param.(from) param.(to)) as [| from_to_eq]; auto.
+    rewrite !FMap.find_update_ne with (map:=prev_state.(tokens)) by auto.
     rewrite !FMap.find_update_ne by auto.
-    rewrite !FMap.find_update_eq by auto.
-    rewrite !FMap.find_update_ne by auto.
-    destruct (FMap.find (from param) (tokens prev_state)) eqn:from_prev; cbn;
+    rewrite !FMap.find_update_eq.
+    destruct (FMap.find (from param) _) eqn:from_prev; cbn;
       [| apply N.le_0_r in enough_balance; rewrite enough_balance];
-    destruct (FMap.find (to param) (tokens prev_state)) eqn:to_prev; cbn;
+    destruct (FMap.find (to param) _) eqn:to_prev; cbn;
     rewrite ?N.add_0_l, ?N.add_0_r, ?N.sub_add, ?N.eqb_refl by auto;
     rewrite andb_true_iff, ?N.eqb_eq;
     cbn in enough_balance.
@@ -456,17 +556,20 @@ Lemma try_transfer_allowance_correct : forall prev_state new_state chain ctx new
 Proof.
   intros * receive_some.
   receive_simpl.
-  clear g0 H1.
   unfold transfer_allowances_update_correct.
   cbn.
   destruct_match eqn:sender_from_eqb.
   - (* sender = from *)
-    rename H into allowances_eq.
+    match goal with
+    [ H : Some (allowances _) = Some _ |- _ ] => rename H into allowances_eq
+    end.
     inversion_clear allowances_eq.
     now rewrite N.eqb_refl.
   - (* sender <> from *)
     receive_simpl.
-    rename H0 into enough_allowance.
+    match goal with
+    [ H : with_default 0 (FMap.find _ (allowances _)) <? _ = false |- _ ] => rename H into enough_allowance
+    end.
     rewrite N.ltb_ge in enough_allowance.
     rewrite FMap.find_update_eq.
     destruct (FMap.find (from param, ctx_from ctx) (allowances prev_state)) eqn:from_prev; cbn.
@@ -520,7 +623,9 @@ Proof.
   intros * receive_some account allowance_key_ne.
   receive_simpl.
   cbn.
-  rename H into allowance_eq.
+  match goal with
+    [ H : _ = Some _ |- _ ] => rename H into allowance_eq
+  end.
   destruct_address_eq.
   - (* from = sender *)
     now inversion_clear allowance_eq.
@@ -538,8 +643,8 @@ Lemma try_transfer_remove_empty_allowances : forall prev_state new_state chain c
 Proof.
   intros * IH receive_some *.
   receive_simpl.
-  destruct_match in H.
-  - now inversion_clear H.
+  destruct_match in *.
+  - now receive_simpl.
   - receive_simpl.
     rewrite !FMap.find_update_eq.
     now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
@@ -554,15 +659,13 @@ Lemma try_transfer_remove_empty_balances : forall prev_state new_state chain ctx
 Proof.
   intros * receive_some *.
   receive_simpl.
-  clear H g0.
-  rename H1 into enough_balance.
-  apply N.ltb_ge in enough_balance.
+  rewrite N.ltb_ge in *.
   destruct (address_eqb_spec param.(from) param.(to)) as [<-|]; auto.
   - rewrite !FMap.find_update_eq.
     now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
   - rewrite !FMap.find_update_ne by auto.
     rewrite !FMap.find_update_eq.
-    rewrite !FMap.find_update_ne by auto.
+    rewrite !FMap.find_update_ne with (map := prev_state.(tokens)) by auto.
     specialize (maybe_cases ) as [[-> ?H] | [-> ?H]];
     now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
 Qed.
@@ -578,12 +681,9 @@ Lemma try_transfer_is_some : forall state chain ctx param,
 Proof.
   split.
   - intros (amount_zero & enough_balance & enough_allowance).
-    (*do 2 eexists.
-    receive_simpl.*)
-    unfold receive.
     apply Z.ltb_ge in amount_zero.
-    rewrite amount_zero.
     cbn.
+    rewrite amount_zero;cbn.
     destruct_match eqn:allowances_eq;
     destruct_match eqn:sender_from_eqb in allowances_eq; try congruence;
     try destruct_match eqn:enough_allowance_check in allowances_eq; try congruence;
@@ -610,18 +710,16 @@ Proof.
       now apply not_eq_sym, enough_allowance, N.le_ngt in sender_from_ne.
   - intros (new_state & new_acts & receive_some).
     receive_simpl.
-    split; try now apply Z.ltb_ge in ctx_amount_zero.
-    clear ctx_amount_zero g0.
-    rename H1 into enough_balance.
-    apply N.ltb_ge in enough_balance.
-    rename H into allowance_check.
-    destruct_match eqn:sender_from_eqb in allowance_check;
+    rewrite Z.ltb_ge in *.
+    split; try assumption.
+    rewrite N.ltb_ge in *.
+    destruct_match eqn:sender_from_eqb in *.
       destruct (address_eqb_spec ctx.(ctx_from) param.(from)) as
-        [send_from_eq | sender_from_ne]; try discriminate.
-    + (* sender = from *)
-      now split.
+        [send_from_eq | sender_from_ne];receive_simpl;try discriminate.
+    +  (* sender = from *)
+       now split.
     + (* sender <> from *)
-      destruct_match eqn:enough_allowance in allowance_check; try congruence.
+      destruct_match eqn:enough_allowance in *; try congruence.
       receive_simpl.
       now apply N.ltb_ge in enough_allowance.
 Qed.
@@ -636,7 +734,6 @@ Lemma try_approve_allowance_correct : forall prev_state new_state chain ctx new_
 Proof.
   intros * receive_some.
   receive_simpl.
-  clear H ctx_amount_zero.
   cbn.
   now rewrite !FMap.find_update_eq.
 Qed.
@@ -658,7 +755,6 @@ Lemma try_approve_preserves_other_allowances : forall prev_state new_state chain
 Proof.
   intros * receive_some allowance_key allowance_key_ne.
   receive_simpl.
-  clear H ctx_amount_zero.
   cbn.
   now rewrite FMap.find_update_ne.
 Qed.
@@ -704,8 +800,8 @@ Proof.
   - intros (amount_zero & safe_approval).
     do 2 eexists.
     receive_simpl.
-    apply Z.ltb_ge in amount_zero.
-    rewrite amount_zero.
+    rewrite <- Z.ltb_ge in amount_zero.
+    rewrite amount_zero;cbn.
     destruct_match eqn:safe_approval_check; eauto.
     receive_simpl.
     apply andb_prop in safe_approval_check as
@@ -713,9 +809,8 @@ Proof.
     now destruct safe_approval.
   - intros (new_state & new_acts & receive_some).
     receive_simpl.
-    split; try now apply Z.ltb_ge in ctx_amount_zero.
-    rename H into safe_approval.
-    now apply andb_false_iff in safe_approval as [?%N.ltb_ge | ?%N.ltb_ge].
+    split. now rewrite Z.ltb_ge in *.
+    now rewrite andb_false_iff in *;repeat rewrite N.ltb_ge in *.
 Qed.
 
 
@@ -729,14 +824,13 @@ Lemma try_mint_or_burn_balance_correct : forall prev_state new_state chain ctx n
 Proof.
   intros * receive_some.
   receive_simpl.
-  rename H0 into enough_tokens.
-  clear ctx_amount_zero H.
-  rewrite Z.ltb_ge in enough_tokens.
+  rewrite Z.ltb_ge in *.
   cbn.
   rewrite FMap.find_update_eq.
   unfold maybe.
-  destruct (Z.to_N (Z.of_N (with_default 0 (FMap.find (target param) (tokens prev_state))) + quantity param) =? 0) eqn:eq_zero; cbn.
-  - apply Neqb_ok in eq_zero.
+  unfold FMap.find in *. (* NOTE: after using AddressMap, unification fails sometime, unless we unfold [FMap.find] and other definitions. *)
+  destruct (Z.to_N (Z.of_N (with_default 0 _) + quantity param) =? 0) eqn:eq_zero; cbn.
+  - apply Neqb_ok in eq_zero. unfold FMap.find in *.
     lia.
   - rewrite <- Z2N.id by lia.
     lia.
@@ -751,13 +845,10 @@ Lemma try_mint_or_burn_total_supply_correct : forall prev_state new_state chain 
 Proof.
   intros * balance_le_total_supply receive_some.
   receive_simpl.
-  rename H0 into enough_tokens.
-  clear ctx_amount_zero H.
-  rewrite Z.ltb_ge in enough_tokens.
+  rewrite Z.ltb_ge in *.
   cbn.
-  rewrite N2Z.inj_abs_N, Z.abs_eq; auto.
-  eapply Z.le_trans; try apply enough_tokens.
-  now apply Zplus_le_compat_r, N2Z.inj_le.
+  rewrite N2Z.inj_abs_N, Z.abs_eq;auto.
+  unfold FMap.find in *;lia.
 Qed.
 
 
@@ -798,8 +889,7 @@ Lemma try_mint_or_burn_remove_empty_balances : forall prev_state new_state chain
 Proof.
   intros * receive_some *.
   receive_simpl.
-  rename H0 into enough_balance.
-  apply Z.ltb_ge in enough_balance.
+  rewrite Z.ltb_ge in *.
   cbn.
   rewrite FMap.find_update_eq.
   now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
@@ -823,10 +913,11 @@ Proof.
     clear e from_admin. cbn.
     destruct_match eqn:enough_balance_check; eauto.
     receive_simpl.
+    unfold FMap.find in *.
     now apply Z.ltb_lt in enough_balance_check.
   - intros (new_state & new_acts & receive_some).
     receive_simpl.
-    split; try now apply Z.ltb_ge in ctx_amount_zero.
+    split; try now rewrite Z.ltb_ge in *.
     split; try now destruct_address_eq.
     now apply Z.ltb_ge.
 Qed.
@@ -864,12 +955,12 @@ Lemma try_get_allowance_is_some : forall prev_state chain ctx param,
 Proof.
   split.
   - intros amount_zero.
-    unfold receive.
+    cbn.
     apply Z.ltb_ge in amount_zero.
     now rewrite amount_zero.
   - intros (new_state & new_acts & receive_some).
     receive_simpl.
-    now apply Z.ltb_ge in ctx_amount_zero.
+    now rewrite Z.ltb_ge in *.
 Qed.
 
 
@@ -906,11 +997,10 @@ Proof.
   split.
   - intros amount_zero.
     unfold receive.
-    apply Z.ltb_ge in amount_zero.
+    rewrite <- Z.ltb_ge in *;cbn.
     now rewrite amount_zero.
   - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    now apply Z.ltb_ge in ctx_amount_zero.
+    now receive_simpl.
 Qed.
 
 
@@ -946,12 +1036,11 @@ Lemma try_get_total_supply_is_some : forall prev_state chain ctx param,
 Proof.
   split.
   - intros amount_zero.
-    unfold receive.
+    cbn.
     apply Z.ltb_ge in amount_zero.
     now rewrite amount_zero.
   - intros (new_state & new_acts & receive_some).
-    receive_simpl.
-    now apply Z.ltb_ge in ctx_amount_zero.
+    now receive_simpl.
 Qed.
 
 
@@ -1036,10 +1125,10 @@ Lemma no_self_calls bstate caddr :
     | _ => False
     end) (outgoing_acts bstate caddr).
 Proof.
-  contract_induction; intros; cbn in *; auto.
+  contract_induction; intros; auto.
   - now inversion IH.
   - apply Forall_app; split; auto.
-    clear IH.
+    clear IH.  simpl in *.
     destruct msg.
     + destruct m;
         (try_solve_acts_correct;
@@ -1102,7 +1191,7 @@ Lemma outgoing_acts_amount_zero : forall bstate caddr,
 Proof.
   intros * reach deployed.
   apply (lift_outgoing_acts_prop contract); auto.
-  intros * receive_some; cbn in *.
+  intros * receive_some. simpl in *.
   destruct msg.
   - destruct m;try_solve_acts_correct.
   - receive_simpl.
@@ -1120,7 +1209,7 @@ Lemma outgoing_acts_are_calls : forall bstate caddr,
 Proof.
   intros * reach deployed.
   apply (lift_outgoing_acts_prop contract); auto.
-  intros * receive_some; cbn in *.
+  intros * receive_some; simpl in *.
   destruct msg.
   - destruct m; try_solve_acts_correct.
   - receive_simpl.
@@ -1147,6 +1236,7 @@ Proof.
   - instantiate (CallFacts := fun _ ctx _ _ =>
       (0 <= ctx_amount ctx)%Z /\ ctx_from ctx <> ctx_contract_address ctx).
     destruct facts as (ctx_amount_positive & _).
+    simpl in *.
     apply contract_not_payable in receive_some as not_payable.
     apply new_acts_amount_zero in receive_some as amount_zero_new_acts.
     apply Z.le_antisymm in ctx_amount_positive; auto.
@@ -1219,26 +1309,24 @@ Lemma sum_balances_eq_total_supply : forall bstate caddr,
 Proof.
   intros * reach deployed.
   apply (lift_contract_state_prop contract);
-    intros *; auto; clear reach deployed bstate caddr.
+    intros *;simpl in *; auto; clear reach deployed bstate caddr.
   - intros init_some.
-    unfold sum_balances.
+    unfold sum_balances. cbn in *.
     erewrite init_total_supply_correct, init_balances_correct; eauto.
     rewrite FMap.elements_add, FMap.elements_empty by auto.
     now cbn.
   - intros IH receive_some.
-    destruct msg. destruct m;cbn in *.
+    destruct msg. destruct m.
     + erewrite <- try_transfer_preserves_total_supply; eauto.
       rename t into param.
       unfold sum_balances.
       receive_simpl.
       cbn.
-      rename H1 into enough_balance.
-      apply N.ltb_ge in enough_balance.
-      clear ctx_amount_zero g g0 H ctx chain new_cstate.
+      rewrite N.ltb_ge in *.
       destruct (address_eqb_spec param.(from) param.(to)) as
         [<-| from_to_ne];
         [rewrite FMap.find_update_eq | rewrite FMap.find_update_ne by auto];
-        destruct (FMap.find (from param) (tokens cstate)) eqn:from_balance;
+        destruct (FMap.find (from param) _) eqn:from_balance;
         destruct (FMap.find (to param) (tokens cstate)) eqn:to_balance;
         destruct param;cbn in *;
           unshelve (repeat match goal with
@@ -1278,7 +1366,7 @@ Proof.
             | |- context [ maybe _ ] => specialize maybe_cases as [[-> ?H] | [-> _]]
             | H : ?y <> ?x |- context [ sumN _ ((?x, ?n) :: FMap.elements (FMap.remove ?y _)) ] =>
                 cbn; rewrite N.add_comm; change n with ((fun '(_, v) => v) (y, n)); rewrite sumN_inv
-           end); try easy.
+           end);try easy.
     + erewrite <- try_approve_preserves_total_supply; eauto.
       unfold sum_balances.
       erewrite <- try_approve_preserves_balances; eauto.
@@ -1286,10 +1374,8 @@ Proof.
       unfold sum_balances.
       receive_simpl.
       cbn.
-      clear ctx_amount_zero H new_cstate ctx chain.
-      rename H0 into enough_balance.
-      apply Z.ltb_ge in enough_balance.
-      destruct (FMap.find (target param) (tokens cstate)) eqn:target_balance; cbn.
+      rewrite Z.ltb_ge in *.
+      destruct (FMap.find (target param) _) eqn:target_balance; cbn.
       * assert (N_add_sub_move : forall n m p, p <= n -> n - p = m -> n = m + p) by lia.
         specialize (balance_le_sum_balances param.(target) cstate) as n_le_supply.
         rewrite target_balance in n_le_supply.
@@ -1364,14 +1450,14 @@ Proof.
   apply (lift_dep_info_contract_state_prop contract);
     auto; intros *; clear deployed trace bstate caddr.
   - intros init_some initial_pool_positive * addr_some.
-    erewrite init_balances_correct in addr_some; eauto.
     cbn in *.
+    erewrite init_balances_correct in addr_some; eauto.
     destruct (address_eqb_spec addr (lqt_provider setup)) as [<-| addr_ne] in addr_some.
     + now rewrite FMap.find_add in addr_some.
     + now rewrite FMap.find_add_ne in addr_some.
   - intros IH receive_some initial_pool_positive * addr_some.
     unfold Blockchain.receive in receive_some.
-    cbn in receive_some.
+    simpl in receive_some.
     destruct msg. destruct m.
     + destruct t.
       specialize (address_eqb_spec addr from0) as [<- | addr_from_ne];
@@ -1411,12 +1497,12 @@ Proof.
   intros * reach deployed.
   apply (lift_contract_state_prop contract);
     intros *; auto; clear reach deployed bstate caddr.
-  - intros init_some * addr_some.
+  - intros init_some * addr_some. cbn in *.
     erewrite init_allowances_correct in addr_some by eauto.
     now rewrite FMap.find_empty in addr_some.
   - intros IH receive_some * addr_some.
     unfold Blockchain.receive in receive_some.
-    cbn in receive_some.
+    simpl in receive_some.
     destruct msg. destruct m.
     + destruct t.
       specialize (address_eqb_spec ctx.(ctx_from) from0) as [<- | addr_from_ne];
@@ -1424,24 +1510,24 @@ Proof.
       * now eapply try_transfer_remove_empty_allowances in receive_some.
       * eapply try_transfer_preserves_other_allowances in receive_some.
        -- now rewrite <- receive_some in addr_some.
-       -- intros H.
-          now inversion H.
+       -- intros HH.
+          now inversion HH.
       * eapply try_transfer_preserves_other_allowances in receive_some.
        -- now rewrite <- receive_some in addr_some.
-       -- intros H.
-          now inversion H.
+       -- intros HH.
+          now inversion HH.
     + destruct a.
       specialize (address_eqb_spec ctx.(ctx_from) sender) as [<- | addr_from_ne];
       only 1: specialize (address_eqb_spec spender0 from0) as [<- | addr_from_ne].
       * now eapply try_approve_remove_empty_allowances in receive_some.
       * eapply try_approve_preserves_other_allowances in receive_some.
        -- now rewrite <- receive_some in addr_some.
-       -- intros H.
-          now inversion H.
+       -- intros HH.
+          now inversion HH.
       * eapply try_approve_preserves_other_allowances in receive_some.
        -- now rewrite <- receive_some in addr_some.
-       -- intros H.
-          now inversion H.
+       -- intros HH.
+          now inversion HH.
     + apply try_mint_or_burn_preserves_allowances in receive_some.
       now rewrite receive_some in *.
     + apply try_get_allowance_preserves_state in receive_some.
@@ -1476,8 +1562,7 @@ Lemma total_supply_correct : forall bstate caddr (trace : ChainTrace empty_state
 Proof.
   contract_induction;
     intros; auto.
-  - erewrite init_total_supply_correct by eauto.
-    now cbn.
+  - now cbn in *;erewrite init_total_supply_correct by eauto.
   - instantiate (CallFacts := fun _ ctx state _ =>
       total_supply state = sum_balances state /\
       ctx_from ctx <> ctx_contract_address ctx).
@@ -1487,7 +1572,7 @@ Proof.
     clear tag IH AddBlockFacts DeployFacts CallFacts dep_info
       prev_out_queue prev_inc_calls prev_out_txs.
     unfold Blockchain.receive in receive_some.
-    cbn in receive_some.
+    simpl in receive_some.
     destruct msg. destruct m.
     + now erewrite <- try_transfer_preserves_total_supply.
     + now erewrite <- try_approve_preserves_total_supply.
@@ -1517,4 +1602,3 @@ Proof.
 Qed.
 
 End Theories.
-End LQTFA12.

--- a/execution/examples/EIP20Token.v
+++ b/execution/examples/EIP20Token.v
@@ -594,6 +594,8 @@ Proof.
   FMap_simpl.
 Qed.
 
+Set Keyed Unification.
+
 (** If the requirements are met then then receive on transfer_from msg must succeed and
     if receive on transfer_from msg succeeds then requirements must hold *)
 Lemma try_transfer_from_is_some : forall state chain ctx from to amount,
@@ -612,22 +614,24 @@ Proof.
             sender_allowance &
             from_enough_balance%N.ltb_ge &
             sender_enough_allowance%N.ltb_ge).
-    destruct_match eqn:allowances_ctx; setoid_rewrite allowances_ctx in sender_allowance; auto.
-    setoid_rewrite allowances_ctx in sender_enough_allowance.
-    cbn in *. clear from_allowances_some.
-    destruct_match eqn:allowance_ctx; setoid_rewrite allowance_ctx in sender_allowance; auto.
-    setoid_rewrite allowance_ctx in sender_enough_allowance.
+    destruct_match eqn:allowances_ctx;cbn in *;auto.
+    clear from_allowances_some.
+    destruct_match eqn:allowance_ctx; rewrite allowance_ctx in sender_allowance; auto.
+    rewrite allowance_ctx in sender_enough_allowance.
     cbn in *. clear sender_allowance.
     destruct_match eqn:amount_from; auto.
-    setoid_rewrite from_enough_balance in amount_from.
-    now setoid_rewrite sender_enough_allowance in amount_from.
+    rewrite from_enough_balance in amount_from.
+    now rewrite sender_enough_allowance in amount_from.
   - intros receive_some.
-    destruct_match eqn:allowances_ctx in receive_some; setoid_rewrite allowances_ctx; try discriminate.
-    destruct_match eqn:allowance_ctx in receive_some; setoid_rewrite allowance_ctx; try discriminate.
+    (* destruct_match eqn:allowances_ctx in receive_some; rewrite allowances_ctx; try discriminate. *)
+    destruct_match eqn:allowances_ctx in receive_some; try discriminate.
+    (* destruct_match eqn:allowance_ctx in receive_some; rewrite allowance_ctx; try discriminate. *)
+    destruct_match eqn:allowance_ctx in receive_some; try discriminate.
     destruct_match eqn:amount_from in receive_some; try discriminate.
+    cbn in *.
     apply Bool.orb_false_iff in amount_from as
-      (from_enough_balance%N.ltb_ge & sender_enough_allowance%N.ltb_ge).
-    intuition.
+        (from_enough_balance%N.ltb_ge & sender_enough_allowance%N.ltb_ge).
+    now rewrite allowance_ctx.
 Qed.
 
 
@@ -692,7 +696,6 @@ Proof.
   receive_simpl.
   unfold get_allowance.
   destruct_match eqn:allowances_from in receive_some;
-    setoid_rewrite allowances_from;
     inversion receive_some;
     cbn; FMap_simpl.
 Qed.

--- a/extraction/_CoqProject
+++ b/extraction/_CoqProject
@@ -31,6 +31,7 @@ theories/ExtractionCorrectness.v
 theories/Inlining.v
 theories/LPretty.v
 theories/LiquidityExtract.v
+theories/NumLiteralTests.v
 theories/Optimize.v
 theories/OptimizeCorrectness.v
 theories/OptimizePropDiscr.v

--- a/extraction/examples/BoardroomVotingExtractionCameLIGO.v
+++ b/extraction/examples/BoardroomVotingExtractionCameLIGO.v
@@ -222,7 +222,6 @@ Definition to_inline : list kername :=
   ; <%% @BV.set_VoterInfo_vote_hash %%>
   ; <%% @BV.set_VoterInfo_public_vote %%>
 
-  ; <%% @Common.AddressMap.AddrMap %%>
   ].
 
 (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)

--- a/extraction/examples/BoardroomVotingExtractionLiquidity.v
+++ b/extraction/examples/BoardroomVotingExtractionLiquidity.v
@@ -308,7 +308,6 @@ Definition TT_remap : list (kername * string) :=
   ; remap <%% @ctx_amount %%> "(fun c -> c.(1).(1).(1))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
   ; remap <%% @ctx_contract_address %%> "(fun c -> c.(1).(0))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
   ; remap <%% @ctx_contract_balance %%> "(fun c -> c.(1).(1).(0))" (* small hack, but valid since ContractCallContext is mapped to a tuple *)
-  ; remap <%% @AddressMap.AddrMap %%> "addrMap"
   ; remap <%% @AddressMap.add %%> "Map.add"
   ; remap <%% @AddressMap.find %%> "Map.find"
   ; remap <%% @AddressMap.of_list %%> "Map.of_list"

--- a/extraction/examples/CameLIGOExtractionTests.v
+++ b/extraction/examples/CameLIGOExtractionTests.v
@@ -404,7 +404,6 @@ Section EIP20TokenExtraction.
     ; <%% @setter_from_getter_State_allowances %%>
     ; <%% @set_State_balances %%>
     ; <%% @set_State_allowances%%>
-    ; <%% @Common.AddressMap.AddrMap %%>
     ].
 
   Time MetaCoq Run

--- a/extraction/examples/Dexter2Extract.v
+++ b/extraction/examples/Dexter2Extract.v
@@ -15,64 +15,24 @@ From ConCert.Execution Require Import Blockchain.
 From ConCert.Execution.Examples Require Dexter2CPMM.
 From ConCert.Execution Require Import Containers.
 From ConCert.Utils Require Import RecordUpdate.
+From ConCert.Execution Require Import Monads.
 From ConCert.Utils Require Import StringExtra.
-
-From stdpp Require gmap.
-
 
 Local Open Scope string_scope.
 
-Import MonadNotation.
+(* Import MonadNotation. *)
 Open Scope Z.
 
-(** Exposing a printing configuration *)
-Existing Instance PrintConfAddModuleNames.PrintWithModuleNames.
+(** Printing configuration *)
+
+(** We print long names for data types and constructors to avoid clashes, but keep constants' names short (no module name added) *)
+Instance dexter2_print_config : CameLIGOPrintConfig :=
+  {| print_ctor_name := PrintConfAddModuleNames.print_ctor_name_;
+     print_type_name := PrintConfAddModuleNames.print_ind_type_name_;
+     print_const_name := snd |}.
 
 Import RecordSetNotations.
 
-
-(** Serialisation plays no role in the extraction result, therfore we defining instances
-    using the opaque ascription of module types to speedup the extraction *)
-Module DSInstancesOpaque : Dexter2CPMM.Dexter2Serializable := Dexter2CPMM.DSInstances.
-
-Module DEX2Extract := Dexter2CPMM.Dexter2 DSInstancesOpaque.
-
-Section Dexter2Extraction.
-
-  Context `{ChainBase}.
-
-  Open Scope Z_scope.
-
-  Import DEX2Extract.
-  Import Dexter2CPMM.
-
-  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
-    let ctx_ := ctx in
-    Some {|
-        tokenPool := 0;
-        xtzPool := 0;
-        lqtTotal := setup.(lqtTotal_);
-        selfIsUpdatingTokenPool := false;
-        freezeBaker := false;
-        manager := setup.(manager_);
-        tokenAddress := setup.(tokenAddress_);
-        tokenId := setup.(tokenId_);
-        lqtAddress := null_address
-      |}.
-
-  Set Printing All.
-
-  Print DEX2Extract.call_to_token.
-  Definition receive_ (chain : Chain)
-       (ctx : ContractCallContext)
-       (state : State)
-       (maybe_msg : option DEX2Extract.Msg)
-    : option (list ActionBody * State) :=
-    match DEX2Extract.receive chain ctx state maybe_msg with
-    | Some x => Some (x.2, x.1)
-    | None => None
-    end.
-  Close Scope Z_scope.
 
   Definition call_to_token_ligo : string :=
     <$ "let call_to_token (addr : address) (amt : nat) (msg : _msg) : operation =" ;
@@ -81,6 +41,9 @@ Section Dexter2Extraction.
        "    Some contract -> contract";
        "  | None -> (failwith ""Contract not found."" : _msg contract) in";
        "  Tezos.transaction msg (natural_to_mutez amt) token_" $>.
+
+Definition mk_callback_ligo : string :=
+  "[@inline] let mk_callback (addr : address) (msg : _msg) : operation = call_to_token addr 0n msg".
 
   (** Next two definition are borrowed from the actual Dexter 2 implementation
        https://gitlab.com/dexter2tz/dexter2tz/-/blob/master/dexter.mligo *)
@@ -100,6 +63,228 @@ Section Dexter2Extraction.
 
   Definition subNatTruncated_ligo : string :=
     "let subNTruncated (n : nat) (m : nat) : nat = if n < m then 0n else abs (n-m)".
+
+  Definition edivNatTrancated_ligo : string :=
+    "let edivTruncated (a : nat) (b : nat) = match ediv a b with Some v -> v | None -> (0n,0n)".
+
+Definition TT_remap_arith : list (kername * string) :=
+[   remap <%% Z %%> "int"
+  ; remap <%% N %%> "nat"
+
+  ; remap <%% N.add %%> "addN"
+  ; remap <%% N.sub %%> "subNTruncated"
+  ; remap <%% N.mul %%> "multN"
+  ; remap <%% N.leb %%> "lebN"
+  ; remap <%% N.ltb %%> "ltbN"
+  ; remap <%% N.eqb %%> "eqN"
+  ; remap <%% N.modulo %%> "moduloN"
+
+  ; remap <%% Z.add %%> "addInt"
+  ; remap <%% Z.sub %%> "subInt"
+  ; remap <%% Z.mul %%> "multInt"
+  ; remap <%% Z.leb %%> "leInt"
+  ; remap <%% Z.ltb %%> "ltInt"
+  ; remap <%% Z.eqb %%> "eqInt"
+  ; remap <%% Z.gtb %%> "gtbInt"
+  ; remap <%% Z.even %%> "evenInt"
+  ; remap <%% Z.abs_N %%> "abs"
+
+  ; remap <%% Z.of_N %%> "z_of_N"
+  ; remap <%% Z.to_N %%> "abs"
+].
+
+  Definition addrMap_ligo := "type 'a addrMap = (address, 'a) map".
+
+  Definition TT_remap_dexter2 : list (kername * string) :=
+   [
+    remap <%% @ContractCallContext %%> CameLIGO_call_ctx_type_name
+  ; remap <%% @FMap %%> "map"
+  ; remap <%% @Common.AddressMap.add %%> "Map.add"
+  ; remap <%% @Common.AddressMap.find %%> "Map.find_opt"
+  ; remap <%% @Common.AddressMap.empty %%> "Map.empty"
+  ; remap <%% @Common.AddressMap.update %%> "Map.update"
+  ; remap <%% @FMap.add %%> "Map.add"
+  ; remap <%% @FMap.find %%> "Map.find_opt"
+  ; remap <%% @FMap.empty %%> "Map.empty"
+  ; remap <%% @FMap.update %%> "Map.update"
+  ; remap <%% @address_eqb %%> "eq_addr"
+   ].
+
+  Definition TT_inlines_dexter2 : list kername :=
+    [
+      <%% Monads.Monad_option %%>
+    ; <%% @Monads.bind %%>
+    ; <%% @Monads.ret %%>
+    ; <%% @Extras.with_default %%>
+    ; <%% option_map %%>
+
+    ; <%% @SetterFromGetter %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_tokenPool %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_selfIsUpdatingTokenPool %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_xtzPool %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_lqtTotal %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_freezeBaker %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_manager %%>
+    ; <%% @Dexter2CPMM.setter_from_getter_State_lqtAddress %%> ].
+
+Module Dexter2LqtExtraction.
+
+  (** Serialisation plays no role in the extraction result, therfore we defining instances
+      using the opaque ascription of module types to speedup the extraction *)
+  Module DLqtSInstancesOpaque : Dexter2FA12.Dexter2LqtSerializable := Dexter2FA12.D2LqtSInstances.
+
+  Module DEX2LQTExtract := Dexter2FA12.Dexter2Lqt DLqtSInstancesOpaque.
+
+  Open Scope Z_scope.
+
+  Import DEX2LQTExtract.
+  Import Dexter2FA12.
+
+  Section D2LqtE.
+  Context `{ChainBase}.
+
+
+  Definition TT_Dexter2_Lqt :=
+    [ remap <%% @Serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+    ; remap <%% @DLqtSInstancesOpaque.setup_serializable %%> ""  (* FIXME: workaround; should be ignored instead *)
+    ; remap <%% unit_serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+    ; remap <%% @mk_callback %%> "mk_callback"
+    ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
+    ; remap <%% @update_allowance %%> "Map.update"
+    ; remap <%% @find_allowance %%> "Map.find_opt"
+    ; remap <%% @empty_allowance %%> "Map.empty"
+     ].
+
+  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
+    let ctx_ := ctx in
+    Some {|
+        tokens := Common.AddressMap.add setup.(lqt_provider) setup.(initial_pool) Common.AddressMap.empty;
+        allowances := empty_allowance;
+        admin := setup.(admin_);
+        total_supply := setup.(initial_pool);
+      |}.
+
+  Definition receive_ (chain : Chain)
+       (ctx : ContractCallContext)
+       (state : State)
+       (maybe_msg : option Dexter2FA12.Msg)
+    : option (list ActionBody * State) :=
+    match DEX2LQTExtract.receive chain ctx state maybe_msg with
+    | Some x => Some (x.2, x.1)
+    | None => None
+    end.
+
+  Definition TT_remap_all :=
+    (TT_remap_arith ++ TT_remap_dexter2 ++ TT_Dexter2_Lqt)%list.
+
+  Definition LIGO_DEXTER2LQT_MODULE : CameLIGOMod Msg ContractCallContext Setup State ActionBody :=
+  {| (* a name for the definition with the extracted code *)
+     lmd_module_name := "cameLIGO_dexter2lqt" ;
+
+      (* definitions of operations on pairs and ints *)
+     lmd_prelude := CameLIGOPrelude ++ nl ++ nl ++
+                    <$ call_to_token_ligo;
+                       "";
+                       mk_callback_ligo;
+                       "";
+                       natural_to_mutez_ligo;
+                       "";
+                       mutez_to_natural_ligo;
+                       "";
+                       xtz_transfer_ligo;
+                       "";
+                       subNatTruncated_ligo $>;
+
+      (* initial storage *)
+      lmd_init := init ;
+
+      (* NOTE: printed as local [let]-bound definitions in the init *)
+      lmd_init_prelude := "";
+
+      (* TODO: maybe not needed, [lmd_prelude] should be enough *)
+      lmd_receive_prelude := "";
+
+      (* the main functionality *)
+      lmd_receive := receive_ ;
+
+      (* code for the entry point *)
+    lmd_entry_point := print_default_entry_point <%% @State %%>
+                                                 <%% @receive_ %%>
+                                                 <%% @Msg %%> |}.
+
+  Time MetaCoq Run
+  (CameLIGO_prepare_extraction TT_inlines_dexter2 TT_remap_all TT_rename_ctors_default "cctx_instance" LIGO_DEXTER2LQT_MODULE).
+
+  Time Definition cameLIGO_dexter2lqt := Eval vm_compute in cameLIGO_dexter2lqt_prepared.
+
+  MetaCoq Run (tmMsg cameLIGO_dexter2lqt).
+
+  (** We redirect the extraction result for later processing and compiling with the CameLIGO compiler *)
+  Redirect "examples/extracted-code/cameligo-extract/dexter2fa12.mligo"
+           MetaCoq Run (tmMsg cameLIGO_dexter2lqt).
+
+
+  End D2LqtE.
+End Dexter2LqtExtraction.
+
+Module Dexter2Extraction.
+
+(** Serialisation plays no role in the extraction result, therfore we defining instances
+    using the opaque ascription of module types to speedup the extraction *)
+Module DSInstancesOpaque : Dexter2CPMM.Dexter2Serializable := Dexter2CPMM.DSInstances.
+
+Module DEX2Extract := Dexter2CPMM.Dexter2 DSInstancesOpaque.
+
+Open Scope Z_scope.
+
+Import DEX2Extract.
+Import Dexter2CPMM.
+
+Section D2E.
+  Context `{ChainBase}.
+
+  Definition TT_Dexter2_CPMM :=
+   [ remap <%% @call_to_token %%> "call_to_token"
+   ; remap <%% @call_to_other_token %%> "call_to_token"
+   ; remap <%% @xtz_transfer %%> "xtz_transfer"
+   ; remap <%% @call_liquidity_token %%> "call_to_token"
+   ; remap <%% token_id %%> "nat"
+
+   ; remap <%% @null_address %%> "(""tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU"" : address)"
+   ; remap <%% @Serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+   ; remap <%% @DSInstancesOpaque.DexterMsg_serializable %%> "" (* FIXME: workaround; should be ignored instead *)
+
+   ; remap <%% N_to_amount %%> "natural_to_mutez"
+   ; remap <%% amount_to_N %%> "mutez_to_natural"
+   ; remap <%% div %%> "divN_opt"
+   ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)" ].
+
+  Definition TT_remap_all :=
+    (TT_remap_arith ++ TT_remap_dexter2 ++ TT_Dexter2_CPMM)%list.
+
+  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
+    let ctx_ := ctx in
+    Some {|
+        tokenPool := 0;
+        xtzPool := 0;
+        lqtTotal := setup.(lqtTotal_);
+        selfIsUpdatingTokenPool := false;
+        freezeBaker := false;
+        manager := setup.(manager_);
+        tokenAddress := setup.(tokenAddress_);
+        tokenId := setup.(tokenId_);
+        lqtAddress := null_address
+      |}.
+
+  Definition receive_ (chain : Chain)
+       (ctx : ContractCallContext)
+       (state : State)
+       (maybe_msg : option DEX2Extract.Msg)
+    : option (list ActionBody * State) :=
+    match DEX2Extract.receive chain ctx state maybe_msg with
+    | Some x => Some (x.2, x.1)
+    | None => None
+    end.
 
   Definition LIGO_DEXTER2_MODULE : CameLIGOMod Msg ContractCallContext Setup State ActionBody :=
   {| (* a name for the definition with the extracted code *)
@@ -134,88 +319,15 @@ Section Dexter2Extraction.
                                                  <%% @receive_ %%>
                                                  <%% @Msg %%> |}.
 
-  Definition TT_remap_arith : list (kername * string) :=
-[   remap <%% Z %%> "int"
-  ; remap <%% N %%> "nat"
-  ; remap <%% nat %%> "nat"
-
-  ; remap <%% Nat.add %%> "addN"
-  ; remap <%% Nat.leb %%> "lebN"
-  ; remap <%% Nat.ltb %%> "ltbN"
-  ; remap <%% Nat.mul %%> "multN"
-
-  ; remap <%% Pos.add %%> "addN"
-  ; remap <%% Pos.sub %%> "subN"
-  ; remap <%% Pos.mul %%> "multN"
-  ; remap <%% Pos.leb %%> "leN"
-  ; remap <%% Pos.eqb %%> "eqN"
-  ; remap <%% Z.add %%> "addInt"
-  ; remap <%% Z.sub %%> "subInt"
-  ; remap <%% Z.mul %%> "multInt"
-  ; remap <%% Z.div %%> "divInt"
-  ; remap <%% Z.leb %%> "leInt"
-  ; remap <%% Z.ltb %%> "ltInt"
-  ; remap <%% Z.eqb %%> "eqInt"
-  ; remap <%% Z.gtb %%> "gtbInt"
-  ; remap <%% Z.even %%> "evenInt"
-  ; remap <%% N.add %%> "addN"
-  ; remap <%% N.sub %%> "subNTruncated"
-  ; remap <%% N.mul %%> "multN"
-  ; remap <%% N.leb %%> "lebN"
-  ; remap <%% N.ltb %%> "ltbN"
-  ; remap <%% N.eqb %%> "eqN"
-  ; remap <%% div %%> "divN_opt"
-  ; remap <%% N.modulo %%> "moduloN"
-  ; remap <%% N.sub %%> "subOption"
-  ; remap <%% N_to_amount %%> "natural_to_mutez"
-  ; remap <%% amount_to_N %%> "mutez_to_natural"
-  ; remap <%% Z.of_N %%> "z_of_N"
-  ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
-].
-
-  Definition TT_remap_dexter2 : list (kername * string) :=
-   [
-    remap <%% @ContractCallContext %%> CameLIGO_call_ctx_type_name
-  ; remap <%% @FMap %%> "map"
-  ; remap <%% @Common.AddressMap.add %%> "Map.add"
-  ; remap <%% @Common.AddressMap.find %%> "Map.find_opt"
-  ; remap <%% @Common.AddressMap.empty %%> "Map.empty"
-  ; remap <%% @FMap.add %%> "Map.add"
-  ; remap <%% @FMap.find %%> "Map.find_opt"
-  ; remap <%% @FMap.empty %%> "Map.empty"
-
-  ; remap <%% @call_to_token %%> "call_to_token"
-  ; remap <%% @call_to_other_token %%> "call_to_token"
-  ; remap <%% @xtz_transfer %%> "xtz_transfer"
-  ; remap <%% @call_liquidity_token %%> "call_to_token"
-  ; remap <%% token_id %%> "nat"
-
-  ; remap <%% @null_address %%> "(""tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU"" : address)"
-  ; remap <%% @Serializable %%> "" (* FIXME: workaround; should be ignored instead *)
-  ; remap <%% @DSInstancesOpaque.DexterMsg_serializable %%> "" (* FIXME: workaround; should be ignored instead *)
-   ].
-
-  Definition TT_remap_all :=
-    (TT_remap_arith ++ TT_remap_dexter2)%list.
-
-  Definition TT_inlines_dexter2 : list kername :=
-    [
-      <%% Monads.Monad_option %%>
-    ; <%% @Monads.bind %%>
-    ; <%% @Monads.ret %%>
-    ; <%% @Extras.with_default %%>
-
-    ; <%% @SetterFromGetter %%> ].
-
   Time MetaCoq Run
   (CameLIGO_prepare_extraction TT_inlines_dexter2 TT_remap_all TT_rename_ctors_default "cctx_instance" LIGO_DEXTER2_MODULE).
 
   Time Definition cameLIGO_dexter2 := Eval vm_compute in cameLIGO_dexter2_prepared.
 
-  MetaCoq Run (tmMsg cameLIGO_dexter2).
-
   (** We redirect the extraction result for later processing and compiling with the CameLIGO compiler *)
   Redirect "examples/extracted-code/cameligo-extract/dexter2CertifiedExtraction.mligo"
-  MetaCoq Run (tmMsg cameLIGO_dexter2).
+           MetaCoq Run (tmMsg cameLIGO_dexter2).
+
+End D2E.
 
 End Dexter2Extraction.

--- a/extraction/examples/ERC20LiquidityExtraction.v
+++ b/extraction/examples/ERC20LiquidityExtraction.v
@@ -46,7 +46,6 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% @fst %%> "fst"
   ; remap <%% @snd %%> "snd"
   ; remap <%% option %%> "option"
-  ; remap <%% @AddressMap.AddrMap %%> "addrMap"
   ; remap <%% positive %%> "nat"
   ; remap <%% Amount %%> "tez"
   ; remap <%% @Address %%> "address"
@@ -180,7 +179,6 @@ Section EIP20TokenExtraction.
     ; <%% @set_State_balances %%>
     ; <%% @set_State_allowances%%>
 
-    ; <%% @Common.AddressMap.AddrMap %%>
     ].
 
   Time MetaCoq Run

--- a/extraction/theories/Common.v
+++ b/extraction/theories/Common.v
@@ -223,13 +223,14 @@ Definition _Zpos :=  EAst.tConstruct {| inductive_mind := <%% Z %%>; inductive_i
 
 Definition _Zneg :=  EAst.tConstruct {| inductive_mind := <%% Z %%>; inductive_ind := 0 |} 2.
 
+Print Pos.to_nat.
 Fixpoint pos_syn_to_nat_aux (n : nat) (t : EAst.term) : option nat :=
   match t with
   | EAst.tApp (EAst.tConstruct ind i) t0 =>
     if eq_kername ind.(inductive_mind) <%% positive %%> then
       match i with
       | 0 => match pos_syn_to_nat_aux (n + n) t0 with
-            | Some v => Some (1 + v)
+            | Some v => Some (n + v)
             | None => None
             end
       | 1 => pos_syn_to_nat_aux (n + n) t0
@@ -245,10 +246,6 @@ Fixpoint pos_syn_to_nat_aux (n : nat) (t : EAst.term) : option nat :=
 
 Definition pos_syn_to_nat := pos_syn_to_nat_aux 1.
 
-Example pos_syn_to_nat_5 :
-  pos_syn_to_nat (EAst.tApp _xI (EAst.tApp _xO _xH)) = Some 5.
-Proof. reflexivity. Qed.
-
 Definition N_syn_to_nat (t : EAst.term) : option nat :=
   match t with
   | EAst.tConstruct ind 0 =>
@@ -263,18 +260,6 @@ Definition N_syn_to_nat (t : EAst.term) : option nat :=
     else None
   | _ => None
   end.
-
-Example N_syn_to_nat_0 :
-  N_syn_to_nat _N0 = Some 0.
-Proof. reflexivity. Qed.
-
-Example N_syn_to_nat_5 :
-  N_syn_to_nat (EAst.tApp _Npos (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some 5.
-Proof. reflexivity. Qed.
-
-Example N_syn_to_nat_fail :
-  N_syn_to_nat (EAst.tApp _Npos (EAst.tApp _xI (EAst.tVar ""))) = None.
-Proof. reflexivity. Qed.
 
 Definition Z_syn_to_Z (t : EAst.term) : option Z :=
   match t with
@@ -297,19 +282,3 @@ Definition Z_syn_to_Z (t : EAst.term) : option Z :=
     else None
   | _ => None
   end.
-
-Example Z_syn_to_Z_0 :
-  Z_syn_to_Z _Z0 = Some 0%Z.
-Proof. reflexivity. Qed.
-
-Example Z_syn_to_Z_5 :
-  Z_syn_to_Z (EAst.tApp _Zpos (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some 5%Z.
-Proof. reflexivity. Qed.
-
-Example Z_syn_to_Z_minus_5 :
-  Z_syn_to_Z (EAst.tApp _Zneg (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some (-5)%Z.
-Proof. reflexivity. Qed.
-
-Example Z_syn_to_Z_fail :
-  Z_syn_to_Z (EAst.tApp _Zpos (EAst.tApp _xI (EAst.tVar ""))) = None.
-Proof. reflexivity. Qed.

--- a/extraction/theories/Extraction.v
+++ b/extraction/theories/Extraction.v
@@ -35,7 +35,7 @@ Local Open Scope string.
 Import MonadNotation.
 
 Existing Instance extraction_checker_flags.
-
+--
 (** We consider a type to be empty, if it is not mutual and has no constructors *)
 Definition is_empty_type_decl (d : ExAst.global_decl) : bool :=
   match d with
@@ -139,7 +139,7 @@ Definition extract_within_coq : extract_template_env_params :=
           extract_transforms := [dearg_transform (fun _ => None) true true true true true] |} |}.
 
 Definition extract_template_env_within_coq := extract_template_env extract_within_coq.
-Print ExAst.one_inductive_body.
+
 (* returns a list of constructor names and the name of the inductive associated *)
 Definition get_projections (env : ExAst.global_env) : list (ident * ExAst.one_inductive_body) :=
   let get_projs (d : ExAst.global_decl) : list (ident * ExAst.one_inductive_body) :=

--- a/extraction/theories/NumLiteralTests.v
+++ b/extraction/theories/NumLiteralTests.v
@@ -1,0 +1,99 @@
+From Coq Require Import BinNums ZArith.
+From Coq Require Import String.
+
+From ConCert.Extraction Require Import Common.
+From ConCert.Extraction Require Import Extraction.
+
+From MetaCoq.Template Require Import Ast.
+From MetaCoq.Template Require Import monad_utils.
+From MetaCoq.Erasure Require EAst.
+From MetaCoq.SafeChecker Require Import PCUICSafeChecker.
+
+
+Example pos_syn_to_nat_5 :
+  pos_syn_to_nat (EAst.tApp _xI (EAst.tApp _xO _xH)) = Some 5.
+Proof. reflexivity. Qed.
+
+Example N_syn_to_nat_0 :
+  N_syn_to_nat _N0 = Some 0.
+Proof. reflexivity. Qed.
+
+Example N_syn_to_nat_5 :
+  N_syn_to_nat (EAst.tApp _Npos (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some 5.
+Proof. reflexivity. Qed.
+
+Open Scope string.
+
+Example N_syn_to_nat_fail :
+  N_syn_to_nat (EAst.tApp _Npos (EAst.tApp _xI (EAst.tVar ""))) = None.
+Proof. reflexivity. Qed.
+
+Example Z_syn_to_Z_0 :
+  Z_syn_to_Z _Z0 = Some 0%Z.
+Proof. reflexivity. Qed.
+
+Example Z_syn_to_Z_5 :
+  Z_syn_to_Z (EAst.tApp _Zpos (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some 5%Z.
+Proof. reflexivity. Qed.
+
+Example Z_syn_to_Z_minus_5 :
+  Z_syn_to_Z (EAst.tApp _Zneg (EAst.tApp _xI (EAst.tApp _xO _xH))) = Some (-5)%Z.
+Proof. reflexivity. Qed.
+
+Example Z_syn_to_Z_fail :
+  Z_syn_to_Z (EAst.tApp _Zpos (EAst.tApp _xI (EAst.tVar ""))) = None.
+Proof. reflexivity. Qed.
+
+Import MonadNotation ResultMonad Core.
+Open Scope monad_scope.
+
+Definition extract_ (p : program) :=
+  entry <- match snd p with
+           | tConst kn _ => ret kn
+           | _ => Err "Expected program to be a tConst"
+           end;;
+  extract_template_env_within_coq
+         (fst p)
+         (Kernames.KernameSet.singleton entry)
+         (fun k => false).
+
+Definition extract_body {A} (def : A) : TemplateMonad _ :=
+  p <- tmQuoteRec def ;;
+  entry <- match snd p with
+           | tConst kn _ => ret kn
+           | _ => tmFail "Expected program to be a tConst"
+          end ;;
+  res <- tmEval Common.lazy (extract_template_env_within_coq
+               (fst p)
+               (Kernames.KernameSet.singleton entry)
+               (fun k => false));;
+  match res with
+  | Ok env => match Erasure.Ex.lookup_env env entry with
+             | Some (Erasure.Ex.ConstantDecl (Erasure.Ex.Build_constant_body _ (Some b))) =>
+                 tmDefinition (snd entry ++ "_extracted") b
+             | Some _ => tmFail "Not a constant or body is missing"
+             | None => tmFail "No constant in the extracted env"
+             end
+  | Err e => tmFail e
+  end.
+
+Open Scope N_scope.
+
+
+(* TODO: Use QuickChick here?*)
+(* NOTE: these numbers come from the Dexter contract, where the bug was discovered *)
+Definition _997 : N := 997%N.
+
+MetaCoq Run (extract_body _997).
+
+Example N_syn_to_nat_997 :
+  N_syn_to_nat _997_extracted = Some 997%nat.
+Proof. reflexivity. Qed.
+
+Definition _1000 : N := 1000%N.
+
+MetaCoq Run (extract_body _1000).
+
+Example N_syn_to_nat_1000 :
+  N_syn_to_nat _1000_extracted = Some 1000%nat.
+Proof. reflexivity. Qed.


### PR DESCRIPTION
* extraction setup (reuse remapping from Dexter 2 CPMM + some extra remapping);
* abbreviations for some definitions in Dexter2FA12 to help with remapping and force type class instances resolution of `FMap` functions related to allowances;
* change `AddressMap.AddrMap` to be an alias (required fixes in proofs);
* fix a bug in printing natural number literals.