### PR TITLE
Update LIGO compiler to v0.34.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: aucobra/concert:deps-coq-8.11-with-compilers-ligo-0.31.0
+    container: aucobra/concert:deps-coq-8.11-with-compilers-ligo-0.34.0
     steps:
     - run: sudo chown -R coq:coq .
     - uses: actions/checkout@v2

--- a/extra/docker/ConCert-deps-8.11-with-compilers/Dockerfile
+++ b/extra/docker/ConCert-deps-8.11-with-compilers/Dockerfile
@@ -24,8 +24,8 @@ RUN rustup target add wasm32-unknown-unknown \
    && sudo chmod +x cargo-concordium_1.0.0 \
    && sudo cp cargo-concordium_1.0.0 /usr/local/bin/cargo-concordium
 
-# install LIGO v0.22.0
-RUN curl -L -O https://gitlab.com/ligolang/ligo/-/jobs/1476886966/artifacts/raw/ligo && sudo chmod +x ./ligo && sudo cp ./ligo /usr/local/bin
+# install LIGO v0.34.0
+RUN curl -L -O https://gitlab.com/ligolang/ligo/-/jobs/1992156467/artifacts/raw/ligo && sudo chmod +x ./ligo && sudo cp ./ligo /usr/local/bin
 
 # install Elm 0.19.1
 

--- a/extraction/Makefile
+++ b/extraction/Makefile
@@ -77,7 +77,7 @@ $(LIQUIDITY_SRC_DIR)/%.tz:
 test-ligo: clean-comiped-ligo $(LIGO_DIST)
 
 $(LIGO_SRC_DIR)/%.tz:
-	ligo compile contract $(LIGO_SRC_DIR)/$*.mligo -e main -o $@ --warn false
+	ligo compile contract $(LIGO_SRC_DIR)/$*.mligo -e main -o $@ --no-warn
 
 clean-comiped-ligo:
 	rm ./examples/extracted-code/cameligo-extract/tests/*.tz -f

--- a/extraction/examples/CameLIGOExtractionTests.v
+++ b/extraction/examples/CameLIGOExtractionTests.v
@@ -414,7 +414,7 @@ Section EIP20TokenExtraction.
   (** We redirect the extraction result for later processing and compiling with the CameLIGO compiler *)
   (* TODO: uncomment, once this fix https://gitlab.com/ligolang/ligo/-/merge_requests/1452 makes it
      into a release version. *)
-  (* Redirect "examples/extracted-code/cameligo-extract/eip20tokenCertifiedExtraction.mligo" *)
+  Redirect "examples/extracted-code/cameligo-extract/eip20tokenCertifiedExtraction.mligo"
   MetaCoq Run (tmMsg cameLIGO_eip20token).
 
 End EIP20TokenExtraction.


### PR DESCRIPTION
The LIGO compiler version is updated to v0.34.0. This version includes a bug fix related to ad hoc polymorphism for `map`/big_map` that prevented the extracted ERC20 token from compiling. With the fix, we can compile all our examples.