### PR TITLE
CameLIGO extraction update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: aucobra/concert:deps-coq-8.11-with-compilers-ligo-0.34.0
+      image: aucobra/concert:deps-coq-8.11-with-compilers-ligo-0.38.1
       options: --user root
     steps:
     - name: Checkout branch ${{ github.ref_name }}

--- a/examples/counter/extraction/CameLIGOCounter.v
+++ b/examples/counter/extraction/CameLIGOCounter.v
@@ -57,6 +57,7 @@ Module Counter.
     end.
 
   Definition counter (c : Chain) (ctx : ContractCallContext) st msg :=
+    (* TODO: we should override masks instead *)
     (* avoid erasing c and ctx arguments *)
     let c_ := c in
     let ctx_ := ctx in
@@ -94,7 +95,17 @@ Section CounterExtraction.
   Import Counter.
   (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)
   Definition TT_remap_counter : list (kername * string) :=
-    [ remap <%% address_coq %%> "address"
+    [ remap <%% Z %%> "int"
+    ; remap <%% Z.add %%> "addInt"
+    ; remap <%% Z.sub %%> "subInt"
+    ; remap <%% Z.mul %%> "multInt"
+    ; remap <%% Z.leb %%> "leInt"
+    ; remap <%% Z.ltb %%> "ltInt"
+    ; remap <%% Z.eqb %%> "eqInt"
+    ; remap <%% Z.gtb %%> "gtbInt"
+    ; remap <%% Z.even %%> "evenInt"
+    ; remap <%% Z.abs_N %%> "abs"
+    ; remap <%% address_coq %%> "address"
     ; remap <%% time_coq %%> "timestamp"
     ; remap <%% nat %%> "address"
     ; remap <%% operation %%> "operation"

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -29,15 +29,17 @@ Instance dexter2_print_config : CameLIGOPrintConfig :=
 (** * Common extraction setup *)
 
 Definition call_to_token_ligo : string :=
-  <$ "let call_to_token (addr : address) (amt : nat) (msg : _msg) : operation =" ;
-     "  let token_ : _msg contract =";
-     "  match (Tezos.get_contract_opt (addr) : _msg contract option) with";
+  <$ "let call_to_token (type msg) (addr : address) (amt : nat) (msg : msg) : operation =" ;
+     "  let token_ : msg contract =";
+     "  match (Tezos.get_contract_opt (addr) : msg contract option) with";
      "    Some contract -> contract";
-     "  | None -> (failwith ""Contract not found."" : _msg contract) in";
+     "  | None -> (failwith ""Contract not found."" : msg contract) in";
      "  Tezos.transaction msg (natural_to_mutez amt) token_" $>.
 
+Compute call_to_token_ligo.
+
 Definition mk_callback_ligo : string :=
-  "[@inline] let mk_callback (addr : address) (msg : _msg) : operation = call_to_token addr 0n msg".
+  "[@inline] let mk_callback (type msg)(addr : address) (msg : msg) : operation = call_to_token addr 0n msg".
 
 (** Next two definition are borrowed from the actual Dexter 2 implementation
      https://gitlab.com/dexter2tz/dexter2tz/-/blob/master/dexter.mligo *)

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -63,7 +63,9 @@ Definition subNatTruncated_ligo : string :=
 Definition edivNatTrancated_ligo : string :=
   "let edivTruncated (a : nat) (b : nat) = match ediv a b with Some v -> v | None -> (0n,0n)".
 
-(** Remapping arithmetic operations *)
+(** Remapping arithmetic operations. *)
+(** We override the default remappings of aritmetic operations since it remaps [Z] to
+    [tez], and [N] to [int], which is not sutable for our purposes. *)
 Definition TT_remap_arith : list (kername * string) :=
 [   remap <%% Z %%> "int"
   ; remap <%% N %%> "nat"

--- a/examples/escrow/extraction/EscrowExtract.v
+++ b/examples/escrow/extraction/EscrowExtract.v
@@ -36,6 +36,8 @@ Module EscrowCameLIGOExtraction.
     ; ("tt", "()")
     ].
 
+  Definition TT_remap_ligo : list (kername * string) := [ remap <%% subAmountOption %%> "subTez" ].
+  
   Definition ESCROW_MODULE_LIGO : CameLIGOMod Msg ContractCallContext (Setup * Chain) State ActionBody :=
     {| (* a name for the definition with the extracted code *)
       lmd_module_name := "cameligo_escrow" ;
@@ -78,11 +80,11 @@ Module EscrowCameLIGOExtraction.
     ].
 
   Time MetaCoq Run
-  (CameLIGO_prepare_extraction to_inline [] TT_rename_ligo [] "cctx_instance" ESCROW_MODULE_LIGO).
+  (CameLIGO_prepare_extraction to_inline TT_remap_ligo TT_rename_ligo [] "cctx_instance" ESCROW_MODULE_LIGO).
 
   Time Definition cameLIGO_escrow := Eval vm_compute in cameligo_escrow_prepared.
 
-  Redirect "../extraction/tests/extracted-code/cameligo-extract/EscrowExtract.mligo"
+  (* Redirect "../extraction/tests/extracted-code/cameligo-extract/EscrowExtract.mligo" *)
   MetaCoq Run (tmMsg cameLIGO_escrow).
 
 End EscrowCameLIGOExtraction.
@@ -216,13 +218,13 @@ Module EscrowLiquidityExtraction.
 
   Import MonadNotation.
 
-  Time MetaCoq Run
-      (t <- liquidity_extraction_specialize PREFIX TT_remap_liquidity TT_rename_liquidity to_inline ESCROW_MODULE_LIQUIDITY ;;
-        tmDefinition ESCROW_MODULE_LIQUIDITY.(lmd_module_name) t
-      ).
+  (* Time MetaCoq Run *)
+  (*     (t <- liquidity_extraction_specialize PREFIX TT_remap_liquidity TT_rename_liquidity to_inline ESCROW_MODULE_LIQUIDITY ;; *)
+  (*       tmDefinition ESCROW_MODULE_LIQUIDITY.(lmd_module_name) t *)
+  (*     ). *)
 
-  (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
-  Redirect "../extraction/tests/extracted-code/liquidity-extract/escrow.liq"
-  MetaCoq Run (tmMsg liquidity_escrow).
+  (* (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *) *)
+  (* Redirect "../extraction/tests/extracted-code/liquidity-extract/escrow.liq" *)
+  (* MetaCoq Run (tmMsg liquidity_escrow). *)
 
 End EscrowLiquidityExtraction.

--- a/examples/stackInterpreter/StackInterpreterExtract.v
+++ b/examples/stackInterpreter/StackInterpreterExtract.v
@@ -306,11 +306,11 @@ Module LiquidityInterp.
        ).
 
   (** The extracted program can be printed and copy-pasted to the online Liquidity editor *)
-  Print liquidity_interp.
+  MetaCoq Run (tmMsg liquidity_interp).
 
   (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *)
-  (* Redirect "../extraction/tests/extracted-code/liquidity-extract/StackInterpreter.liq" *)
-  (* MetaCoq Run (tmMsg liquidity_interp). *)
+  Redirect "../extraction/tests/extracted-code/liquidity-extract/StackInterpreter.liq"
+  MetaCoq Run (tmMsg liquidity_interp).
 
 End LiquidityInterp.
 
@@ -385,7 +385,7 @@ Module CameLIGOInterp.
 
     Time Definition cameligo_interp := Eval vm_compute in cameligo_interp_prepared.
 
-    Print cameligo_interp.
+    MetaCoq Run (tmMsg cameligo_interp).
   (** We redirect the extraction result for later processing and compiling with the CameLIGO compiler *)
     Redirect "../extraction/tests/extracted-code/cameligo-extract/StackInterpreter.mligo"
     MetaCoq Run (tmMsg cameligo_interp).

--- a/extra/docker/ConCert-deps-8.11-with-compilers/Dockerfile
+++ b/extra/docker/ConCert-deps-8.11-with-compilers/Dockerfile
@@ -24,8 +24,8 @@ RUN rustup target add wasm32-unknown-unknown \
    && sudo chmod +x cargo-concordium_1.0.0 \
    && sudo cp cargo-concordium_1.0.0 /usr/local/bin/cargo-concordium
 
-# install LIGO v0.34.0
-RUN curl -L -O https://gitlab.com/ligolang/ligo/-/jobs/1992156467/artifacts/raw/ligo && sudo chmod +x ./ligo && sudo cp ./ligo /usr/local/bin
+# install LIGO v0.38.1
+RUN curl -L -O https://gitlab.com/ligolang/ligo/-/jobs/2217283618/artifacts/raw/ligo && sudo chmod +x ./ligo && sudo cp ./ligo /usr/local/bin
 
 # install Elm 0.19.1
 

--- a/extraction/Makefile
+++ b/extraction/Makefile
@@ -77,7 +77,7 @@ $(LIQUIDITY_SRC_DIR)/%.tz:
 test-ligo: clean-comiped-ligo $(LIGO_DIST)
 
 $(LIGO_SRC_DIR)/%.tz:
-	ligo compile contract $(LIGO_SRC_DIR)/$*.mligo -e main -o $@ --no-warn
+	ligo compile contract --protocol ithaca $(LIGO_SRC_DIR)/$*.mligo -e main -o $@ --no-warn
 
 clean-comiped-ligo:
 	rm -f ./tests/extracted-code/cameligo-extract/tests/*.tz

--- a/extraction/tests/CameLIGOExtractionTests.v
+++ b/extraction/tests/CameLIGOExtractionTests.v
@@ -29,17 +29,24 @@ Module FoldLeft.
       | b :: t => foldL t (f a0 b)
       end.
 
-  Definition sum (xs : list nat) := foldL Nat.add xs 0.
+  Fixpoint foldLAlt {A B : Type} (f : A -> B -> A) (l : list B) (a0 : A) : A :=
+      match l with
+      | [] => a0
+      | b :: t => foldLAlt f t (f a0 b)
+      end.
+
+
+  Definition sum (xs : list nat) := foldLAlt Nat.add xs 0.
 
   Definition harness : string :=
-    "let main (st : unit * nat option) : operation list * (nat option)  = (([]: operation list), Some (sum ([1,2,3])))".
+    "let main (st : unit * nat option) : operation list * (nat option)  = (([]: operation list), Some (sum ([1n;2n;3n])))".
 
   Time MetaCoq Run
        (t <- CameLIGO_extract_single
               []
               []
               TT_rename_ctors_default
-              ""
+              "let addN (n : nat) (m : nat) = n + m"
               harness
               sum ;;
         tmDefinition "cameligo_sum" t).

--- a/extraction/tests/CameLIGOExtractionTests.v
+++ b/extraction/tests/CameLIGOExtractionTests.v
@@ -20,6 +20,36 @@ Definition bindOptCont {A B} (a : option A) (f : A -> option B) : option B :=
   | None => None
   end.
 
+Module FoldLeft.
+
+  Definition foldL {A B : Type} (f : A -> B -> A) : list B -> A -> A :=
+    fix foldL (l : list B) (a0 : A) {struct l} : A :=
+      match l with
+      | [] => a0
+      | b :: t => foldL t (f a0 b)
+      end.
+
+  Definition sum (xs : list nat) := foldL Nat.add xs 0.
+
+  Definition harness : string :=
+    "let main (st : unit * nat option) : operation list * (nat option)  = (([]: operation list), Some (sum ([1,2,3])))".
+
+  Time MetaCoq Run
+       (t <- CameLIGO_extract_single
+              []
+              []
+              TT_rename_ctors_default
+              ""
+              harness
+              sum ;;
+        tmDefinition "cameligo_sum" t).
+
+    (** Extraction results in fully functional CameLIGO code *)
+    (* Redirect "tests/extracted-code/cameligo-extract/SafeHead.mligo" *)
+    MetaCoq Run (tmMsg cameligo_sum).
+
+End FoldLeft.
+
 Module SafeHead.
   (** This module shows how one can extract programs containing [False_rect] *)
 

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -82,6 +82,8 @@ Program Definition annot_extract_template_env_specalize
   wfe <-check_wf_env_func extract_within_coq e;;
   annot_extract_env_cameligo e wfe seeds ignore.
 
+
+
 Definition CameLIGO_ignore_default {Base : ChainBase} :=
   [
       <%% prod %%>
@@ -132,7 +134,11 @@ Definition TT_remap_default : list (kername * string) :=
   ; remap <%% Pos.leb %%> "leN"
   ; remap <%% Pos.eqb %%> "eqN"
   ; remap <%% Z.add %%> "addTez"
-  ; remap <%% Z.sub %%> "subTez"
+  (* FIXME: subtraction of tez returns option in LIGO now We should
+     not use Z.sub directly, but a similar operation that returns
+     [option Z] instead. For now, it can be provided and remapped by
+     each contract, but ideally it should be in some central place. *)
+  (* ; remap <%% Z.sub %%> "subTez" *)
   ; remap <%% Z.mul %%> "multTez"
   ; remap <%% Z.div %%> "divTez"
   ; remap <%% Z.leb %%> "leTez"

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -106,6 +106,9 @@ Definition TT_remap_default : list (kername * string) :=
     (* types *)
     remap <%% Z %%> "tez"
   (* NOTE: subtracting two [nat]s gives [int], so we remap [N] to [int] and use trancated subtraction *)
+  (* FIXME: this doesn't look right. [N] should be [nat] in CameLIGO and [Z] should be
+     [int]. However, [Z] is also used as the type of currency, that could lead to clashes
+     in the extracted code. *)
   ; remap <%% N %%> "int"
   ; remap <%% nat %%> "nat"
   ; remap <%% bool %%> "bool"

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -155,10 +155,16 @@ Section PPTerm.
       ; "sender"
     ].
 
+  (* NOTE: We should probably add more validation rules *)
+  Definition ligo_valid_type_var (tv : string) : bool :=
+    match String.index 0 "'" tv with
+    | Some _ => false
+    | None => true
+    end.
+
   Definition is_fresh (Γ : context) (id : ident) :=
     negb (is_reserved_name id ligo_reserved_names)
-    &&
-    List.forallb
+    && List.forallb
       (fun decl =>
          match decl.(decl_name) with
          | nNamed id' =>
@@ -197,9 +203,12 @@ Section PPTerm.
               end
     in
     let id := uncapitalize id in
-    if is_fresh ctx id then id
-    else fresh_id_from ctx (List.length ctx) id.
-
+    if ligo_valid_type_var id then
+      if is_fresh ctx id then id
+      else
+        fresh_id_from ctx (List.length ctx) id
+    else fresh_id_from ctx (List.length ctx) "a".
+  
   Fixpoint fresh_string_names (Γ : context) (vs : list name) : context * list string :=
     match vs with
     | [] => (Γ, [])
@@ -278,7 +287,7 @@ Section PPTerm.
     else
       let ps := concat "," (map (print_type_var_name true) ty_ctx) in
       parens (Nat.eqb #|ty_ctx| 1) ps ^ " ".
-
+  
   Definition print_type_declaration (nm : string) (ty_ctx : list string) (body : string) : string :=
     "type " ^ print_type_params ty_ctx ^ nm ^ " = " ^ body.
   

--- a/extraction/theories/ExAst.v
+++ b/extraction/theories/ExAst.v
@@ -6,7 +6,7 @@ Inductive box_type :=
 | TAny
 | TArr (dom : box_type) (codom : box_type)
 | TApp (_ : box_type) (_ : box_type)
-| TVar (_ : nat) (* Index of type variable *)
+| TVar (_ : nat) (* Level of type variable *)
 | TInd (_ : inductive)
 | TConst (_ : kername).
 

--- a/extraction/theories/TypeAnnotations.v
+++ b/extraction/theories/TypeAnnotations.v
@@ -34,32 +34,63 @@ Proof. now sq. Qed.
 Section annotate.
   Context {A : Type}.
   Context (annotate_types :
-             forall Γ t (Ht : welltyped Σ Γ t) et (er : erases Σ Γ t et), annots A et).
+             forall Γ (erΓ : Vector.t tRel_kind #|Γ|) t (Ht : welltyped Σ Γ t) et (er : erases Σ Γ t et), annots A et).
 
   Equations? (noeqns) annotate_branches
            Γ
+           (erΓ : Vector.t tRel_kind #|Γ|)
            (brs : list (nat × term))
            (ebrs : list (nat × E.term))
            (wf : Forall2 (fun '(_, t) '(_, et) => welltyped Σ Γ t /\ erases Σ Γ t et) brs ebrs)
     : bigprod (annots A ∘ snd) ebrs by struct ebrs :=
-    annotate_branches Γ _ [] _ := tt;
-    annotate_branches Γ ((_, t) :: brs) ((_, et) :: ebrs) wf :=
-      (annotate_types Γ t _ et _, annotate_branches Γ brs ebrs _);
-    annotate_branches _ _ _ _ := !.
+    annotate_branches Γ _ _ [] _ := tt;
+    annotate_branches Γ _ ((_, t) :: brs) ((_, et) :: ebrs) wf :=
+      (annotate_types Γ _ t _ et _, annotate_branches Γ _ brs ebrs _);
+    annotate_branches _ _ _ _ _ := !.
   Proof. all: now depelim wf. Qed.
+
+
+  Definition type_flag_to_tRel_kind {Γ T}
+             (tf : type_flag Σ Γ T) (var_l : nat) : tRel_kind :=
+    match tf with
+    | {| is_logical := false; conv_ar := inl _ |} =>
+        (* non-logical arity becomes a type var *)
+        RelTypeVar var_l
+    | _ => RelOther
+    end.
+
+
+
+  Equations? (noeqns) context_to_erased
+           (Γ0 : context)
+           (var_ind : nat)
+           (mfix : list (def term))
+           (wt : Forall (fun d => ∥ isType Σ Γ0 (dtype d) ∥) mfix) : Vector.t tRel_kind #|mfix| :=
+    context_to_erased _ _ [] _ := []%vector;
+    context_to_erased Γ0 vi (d :: Γ1) _ :=
+      let i := type_flag_to_tRel_kind (flag_of_type Σ wfextΣ Γ0 (dtype d) _) (#|Γ0| + vi) in
+      (i :: context_to_erased Γ0 (1+vi) Γ1 _)%vector.
+  Proof.
+    - inversion wt;subst;eauto.
+    - subst i. inversion wt;subst;eauto.
+  Qed.
+
 
   Equations? (noeqns) annotate_defs
            Γ
+           (erΓ : Vector.t tRel_kind #|Γ|)
            (defs : list (def term))
            (edefs : list (E.def E.term))
            (wf : Forall2 (fun d ed => welltyped Σ Γ (dbody d) /\ erases Σ Γ (dbody d) (E.dbody ed))
                          defs edefs)
     : bigprod (annots A ∘ E.dbody) edefs by struct edefs :=
-    annotate_defs Γ _ [] _ := tt;
-    annotate_defs Γ (d :: defs) (ed :: edefs) wf :=
-      (annotate_types Γ (dbody d) _ (E.dbody ed) _, annotate_defs Γ defs edefs _);
-    annotate_defs _ _ _ _ := !.
-  Proof. all: now depelim wf. Qed.
+    annotate_defs Γ _ _ [] _ := tt;
+    annotate_defs Γ _ (d :: defs) (ed :: edefs) wf :=
+      (annotate_types Γ erΓ (dbody d) _ (E.dbody ed) _, annotate_defs Γ erΓ defs edefs _);
+    annotate_defs _ _ _ _ _ := !.
+  Proof.
+    all: now depelim wf.
+  Qed.
 End annotate.
 
 Fixpoint vec_repeat {A} (a : A) (n : nat) : Vector.t A n :=
@@ -68,13 +99,13 @@ Fixpoint vec_repeat {A} (a : A) (n : nat) : Vector.t A n :=
   | S n => (a :: vec_repeat a n)%vector
   end.
 
-Program Definition erase_type_of Γ t (wt : welltyped Σ Γ t) : box_type :=
+Program Definition erase_type_of Γ erΓ t (wt : welltyped Σ Γ t) : box_type :=
   let ty := type_of Σ wfΣ _ Γ t wt in
   let flag := flag_of_type Σ wfextΣ Γ ty _ in
   if conv_ar flag then
     TBox
   else
-    (erase_type_aux Σ wfextΣ Γ (vec_repeat RelOther #|Γ|) ty _ None).2.
+    (erase_type_aux Σ wfextΣ Γ erΓ ty _ None).2.
 Next Obligation.
   destruct wfextΣ as [[]].
   now constructor.
@@ -95,13 +126,60 @@ Next Obligation.
   eapply validity_term in typ; eauto using sq.
 Qed.
 
+Lemma Forall_mapi:
+  forall {A B : Type} {n} (P : B -> Prop) (f : nat -> A -> B)
+    (l : list A),
+  Forall ( fun x => forall i : nat, P (f i x)) l ->
+  Forall P (mapi_rec f l n).
+Proof.
+  intros A B n P f l H.
+  revert dependent n.
+  induction l; intros n.
+  - constructor.
+  - cbn. inversion H;subst. constructor;auto.
+Qed.
+
+Definition app_length_transparent {A} (l1 l2 : list A) :
+  #|l1| + #|l2| = #|l1 ++ l2|.
+induction l1.
+- reflexivity.
+- cbn. now rewrite IHl1.
+Defined.
+
+Definition mapi_length_transparent {A B} {f : nat -> A -> B} (l : list A) : forall n, #|mapi_rec f l n| = #|l|.
+induction l;intros.
+- reflexivity.
+- cbn. now rewrite IHl.
+Defined.
+
+Definition Sn_plus_one_transparent {n} : S n = n + 1.
+now induction n. Defined.
+
+(* NOTE: borrowed from metacoq's MCList. There it's defined for some other [rev] *)
+Definition rev_length_transparent {A} (l : list A) :
+  #|List.rev l| = #|l|.
+induction l.
+  - reflexivity.
+  - cbn. rewrite <- app_length_transparent.
+    cbn. rewrite IHl. symmetry. apply Sn_plus_one_transparent.
+Defined.
+
+Definition rev_mapi_app_length {A B} {f : nat -> A -> B} (l1 : list A) (l2 : list B) :
+  #|l1| + #|l2| = #|List.rev (mapi f l1) ++ l2|.
+transitivity (#|List.rev (mapi f l1)| + #|l2|).
+rewrite rev_length_transparent.
+unfold mapi. rewrite mapi_length_transparent;reflexivity.
+apply app_length_transparent.
+Defined.
+
 Equations? (noeqns) annotate_types
          (Γ : context)
+         (erΓ : Vector.t tRel_kind #|Γ|)
          (t : term) (wt : welltyped Σ Γ t)
          (et : E.term)
          (er : erases Σ Γ t et) : annots box_type et by struct et :=
 (* For some reason 'with' hangs forever so we need 'where' here *)
-annotate_types Γ t wt et er := annot (erase_type_of Γ t wt) et t wt er
+annotate_types Γ erΓ t wt et er := annot (erase_type_of Γ erΓ t wt) et t wt er
 where annot
         (bt : box_type)
         (et : E.term)
@@ -111,33 +189,43 @@ annot bt E.tBox _ _ _ => bt;
 annot bt (E.tRel _) _ _ _ => bt;
 annot bt (E.tVar _) _ _ _ => bt;
 annot bt (E.tEvar _ ets) t wt er => !;
-annot bt (E.tLambda na eB) (tLambda na' A B) wt er => (bt, annotate_types (Γ,, vass na' A) B _ eB _);
+annot bt (E.tLambda na eB) (tLambda na' A B) wt er =>
+  let erΓ1 := (type_flag_to_tRel_kind (flag_of_type Σ wfextΣ Γ A _) #|Γ| :: erΓ)%vector in
+  (bt, annotate_types (Γ,, vass na' A) erΓ1 B _ eB _);
 annot bt (E.tLetIn na eb eb') (tLetIn na' b ty b') wt er =>
-  (bt, (annotate_types Γ b _ eb _, annotate_types (Γ,, vdef na' b ty) b' _ eb' _));
+  let erΓ1 := (type_flag_to_tRel_kind (flag_of_type Σ wfextΣ Γ ty _) #|Γ| :: erΓ)%vector in
+  (bt, (annotate_types Γ _ b _ eb _, annotate_types (Γ,, vdef na' b ty) erΓ1 b' _ eb' _));
 annot bt (E.tApp ehd earg) (tApp hd arg) wt er =>
-  (bt, (annotate_types Γ hd _ ehd _, annotate_types Γ arg _ earg _));
+  (bt, (annotate_types Γ _ hd _ ehd _, annotate_types Γ _ arg _ earg _));
 annot bt (E.tConst _) _ wt er => bt;
 annot bt (E.tConstruct _ _) _ wt er => bt;
 annot bt (E.tCase _ ediscr ebrs) (tCase _ _ discr brs) wt er =>
-  (bt, (annotate_types Γ discr _ ediscr _, annotate_branches annotate_types Γ brs ebrs _));
-annot bt (E.tProj _ et) (tProj _ t) wt er => (bt, annotate_types Γ t _ et _);
+  (bt, (annotate_types Γ _ discr _ ediscr _, annotate_branches annotate_types Γ erΓ brs ebrs _));
+annot bt (E.tProj _ et) (tProj _ t) wt er => (bt, annotate_types Γ erΓ t _ et _);
 annot bt (E.tFix edefs _) (tFix defs _) wt er =>
-  (bt, annotate_defs annotate_types (Γ,,, fix_context defs) defs edefs _);
+  let erΓ1 := Vector.append (context_to_erased Γ 0 defs _) erΓ in
+  (bt, annotate_defs annotate_types (Γ,,, fix_context defs) (VectorEq.cast erΓ1 (rev_mapi_app_length _ _)) defs edefs _);
 annot bt (E.tCoFix edefs _) (tCoFix defs _) wt er =>
-  (bt, annotate_defs annotate_types (Γ,,, fix_context defs) defs edefs _);
+  let erΓ1 := Vector.append (context_to_erased Γ 0 defs _) erΓ in
+  (bt, annotate_defs annotate_types (Γ,,, fix_context defs) (VectorEq.cast erΓ1 (rev_mapi_app_length _ _)) defs edefs _);
 annot bt _ _ wt er => !
 }.
 Proof.
   all: try solve [inversion er; auto].
-  all: destruct wt.
-  all: destruct wfextΣ as [[]].
+  all: try destruct wt.
+  all: try destruct wfextΣ as [[]].
+  all: try subst erΓ1.
   - depelim er.
     now apply inversion_Evar in X.
   - apply inversion_Lambda in X as (? & ? & ? & ? & ?); auto.
+    constructor;econstructor; eauto.
+  - apply inversion_Lambda in t0 as (? & ? & ? & ? & ?); auto.
     econstructor; eauto.
   - apply inversion_LetIn in X as (?&?&?&?&?&?); auto.
+    constructor;econstructor; eauto.
+  - apply inversion_LetIn in t0 as (?&?&?&?&?&?); auto.
     econstructor; eauto.
-  - apply inversion_LetIn in X as (?&?&?&?&?&?); auto.
+  - apply inversion_LetIn in t0 as (?&?&?&?&?&?); auto.
     econstructor; eauto.
   - apply inversion_App in X as (?&?&?&?&?&?); auto.
     econstructor; eauto.
@@ -160,6 +248,10 @@ Proof.
   - apply inversion_Proj in X as (?&?&?&?&?&?&?&?&?); auto.
     econstructor; eauto.
   - apply inversion_Fix in X as (?&?&?&?&?&?&?); auto.
+    apply All_Forall.
+    eapply All_impl. apply a.
+    intros. cbn in *;now constructor.
+  - apply inversion_Fix in t1 as (?&?&?&?&?&?&?); auto.
     depelim er.
     clear -a0 X.
     eapply All2_All_mix_left in X; eauto.
@@ -174,6 +266,10 @@ Proof.
     split; [|now auto].
     econstructor; eauto.
   - apply inversion_CoFix in X as (?&?&?&?&?&?&?); auto.
+    apply All_Forall.
+    eapply All_impl. apply a.
+    intros. cbn in *;now constructor.
+  - apply inversion_CoFix in t1 as (?&?&?&?&?&?&?); auto.
     depelim er.
     clear -a0 X.
     eapply All2_All_mix_left in X; eauto.
@@ -181,7 +277,7 @@ Proof.
     revert X.
     generalize (Γ,,, fix_context defs).
     clear Γ.
-    intros Γ a.
+    intros Γ1 a.
     induction a; [now constructor|].
     constructor; [|now eauto].
     destruct r as (? & ? & ? & ?).
@@ -204,7 +300,7 @@ Proof.
   - destruct cst; cbn.
     destruct cst_body; [|exact tt].
     cbn.
-    apply (annotate_types [] t); [|apply ErasureFunction.erases_erase].
+    apply (annotate_types [] []%vector t); [|apply ErasureFunction.erases_erase].
     cbn in *.
     destruct wt.
     econstructor; eauto.


### PR DESCRIPTION
The update is mainly about the changes in handling recursive functions and polymorphism.
In particular, tail-recursive multi-argument polymorphic functions, like `fold_left` can be extracted into nice CameLIGO code.

* simplify the extraction of recursive functions: no need to pack multiple arguments into a tuple, LIGO supports multi-argument recursive functions;
* fixes in the extraction of polymorphic functions: use explicit type abstractions `(type a)` instead of implicitly generalised variables `_a`;
* pass a context with type variables to the pretty-printer to retain the name of parameters that are close to the original Coq names;
* bump the LIGO compiler version to 0.38.1;
* fixes in type annotations: subterms with types containing type variables were not annotated correctly;
* add tests for the implemented fixes;
* fix subtraction of `tez`: the `ithaca` protocol introduced an operation for `tez` with the result `tez option`; the old `SUB` instruction of Michelson is depricated; the PR updates the CameLIGO prelude and makes sure that our contracts use the partial version of the subtraction.