### PR TITLE
Dexter2 set_delegate remap

### DIFF
--- a/examples/dexter/Dexter.v
+++ b/examples/dexter/Dexter.v
@@ -43,7 +43,7 @@ Inductive DexterMsg :=
 Global Instance DexterMsg_serializable : Serializable DexterMsg :=
   Derive Serializable DexterMsg_rect <tokens_to_asset, add_to_tokens_reserve>.
 
-Definition Msg := @FA2ReceiverMsg BaseTypes DexterMsg _.
+Definition Msg := @FA2ReceiverMsg BaseTypes DexterMsg.
 
 
 Record State :=

--- a/examples/dexter/DexterTests.v
+++ b/examples/dexter/DexterTests.v
@@ -91,7 +91,7 @@ End ExplotContract.
 Definition deploy_exploit : @ActionBody LocalChainBase := create_deployment 0 exploit_contract tt.
 Definition exploit_caddr : Address := BoundedN.of_Z_const AddrSize 130%Z.
 
-Definition dexter_other_msg := @other_msg _ DexterMsg _.
+Definition dexter_other_msg := @other_msg _ DexterMsg.
 
 Definition add_operator_all owner operator := {|
   op_param_owner := owner;

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -43,6 +43,7 @@ Definition token_id := FA2Interface.token_id.
 Definition token_contract_transfer := FA2Interface.transfer.
 Definition balance_of := FA2Interface.balance_of_response.
 Definition mintOrBurn := Dexter2FA12.mintOrBurn_param.
+Definition baker_address := option Address.
 
 (** ** Entrypoint types *)
 
@@ -89,7 +90,7 @@ Record token_to_token_param :=
 
 Record set_baker_param :=
   build_set_baker_param{
-    baker : option Address;
+    baker : baker_address;
     freezeBaker_ : bool
 }.
 
@@ -188,7 +189,7 @@ Module Type NullAddress.
     Parameter null_address : Address.
 
     (** Place holder for tezos set delegate operation *)
-    Parameter set_delegate_call : option Address -> list ActionBody.
+    Parameter set_delegate_call : baker_address -> list ActionBody.
     Axiom delegate_call : forall addr, Forall (fun action => 
       match action with
       | act_transfer _ _ => False
@@ -560,7 +561,7 @@ Module NullAddressAxiom <: NullAddress.
     Existing Instance BaseTypes.
 
     Parameter null_address : Address.
-    Parameter set_delegate_call : option Address -> list ActionBody.
+    Parameter set_delegate_call : baker_address -> list ActionBody.
     Axiom delegate_call : forall addr, Forall (fun action => 
       match action with
       | act_transfer _ _ => False
@@ -669,7 +670,7 @@ Section Theories.
   Qed.
   Opaque sub.
 
-  Lemma set_delegate_call_nil : forall (addr : option Address),
+  Lemma set_delegate_call_nil : forall (addr : baker_address),
     set_delegate_call addr = [].
   Proof.
     intros.

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -179,11 +179,22 @@ Module Type Dexter2Serializable.
   End DS.
 End Dexter2Serializable.
 
-(** * Contract functions *)
+Module Type NullAddress.
+  Section NullAddress.
+    Parameter BaseTypes : ChainBase.
+    Existing Instance BaseTypes.
 
-Module Dexter2 (SI : Dexter2Serializable).
+    (** Null address that will newer contain contracts *)
+    Parameter null_address : Address.
+  End NullAddress.
+End NullAddress.
+
+
+(** * Contract functions *)
+Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
 
   Import SI.
+  Export NAddr.
 
   Existing Instance add_liquidity_param_serializable.
   Existing Instance remove_liquidity_param_serializable.
@@ -197,9 +208,9 @@ Module Dexter2 (SI : Dexter2Serializable).
   Existing Instance ClientMsg_serializable.
   Existing Instance state_serializable.
   Existing Instance FA2Token_Msg_serializable.
+  Existing Instance BaseTypes.
 
   Section DexterDefs.
-    Context `{BaseTypes : ChainBase}.
     Open Scope N_scope.
 
     (** ** Helper functions *)
@@ -231,8 +242,6 @@ Module Dexter2 (SI : Dexter2Serializable).
     Definition non_zero_amount (amt : Z) : bool:= (0 <? amt)%Z.
     Global Arguments non_zero_amount _ /. (* always unfold, if applied *)
 
-    (** Null address that will newer contain contracts *)
-    Parameter null_address : Address.
 
     Definition call_liquidity_token (addr : Address) (amt : N) (msg : Dexter2FA12.Msg) :=
       act_call addr (N_to_amount amt) (serialize msg).
@@ -539,14 +548,22 @@ Module DSInstances <: Dexter2Serializable.
 End DSInstances.
   (* end hide *)
 
-(** Instantiating the implementaion with required instances for serialisation/deserialisation *)
-Module DEX2 := Dexter2 DSInstances.
+Module NullAddressAxiom <: NullAddress.
+  Section NAddr.
+    Parameter BaseTypes : ChainBase.
+    Existing Instance BaseTypes.
 
+    Parameter null_address : Address.
+  End NAddr.
+End NullAddressAxiom.
+
+(** Instantiating the implementaion with required instances for serialisation/deserialisation *)
+Module DEX2 := Dexter2 DSInstances NullAddressAxiom.
 Import DEX2.
 
 (** * Properties *)
 Section Theories.
-  Context {BaseTypes : ChainBase}.
+  Existing Instance BaseTypes.
   Open Scope N_scope.
   Global Arguments amount_to_N /.
 

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -164,7 +164,7 @@ Module Type Dexter2Serializable.
     Axiom setup_serializable : Serializable Setup.
     Existing Instance setup_serializable.
 
-    Axiom ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg _ DexterMsg DexterMsg_serializable).
+    Axiom ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg _ DexterMsg).
     Existing Instance ClientMsg_serializable.
 
     Axiom state_serializable : Serializable State.
@@ -231,7 +231,7 @@ Module Dexter2 (SI : Dexter2Serializable).
     (** Null address that will newer contain contracts *)
     Parameter null_address : Address.
 
-    Definition Msg := @FA2Token.FA2ReceiverMsg BaseTypes DexterMsg _.
+    Definition Msg := @FA2Token.FA2ReceiverMsg BaseTypes DexterMsg.
 
   Definition call_liquidity_token (addr : Address) (amt : N) (msg : Dexter2FA12.Msg) :=
     act_call addr (N_to_amount amt) (serialize msg).
@@ -404,7 +404,7 @@ Module Dexter2 (SI : Dexter2Serializable).
     Some (new_state, []).
 
   Definition call_to_other_token (token_addr : Address) (amount : N)
-             (msg : @FA2Token.FA2ReceiverMsg _ DexterMsg _) :=
+             (msg : @FA2Token.FA2ReceiverMsg _ DexterMsg) :=
     act_call token_addr (N_to_amount amount) (serialize msg).
 
   (** ** Tokens to tokens *)
@@ -526,7 +526,7 @@ Module DSInstances <: Dexter2Serializable.
     Global Instance setup_serializable `{ChainBase} : Serializable Setup :=
       Derive Serializable Setup_rect <build_setup>.
 
-    Global Instance ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg BaseTypes DexterMsg _) :=
+    Global Instance ClientMsg_serializable : Serializable (@FA2Token.FA2ReceiverMsg BaseTypes DexterMsg) :=
       fun _ => @FA2Token.FA2ReceiverMsg_serializable _ _ _.
 
     Global Instance state_serializable `{ChainBase} : Serializable State :=

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -173,7 +173,7 @@ Module Dexter2LqtExtraction.
        (state : State)
        (maybe_msg : option Dexter2FA12.Msg)
     : option (list ActionBody * State) :=
-    match DEX2LQTExtract.receive chain ctx state maybe_msg with
+    match DEX2LQTExtract.receive_lqt chain ctx state maybe_msg with
     | Some x => Some (x.2, x.1)
     | None => None
     end.

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -36,8 +36,6 @@ Definition call_to_token_ligo : string :=
      "  | None -> (failwith ""Contract not found."" : msg contract) in";
      "  Tezos.transaction msg (natural_to_mutez amt) token_" $>.
 
-Compute call_to_token_ligo.
-
 Definition mk_callback_ligo : string :=
   "[@inline] let mk_callback (type msg)(addr : address) (msg : msg) : operation = call_to_token addr 0n msg".
 
@@ -265,7 +263,8 @@ Section D2E.
    ; remap <%% N_to_amount %%> "natural_to_mutez"
    ; remap <%% amount_to_N %%> "mutez_to_natural"
    ; remap <%% div %%> "divN_opt"
-   ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)" ].
+   ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
+   ; remap <%% set_delegate_call %%> "(fun (x : key_hash option) -> [Tezos.set_delegate x])" ].
 
   Definition TT_remap_all :=
     (TT_remap_arith ++ TT_remap_dexter2 ++ TT_Dexter2_CPMM)%list.

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -238,7 +238,7 @@ Module Dexter2Extraction.
     using the opaque ascription of module types to speedup the extraction *)
 Module DSInstancesOpaque : Dexter2CPMM.Dexter2Serializable := Dexter2CPMM.DSInstances.
 
-Module DEX2Extract := Dexter2CPMM.Dexter2 DSInstancesOpaque.
+Module DEX2Extract := Dexter2CPMM.Dexter2 DSInstancesOpaque Dexter2CPMM.NullAddressAxiom.
 
 Open Scope Z_scope.
 
@@ -246,7 +246,7 @@ Import DEX2Extract.
 Import Dexter2CPMM.
 
 Section D2E.
-  Context `{ChainBase}.
+  Existing Instance BaseTypes.
 
   Definition extra_ignore :=
    [ <%% @Serializable %%>

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -287,7 +287,7 @@ Section D2E.
   Definition receive_ (chain : Chain)
        (ctx : ContractCallContext)
        (state : State)
-       (maybe_msg : option DEX2Extract.Msg)
+       (maybe_msg : option Dexter2CPMM.Msg)
     : option (list ActionBody * State) :=
     match DEX2Extract.receive chain ctx state maybe_msg with
     | Some x => Some (x.2, x.1)

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -289,7 +289,7 @@ Section D2E.
        (state : State)
        (maybe_msg : option Dexter2CPMM.Msg)
     : option (list ActionBody * State) :=
-    match DEX2Extract.receive chain ctx state maybe_msg with
+    match DEX2Extract.receive_cpmm chain ctx state maybe_msg with
     | Some x => Some (x.2, x.1)
     | None => None
     end.

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -264,6 +264,7 @@ Section D2E.
    ; remap <%% amount_to_N %%> "mutez_to_natural"
    ; remap <%% div %%> "divN_opt"
    ; remap <%% non_zero_amount %%> "(fun (x : tez) -> 0tez < x)"
+   ; remap <%% @baker_address %%> "key_hash option"
    ; remap <%% set_delegate_call %%> "(fun (x : key_hash option) -> [Tezos.set_delegate x])" ].
 
   Definition TT_remap_all :=

--- a/examples/dexter2/Dexter2FA12.v
+++ b/examples/dexter2/Dexter2FA12.v
@@ -174,7 +174,7 @@ Module Type Dexter2LqtSerializable.
 
     Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-    Axiom FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
+    Axiom FA12ReceiverMsg_serializable : forall {Msg : Type} `{Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
 
     Axiom msg_serializable : Serializable Msg.
 
@@ -211,7 +211,7 @@ Module D2LqtSInstances <: Dexter2LqtSerializable.
     Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
       Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
 
-    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
+    Instance FA12ReceiverMsg_serializable {Msg : Type} `{Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
       Derive Serializable (@FA12ReceiverMsg_rect Msg) <
         (@receive_allowance Msg),
         (@receive_balance_of Msg),

--- a/examples/dexter2/Dexter2FA12.v
+++ b/examples/dexter2/Dexter2FA12.v
@@ -99,7 +99,7 @@ Record Setup :=
 (* Any contract that wants to receive callback messages from the FA1.2 liquidity contract
    should have this type as its Msg type. The contract may have other endpoints,
    as composed in the 'other_msg' constructor. *)
-Inductive FA12ReceiverMsg {Msg' : Type} `{Serializable Msg'} :=
+Inductive FA12ReceiverMsg {Msg' : Type} :=
   | receive_allowance : N ->  FA12ReceiverMsg
   | receive_balance_of : N -> FA12ReceiverMsg
   | receive_total_supply : N -> FA12ReceiverMsg
@@ -174,7 +174,7 @@ Module Type Dexter2LqtSerializable.
 
     Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg serMsg).
+    Axiom FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
 
     Axiom msg_serializable : Serializable Msg.
 
@@ -211,12 +211,12 @@ Module D2LqtSInstances <: Dexter2LqtSerializable.
     Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
       Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
 
-    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg serMsg) :=
-      Derive Serializable (@FA12ReceiverMsg_rect Msg serMsg) <
-        (@receive_allowance Msg serMsg),
-        (@receive_balance_of Msg serMsg),
-        (@receive_total_supply Msg serMsg),
-        (@other_msg Msg serMsg)>.
+    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
+      Derive Serializable (@FA12ReceiverMsg_rect Msg) <
+        (@receive_allowance Msg),
+        (@receive_balance_of Msg),
+        (@receive_total_supply Msg),
+        (@other_msg Msg)>.
 
     Instance msg_serializable : Serializable Msg :=
       Derive Serializable Msg_rect <msg_transfer,
@@ -320,12 +320,12 @@ Definition try_mint_or_burn (sender : Address) (param : mintOrBurn_param) (state
     Some (state<|tokens := tokens_|>
                <|total_supply := total_supply_|>).
 
-Definition mk_callback (to_addr : Address) (msg : @FA12ReceiverMsg unit _) :=
+Definition mk_callback (to_addr : Address) (msg : @FA12ReceiverMsg unit) :=
   act_call to_addr 0 (serialize msg).
 
-Definition receive_allowance_ n := @receive_allowance unit _ n.
-Definition receive_balance_of_ n := @receive_balance_of unit _ n.
-Definition receive_total_supply_ n := @receive_total_supply unit _ n.
+Definition receive_allowance_ n := @receive_allowance unit n.
+Definition receive_balance_of_ n := @receive_balance_of unit n.
+Definition receive_total_supply_ n := @receive_total_supply unit n.
 
 (** ** Get allowance *)
 (** Get the quantity that [snd request] is allowed to spend on behalf of [fst request] *)

--- a/examples/dexter2/Dexter2FA12.v
+++ b/examples/dexter2/Dexter2FA12.v
@@ -190,7 +190,7 @@ Module D2LqtSInstances <: Dexter2LqtSerializable.
   Section Serialization.
     Context `{ChainBase}.
 
-    Instance  callback_serializable : Serializable callback :=
+    Instance callback_serializable : Serializable callback :=
     Derive Serializable callback_rect <Build_callback>.
 
     Instance transfer_param_serializable : Serializable transfer_param :=
@@ -250,7 +250,7 @@ Existing Instance mintOrBurn_param_serializable.
 Existing Instance getAllowance_param_serializable.
 Existing Instance getBalance_param_serializable.
 Existing Instance getTotalSupply_param_serializable.
-Existing Instance  FA12ReceiverMsg_serializable.
+Existing Instance FA12ReceiverMsg_serializable.
 Existing Instance msg_serializable.
 Existing Instance state_serializable.
 Existing Instance setup_serializable.

--- a/examples/fa1_2/FA1_2.v
+++ b/examples/fa1_2/FA1_2.v
@@ -122,7 +122,7 @@ Module Type FA12Serializable.
 
     Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
+    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
 
     Axiom msg_serializable : Serializable Msg.
 
@@ -154,7 +154,7 @@ Module FA12SInstances <: FA12Serializable.
     Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
       Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
 
-    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
+    Instance FA12ReceiverMsg_serializable {Msg : Type} `{Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
       Derive Serializable (@FA12ReceiverMsg_rect Msg) <
         (@receive_allowance Msg),
         (@receive_balance_of Msg),

--- a/examples/fa1_2/FA1_2.v
+++ b/examples/fa1_2/FA1_2.v
@@ -80,7 +80,7 @@ Record Setup :=
 (* Any contract that wants to receive callback messages from the FA1.2 liquidity contract
    should have this type as its Msg type. The contract may have other endpoints,
    as composed in the 'other_msg' constructor. *)
-Inductive FA12ReceiverMsg {Msg' : Type} `{Serializable Msg'} :=
+Inductive FA12ReceiverMsg {Msg' : Type} :=
   | receive_allowance : N ->  FA12ReceiverMsg
   | receive_balance_of : N -> FA12ReceiverMsg
   | receive_total_supply : N -> FA12ReceiverMsg
@@ -122,7 +122,7 @@ Module Type FA12Serializable.
 
     Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg serMsg).
+    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{serMsg : Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
 
     Axiom msg_serializable : Serializable Msg.
 
@@ -154,12 +154,12 @@ Module FA12SInstances <: FA12Serializable.
     Instance getTotalSupply_param_serializable : Serializable getTotalSupply_param :=
       Derive Serializable getTotalSupply_param_rect <build_getTotalSupply_param>.
 
-    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg serMsg) :=
-      Derive Serializable (@FA12ReceiverMsg_rect Msg serMsg) <
-        (@receive_allowance Msg serMsg),
-        (@receive_balance_of Msg serMsg),
-        (@receive_total_supply Msg serMsg),
-        (@other_msg Msg serMsg)>.
+    Instance FA12ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA12ReceiverMsg Msg) :=
+      Derive Serializable (@FA12ReceiverMsg_rect Msg) <
+        (@receive_allowance Msg),
+        (@receive_balance_of Msg),
+        (@receive_total_supply Msg),
+        (@other_msg Msg)>.
 
     Instance msg_serializable : Serializable Msg :=
       Derive Serializable Msg_rect <transfer,
@@ -243,12 +243,12 @@ Definition try_approve (sender : Address) (param : approve_param) (state : State
   let allowances_ := update_allowance allowance_key (maybe param.(value_)) allowances_ in
     Some (state<|allowances := allowances_|>).
 
-Definition mk_callback (to_addr : Address) (msg : @FA12ReceiverMsg unit _) :=
+Definition mk_callback (to_addr : Address) (msg : @FA12ReceiverMsg unit) :=
   act_call to_addr 0 (serialize msg).
 
-Definition receive_allowance_ n := @receive_allowance unit _ n.
-Definition receive_balance_of_ n := @receive_balance_of unit _ n.
-Definition receive_total_supply_ n := @receive_total_supply unit _ n.
+Definition receive_allowance_ n := @receive_allowance unit n.
+Definition receive_balance_of_ n := @receive_balance_of unit n.
+Definition receive_total_supply_ n := @receive_total_supply unit n.
 
 (** ** Get allowance *)
 (** Get the quantity that [snd request] is allowed to spend on behalf of [fst request] *)

--- a/examples/fa1_2/FA1_2.v
+++ b/examples/fa1_2/FA1_2.v
@@ -122,7 +122,7 @@ Module Type FA12Serializable.
 
     Axiom getTotalSupply_param_serializable : Serializable getTotalSupply_param.
 
-    Axiom  FA12ReceiverMsg_serializable : forall {Msg : Type} `{Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
+    Axiom FA12ReceiverMsg_serializable : forall {Msg : Type} `{Serializable Msg}, Serializable (@FA12ReceiverMsg Msg).
 
     Axiom msg_serializable : Serializable Msg.
 
@@ -136,7 +136,7 @@ Module FA12SInstances <: FA12Serializable.
   Section Serialization.
     Context `{ChainBase}.
 
-    Instance  callback_serializable : Serializable callback :=
+    Instance callback_serializable : Serializable callback :=
     Derive Serializable callback_rect <Build_callback>.
 
     Instance transfer_param_serializable : Serializable transfer_param :=

--- a/examples/fa2/FA2Gens.v
+++ b/examples/fa2/FA2Gens.v
@@ -233,7 +233,7 @@ End FA2ContractGens.
 (* The generators for this section assume that 'fa2_client_addr' is an address to an fa2 client contract
   with message type ClientMsg *)
 Section FA2ClientGens.
-Let client_other_msg := @other_msg _ FA2ClientMsg _.
+Let client_other_msg := @other_msg _ FA2ClientMsg.
 
 Definition gIsOperatorMsg : G (option ClientMsg) :=
  '(addr1, addr2) <- gUniqueAddrPair ;;

--- a/examples/fa2/FA2Printers.v
+++ b/examples/fa2/FA2Printers.v
@@ -11,7 +11,7 @@ Local Open Scope string_scope.
 
 Instance showCallback {A : Type}: Show (FA2Interface.callback A) :=
 {|
-  show v := "callback"
+  show v := "return address: " ++ show v.(return_addr A)
 |}.
 
 Instance showFA2InterfaceTransfer : Show FA2Interface.transfer :=

--- a/examples/fa2/FA2Printers.v
+++ b/examples/fa2/FA2Printers.v
@@ -209,7 +209,7 @@ Instance showFA2Interfaceset_hook_param : Show FA2Interface.set_hook_param :=
 Instance showFA2ReceiverMsg {Msg : Type}
                            `{serMsg : Serializable Msg}
                            `{Show Msg}
-                           : Show (@FA2ReceiverMsg _ Msg serMsg) :=
+                           : Show (@FA2ReceiverMsg _ Msg) :=
 {|
   show m := match m with
             | receive_balance_of_param param => "receive_balance_of_param " ++ show param
@@ -224,7 +224,7 @@ Instance showFA2ReceiverMsg {Msg : Type}
 Instance showFA2TransferHook {Msg : Type}
                             `{serMsg : Serializable Msg}
                             `{Show Msg}
-                             : Show (@FA2TransferHook _ Msg serMsg) :=
+                             : Show (@FA2TransferHook _ Msg) :=
 {|
   show m := match m with
             | transfer_hook param => "transferhook " ++ show param

--- a/examples/fa2/FA2Token.v
+++ b/examples/fa2/FA2Token.v
@@ -26,7 +26,7 @@ Open Scope N_scope.
 (* Any contract that wants to receive callback messages from the FA2 contract
    should have this type as its Msg type. The contract may have other endpoints,
    as composed in the 'other_msg' constructor *)
-Inductive FA2ReceiverMsg {Msg' : Type} `{Serializable Msg'} :=
+Inductive FA2ReceiverMsg {Msg' : Type} :=
   | receive_balance_of_param : list balance_of_response -> FA2ReceiverMsg
   | receive_total_supply_param : list total_supply_response -> FA2ReceiverMsg
   | receive_metadata_callback : list token_metadata -> FA2ReceiverMsg
@@ -35,7 +35,7 @@ Inductive FA2ReceiverMsg {Msg' : Type} `{Serializable Msg'} :=
   | other_msg : Msg' -> FA2ReceiverMsg.
 
 (* Transfer hook contracts of the FA2 Contract should use this type as their Msg type *)
-Inductive FA2TransferHook {Msg : Type} `{Serializable Msg} :=
+Inductive FA2TransferHook {Msg : Type} :=
   | transfer_hook : transfer_descriptor_param -> FA2TransferHook
   | hook_other_msg : Msg -> FA2TransferHook.
 
@@ -85,19 +85,19 @@ Section Serialization.
 Global Instance setup_serializable : Serializable Setup :=
   Derive Serializable Setup_rect <build_setup>.
 
-Global Instance FA2ReceiverMsg_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA2ReceiverMsg Msg serMsg) :=
-  Derive Serializable (@FA2ReceiverMsg_rect Msg serMsg) <
-    (@receive_balance_of_param Msg serMsg),
-    (@receive_total_supply_param Msg serMsg),
-    (@receive_metadata_callback Msg serMsg),
-    (@receive_is_operator Msg serMsg),
-    (@receive_permissions_descriptor Msg serMsg),
-    (@other_msg Msg serMsg)>.
+Global Instance FA2ReceiverMsg_serializable {Msg : Type} `{Serializable Msg} : Serializable (@FA2ReceiverMsg Msg) :=
+  Derive Serializable (@FA2ReceiverMsg_rect Msg) <
+    (@receive_balance_of_param Msg),
+    (@receive_total_supply_param Msg),
+    (@receive_metadata_callback Msg),
+    (@receive_is_operator Msg),
+    (@receive_permissions_descriptor Msg),
+    (@other_msg Msg)>.
 
-Global Instance FA2TransferHook_serializable {Msg : Type} `{serMsg : Serializable Msg} : Serializable (@FA2TransferHook Msg serMsg) :=
-  Derive Serializable (@FA2TransferHook_rect Msg serMsg) <
-    (@transfer_hook  Msg serMsg),
-    (@hook_other_msg Msg serMsg)>.
+Global Instance FA2TransferHook_serializable {Msg : Type} `{Serializable Msg} : Serializable (@FA2TransferHook Msg) :=
+  Derive Serializable (@FA2TransferHook_rect Msg) <
+    (@transfer_hook  Msg),
+    (@hook_other_msg Msg)>.
 
 Global Instance callback_permissions_descriptor_serializable : Serializable (callback permissions_descriptor) := callback_serializable.
 

--- a/examples/fa2/FA2TokenTests.v
+++ b/examples/fa2/FA2TokenTests.v
@@ -135,7 +135,7 @@ Definition chain_without_transfer_hook := unpack_result chain_without_transfer_h
 Definition chain_with_transfer_hook := unpack_result chain_with_transfer_hook'.
 
 
-Definition client_other_msg := @other_msg _ FA2ClientMsg _.
+Definition client_other_msg := @other_msg _ FA2ClientMsg.
 
 Definition call_client_is_op_act :=
   let params := Build_is_operator_param

--- a/examples/fa2/TestContracts.v
+++ b/examples/fa2/TestContracts.v
@@ -34,7 +34,7 @@ Global Instance FA2ClientMsg_serializable : Serializable FA2ClientMsg :=
     Call_fa2_metadata_callback,
     Call_fa2_permissions_descriptor>.
 
-Definition ClientMsg := @FA2ReceiverMsg BaseTypes FA2ClientMsg _.
+Definition ClientMsg := @FA2ReceiverMsg BaseTypes FA2ClientMsg.
 
 Record ClientState :=
   build_clientstate {
@@ -103,7 +103,7 @@ Global Instance FA2TransferHookMsg_serializable : Serializable FA2TransferHookMs
   Derive Serializable FA2TransferHookMsg_rect <
     set_permission_policy>.
 
-Definition TransferHookMsg := @FA2TransferHook BaseTypes FA2TransferHookMsg _.
+Definition TransferHookMsg := @FA2TransferHook BaseTypes FA2TransferHookMsg.
 
 Record HookState :=
   build_hookstate {


### PR DESCRIPTION
Add remapping of the `set_delegate_call` placeholder in the Dexter2 CPMM contract. The function is remapped to `Tezos.set_delegate`.

PR includes other minor implementation changes and refactoring in FA2, FA1.2, and Dexter2.