### PR TITLE
Pin concordium-std to version 2.0.0

### DIFF
--- a/extraction/tests/extracted-code/concordium-extract/concert-std/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/concert-std/Cargo.toml
@@ -12,6 +12,5 @@ concert-std-derive = { path = "../concert-std-derive" }
 immutable-map = "0.1.2"
 
 [dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 default-features = false

--- a/extraction/tests/extracted-code/concordium-extract/counter-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/counter-extracted/Cargo.toml
@@ -16,13 +16,11 @@ immutable-map = "0.1.2"
 
 
 [dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 default-features = false
 
 [dev-dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 features = ["std"] # std is needed because testing depends on std.
 
 [lib]

--- a/extraction/tests/extracted-code/concordium-extract/escrow-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/escrow-extracted/Cargo.toml
@@ -14,15 +14,12 @@ concert-std = { path = "../concert-std" }
 bumpalo = "3.5.0"
 immutable-map = "0.1.2"
 
-
 [dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 default-features = false
 
 [dev-dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 features = ["std"] # std is needed because testing depends on std.
 
 [lib]

--- a/extraction/tests/extracted-code/concordium-extract/interp-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/interp-extracted/Cargo.toml
@@ -14,15 +14,12 @@ concert-std = { path = "../concert-std" }
 bumpalo = "3.5.0"
 immutable-map = "0.1.2"
 
-
 [dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 default-features = false
 
 [dev-dependencies.concordium-std]
-git = "https://github.com/Concordium/concordium-rust-smart-contracts.git"
-branch = "main"
+version = "2.0.0"
 features = ["std"] # std is needed because testing depends on std.
 
 [lib]


### PR DESCRIPTION
The new version (unreleased) of Concordium's stdlib has many changes that break our examples, we stick to v2.0.0 and update our code later, maybe after v3.0.0 is released.