### PR TITLE
[CameLIGO] Remove init wrapper

### DIFF
--- a/examples/boardroomVoting/BoardroomVotingExtractionCameLIGO.v
+++ b/examples/boardroomVoting/BoardroomVotingExtractionCameLIGO.v
@@ -135,11 +135,10 @@ Definition BV_MODULE : CameLIGOMod BV.Msg ContractCallContext setupWchain BV.Sta
     lmd_receive := receive_wrapper;
 
     (* code for the entry point *)
-    lmd_entry_point := CameLIGOPretty.printWrapper (PREFIX ++ "receive_wrapper")
+    lmd_entry_point := CameLIGOPretty.printMain (PREFIX ++ "receive_wrapper")
                         "msg"
                         "state"
-                        ++ nl
-                        ++ CameLIGOPretty.printMain "state" |}.
+  |}.
 
 Definition inline_boardroom_params : list kername :=
   [

--- a/examples/boardroomVoting/BoardroomVotingExtractionCameLIGO.v
+++ b/examples/boardroomVoting/BoardroomVotingExtractionCameLIGO.v
@@ -48,6 +48,27 @@ Definition setupWchain := (BV.Setup × Chain).
 
 Definition init_wrapper (cctx : ContractCallContext) (s : setupWchain) := (run_contract_initer BV.init) s.2 cctx s.1.
 
+
+(** In the Tezos blockchain there is no concept of initialisation
+    function. However, it's common to provide a function that computes
+    a valid initial storage that can be used for deployment.*)
+Definition init (s : Address * Setup) : option State :=
+  if (finish_registration_by s.2 <? finish_vote_by s.2)%nat
+      then
+        Some {| owner := s.1;
+                registered_voters := AddressMap.empty;
+                public_keys := [];
+                setup := s.2;
+               tally := None; |}
+      else None.
+
+Lemma init_eq_init_wrapper cctx s :
+  init_wrapper cctx s = init (cctx.(ctx_from), s.1).
+Proof.
+  unfold init_wrapper,init. cbn.
+  now destruct (_ <? _)%nat.
+Qed.
+
 Definition receive_wrapper (c : Chain)
                            (ctx : ContractCallContext)
                            (st : BV.State) 
@@ -117,7 +138,7 @@ Definition hash_func_def := "let hash_func (l :  (nat) list) = addN 1n (List.fol
 Definition callctx := "(Tezos.sender,(Tezos.self_address,(Tezos.amount,Tezos.balance)))".
 
 
-Definition BV_MODULE : CameLIGOMod BV.Msg ContractCallContext setupWchain BV.State ActionBody :=
+Definition BV_MODULE : CameLIGOMod BV.Msg ContractCallContext (Address * Setup) BV.State ActionBody :=
   {| (* a name for the definition with the extracted code *)
     lmd_module_name := "cameligo_boardroomvoting" ;
 
@@ -125,7 +146,7 @@ Definition BV_MODULE : CameLIGOMod BV.Msg ContractCallContext setupWchain BV.Sta
     lmd_prelude := concat nl [CameLIGOPretty.CameLIGOPrelude; extra_ops; hash_func_def];
 
     (* initial storage *)
-    lmd_init := init_wrapper;
+    lmd_init := init;
 
     (* no extra operations in [init] are required *)
     lmd_init_prelude := "";

--- a/examples/counter/extraction/CameLIGOCounter.v
+++ b/examples/counter/extraction/CameLIGOCounter.v
@@ -29,9 +29,7 @@ Module Counter.
   Definition operation := ActionBody.
   Definition storage := Z × address.
 
-  Definition init (ctx : ContractCallContext) (setup : Z * address) : option storage :=
-    let ctx_ := ctx in (* prevents optimisations from removing unused [ctx]  *)
-    Some setup.
+  Definition init (setup : Z * address) : option storage := Some setup.
 
   Inductive msg :=
   | Inc (_ : Z)

--- a/examples/counter/extraction/CameLIGOCounter.v
+++ b/examples/counter/extraction/CameLIGOCounter.v
@@ -87,8 +87,7 @@ Module Counter.
 
         (* code for the entry point *)
         lmd_entry_point :=
-          CameLIGOPretty.printWrapper ("counter") "msg" "storage" ++ nl
-          ++ CameLIGOPretty.printMain "storage" |}.
+          CameLIGOPretty.printMain "counter" "msg" "storage" |}.
 
 End Counter.
 Section CounterExtraction.

--- a/examples/counter/extraction/CounterSubsetTypes.v
+++ b/examples/counter/extraction/CounterSubsetTypes.v
@@ -164,10 +164,7 @@ Module CameLIGOExtractionSetup.
   Existing Instance PrintConfAddModuleNames.PrintWithModuleNames.
 
 
-  Definition init (ctx : ContractCallContext) (setup : Z) : option storage :=
-    (* prevents optimisations from removing unused [ctx]
-       TODO: override masks instead. *)
-    let ctx_ := ctx in 
+  Definition init (setup : Z) : option storage :=
     Some setup.
 
   (** A translation table for definitions we want to remap. The corresponding top-level definitions will be *ignored* *)

--- a/examples/crowdfunding/CrowdfundingCameLIGO.v
+++ b/examples/crowdfunding/CrowdfundingCameLIGO.v
@@ -90,11 +90,10 @@ Defined.
 
       (* code for the entry point *)
       lmd_entry_point :=
-        "type storage = ((time_coq * (tez * address)) * ((address,tez) map * bool))" ++ CameLIGOPretty.printWrapper ("crowdfunding_receive")
+      "type storage = ((time_coq * (tez * address)) * ((address,tez) map * bool))" ++ nl
+       ++ CameLIGOPretty.printMain "crowdfunding_receive"
                                     "msg_coq"
-                                    "storage"
-                                    ++ nl
-                                    ++ CameLIGOPretty.printMain "storage" |}.
+                                    "storage" |}.
 
   (** We run the extraction procedure inside the [TemplateMonad].
       It uses the certified erasure from [MetaCoq] and the certified deboxing procedure

--- a/examples/crowdfunding/CrowdfundingCameLIGO.v
+++ b/examples/crowdfunding/CrowdfundingCameLIGO.v
@@ -32,8 +32,18 @@ Defined.
   Notation storage := ((time_coq × Z × address_coq) × Maps.addr_map_coq × bool).
 
   Definition crowdfunding_init (ctx : ContractCallContext)
-            (setup : (time_coq × Z × address_coq)) : option storage :=
-    if ctx.(ctx_amount) =? 0 then Some (setup, (Maps.mnil, false)) else None.
+              (setup : (time_coq × Z × address_coq)) : option storage :=
+      if ctx.(ctx_amount) =? 0 then Some (setup, (Maps.mnil, false)) else None.
+
+  Definition init (setup : (time_coq × Z × address_coq)) : option storage :=
+    Some (setup, (Maps.mnil, false)).
+
+  Lemma crowdfunding_init_eq_init ctx setup :
+    ctx.(ctx_amount) =? 0 -> (* no money should be sent on deployment *)
+    crowdfunding_init ctx setup = init setup.
+  Proof.
+    intros Hamount. unfold crowdfunding_init. now rewrite Hamount.
+  Qed.
 
   Open Scope Z.
   Import SimpleBlockchainExt.AcornBlockchain.
@@ -63,7 +73,7 @@ Defined.
 
 
   Definition CF_MODULE :
-    CameLIGOMod _ _ (time_coq × Z × address_coq) storage SimpleActionBody_coq :=
+    CameLIGOMod _ _ _ storage SimpleActionBody_coq :=
     {| (* a name for the definition with the extracted code *)
       lmd_module_name := "cameLIGO_crowdfunding" ;
 
@@ -78,7 +88,7 @@ Defined.
           (Tezos.now, (42tez,(""tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"": address)))";
 
       (* initial storage *)
-      lmd_init := crowdfunding_init ;
+      lmd_init := init ;
 
       (* init requires some extra operations *)
       lmd_init_prelude := "";

--- a/examples/crowdfunding/CrowdfundingCertifiedExtraction.v
+++ b/examples/crowdfunding/CrowdfundingCertifiedExtraction.v
@@ -78,7 +78,7 @@ Definition crowdfunding_receive
            (st : storage) : option (list SimpleActionBody_coq × storage) :=
   receive params.2 st params.1.
 
-Definition COUNTER_MODULE :
+Definition CROWDFUNDING_MODULE :
   LiquidityMod params SimpleCallCtx (time_coq × Z × address_coq) storage SimpleActionBody_coq :=
   {| (* a name for the definition with the extracted code *)
      lmd_module_name := "liquidity_crowdfunding" ;
@@ -112,8 +112,8 @@ Definition COUNTER_MODULE :
     that removes application of boxes to constants and constructors. *)
 
 Time MetaCoq Run
-     (t <- liquidity_extraction PREFIX TT_remap TT_rename [] COUNTER_MODULE ;;
-      tmDefinition COUNTER_MODULE.(lmd_module_name) t
+     (t <- liquidity_extraction PREFIX TT_remap TT_rename [] CROWDFUNDING_MODULE ;;
+      tmDefinition CROWDFUNDING_MODULE.(lmd_module_name) t
      ).
 
 Print liquidity_crowdfunding.

--- a/examples/dexter2/Dexter2Extract.v
+++ b/examples/dexter2/Dexter2Extract.v
@@ -157,14 +157,23 @@ Module Dexter2LqtExtraction.
     ; remap <%% @empty_allowance %%> "Map.empty"
      ].
 
-  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
-    let ctx_ := ctx in
+  (** We redefine the init function, because in the Tezos blockchain
+      there is no concept of initialisation function. However, it's common
+      to provide a function that computes a valid initial storage that can
+      be used for deployment. *)
+  Definition init (setup : Setup) : option State :=
     Some {|
         tokens := ContractCommon.AddressMap.add setup.(lqt_provider) setup.(initial_pool) ContractCommon.AddressMap.empty;
         allowances := empty_allowance;
         admin := setup.(admin_);
         total_supply := setup.(initial_pool);
       |}.
+
+    (** We prove that the "new" init function, which does not use [chain] and [ctx],
+        computes the same result as the contract's init *)
+  Lemma init_total_no_context_use chain ctx setup :
+    Dexter2FA12.DEX2LQT.init_lqt chain ctx setup = init setup.
+  Proof. reflexivity. Qed.
 
   Definition receive_ (chain : Chain)
        (ctx : ContractCallContext)
@@ -270,8 +279,8 @@ Section D2E.
   Definition TT_remap_all :=
     (TT_remap_arith ++ TT_remap_dexter2 ++ TT_Dexter2_CPMM)%list.
 
-  Definition init (ctx : ContractCallContext) (setup : Setup) : option State :=
-    let ctx_ := ctx in
+  (** We redefine [init] for the same reasons as for the liquidity token *)
+  Definition init (setup : Setup) : option State :=
     Some {|
         tokenPool := 0;
         xtzPool := 0;
@@ -283,6 +292,13 @@ Section D2E.
         tokenId := setup.(tokenId_);
         lqtAddress := null_address
       |}.
+
+  (** We prove that the "new" init function, which does not use [chain] and [ctx],
+      is total and computes the same result as the contract's init *)
+  Lemma init_total_no_context_use chain ctx setup :
+    Dexter2CPMM.DEX2.init_cpmm chain ctx setup = init setup.
+  Proof. reflexivity. Qed.
+
 
   Definition receive_ (chain : Chain)
        (ctx : ContractCallContext)

--- a/examples/eip20/EIP20CameLIGOExtraction.v
+++ b/examples/eip20/EIP20CameLIGOExtraction.v
@@ -20,11 +20,14 @@ Section EIP20TokenExtraction.
 
   Import EIP20Token.
 
-  Definition init (ctx : ContractCallContext) (setup : EIP20Token.Setup) : option EIP20Token.State :=
-    let ctx_ := ctx in
+  Definition init (setup : EIP20Token.Setup) : option EIP20Token.State :=
     Some {| total_supply := setup.(init_amount);
             balances := ContractCommon.AddressMap.add (EIP20Token.owner setup) (init_amount setup) ContractCommon.AddressMap.empty;
             allowances := ContractCommon.AddressMap.empty |}.
+
+  Lemma EIP20Token_init_eq_init chain ctx setup :
+    EIP20Token.init chain ctx setup = init setup.
+  Proof. reflexivity. Qed.
 
   Definition receive_ (chain : Chain)
        (ctx : ContractCallContext)

--- a/examples/eip20/EIP20CameLIGOExtraction.v
+++ b/examples/eip20/EIP20CameLIGOExtraction.v
@@ -57,8 +57,7 @@ Section EIP20TokenExtraction.
 
       (* code for the entry point *)
       lmd_entry_point :=
-        CameLIGOPretty.printWrapper "receive_" "msg" "state" ++ nl
-        ++ CameLIGOPretty.printMain "state"|}.
+        CameLIGOPretty.printMain "receive_" "msg" "state" |}.
 
   Definition TT_remap_eip20token : list (kername * string) :=
     TT_remap_default ++ [

--- a/examples/escrow/extraction/EscrowExtract.v
+++ b/examples/escrow/extraction/EscrowExtract.v
@@ -108,7 +108,7 @@ Module EscrowCameLIGOExtraction.
 
   Time Definition cameLIGO_escrow := Eval vm_compute in cameligo_escrow_prepared.
 
-  (* Redirect "../extraction/tests/extracted-code/cameligo-extract/EscrowExtract.mligo" *)
+  Redirect "../extraction/tests/extracted-code/cameligo-extract/EscrowExtract.mligo"
   MetaCoq Run (tmMsg cameLIGO_escrow).
 
 End EscrowCameLIGOExtraction.
@@ -241,14 +241,14 @@ Module EscrowLiquidityExtraction.
     ].
 
   Import MonadNotation.
+  
+  Time MetaCoq Run
+      (t <- liquidity_extraction_specialize PREFIX TT_remap_liquidity TT_rename_liquidity to_inline ESCROW_MODULE_LIQUIDITY ;;
+        tmDefinition ESCROW_MODULE_LIQUIDITY.(lmd_module_name) t
+      ).
 
-  (* Time MetaCoq Run *)
-  (*     (t <- liquidity_extraction_specialize PREFIX TT_remap_liquidity TT_rename_liquidity to_inline ESCROW_MODULE_LIQUIDITY ;; *)
-  (*       tmDefinition ESCROW_MODULE_LIQUIDITY.(lmd_module_name) t *)
-  (*     ). *)
-
-  (* (** We redirect the extraction result for later processing and compiling with the Liquidity compiler *) *)
-  (* Redirect "../extraction/tests/extracted-code/liquidity-extract/escrow.liq" *)
-  (* MetaCoq Run (tmMsg liquidity_escrow). *)
+  (* (** we redirect the extraction result for later processing and compiling with the Liquidity compiler *) *)
+  Redirect "../extraction/tests/extracted-code/liquidity-extract/escrow.liq"
+  MetaCoq Run (tmMsg liquidity_escrow).
 
 End EscrowLiquidityExtraction.

--- a/examples/escrow/extraction/EscrowExtract.v
+++ b/examples/escrow/extraction/EscrowExtract.v
@@ -57,9 +57,8 @@ Module EscrowCameLIGOExtraction.
       lmd_receive_prelude := "";
       (* code for the entry point *)
       lmd_entry_point :=
-        printWrapper "escrow_receive" "msg" "state" 
-                     ++ nl
-                     ++ CameLIGOPretty.printMain "state" |}.
+        printMain "escrow_receive" "msg" "state" 
+    |}.
 
   Definition to_inline : list kername := 
     [ <%% Monads.Monad_option %%>

--- a/examples/stackInterpreter/StackInterpreterExtract.v
+++ b/examples/stackInterpreter/StackInterpreterExtract.v
@@ -319,9 +319,8 @@ Module CameLIGOInterp.
   Import CameLIGOExtract CameLIGOPretty.
   Existing Instance PrintConfShortNames.PrintWithShortNames.
 
-  Definition init (ctx : ContractCallContext) (setup : unit) : option storage :=
-    let ctx0 := ctx in
-    let setup0 := setup in (* prevents optimisations from removing unused [ctx] and [setup]  *)
+  Definition init (setup : unit) : option storage :=
+    let setup0 := setup in (* prevents optimisations from removing unused [setup]. TODO: override masks instead  *)
     Some [].
 
 

--- a/examples/stackInterpreter/StackInterpreterExtract.v
+++ b/examples/stackInterpreter/StackInterpreterExtract.v
@@ -376,9 +376,8 @@ Module CameLIGOInterp.
 
        (* code for the entry point *)
        lmd_entry_point :=
-         CameLIGOPretty.printWrapper "receive_" "params" "value list"
-                                     ++ nl
-                                     ++ CameLIGOPretty.printMain "storage" |}.
+         CameLIGOPretty.printMain "receive_" "params" "value list"
+    |}.
 
     Time MetaCoq Run
     (CameLIGO_prepare_extraction [] TT_remap_ligo TT_rename_ctors_default [] "cctx_instance" LIGO_INTERP_MODULE).

--- a/extraction/theories/CameLIGOExtract.v
+++ b/extraction/theories/CameLIGOExtract.v
@@ -20,7 +20,7 @@ From MetaCoq.Template Require Import All.
 Record CameLIGOMod {Base : ChainBase} (msg ctx setup storage operation : Type) :=
   { lmd_module_name : string ;
     lmd_prelude : string ;
-    lmd_init : ctx -> setup -> option storage;
+    lmd_init : setup -> option storage;
     lmd_init_prelude : string ;
     lmd_receive_prelude : string;
     lmd_receive : Chain -> ctx -> storage -> option msg -> option (list operation * storage);

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -780,7 +780,7 @@ Section PPLigo.
       let printed_targs_outer := printed_targs_inner in
       let decl_outer :=
         "init " ++ concat " " printed_targs_outer ++ " : " ++ printed_outer_ret_ty in
-      let inner_app := "inner " ++ concat " " (map (string_of_name ctx) args) in
+      let inner_app := "inner " ++ concat " " sargs in
       ret ("let " ++ decl_outer ++ " = "
                       ++ let_inner
                       ++ nl

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -1022,36 +1022,18 @@ Section PPLigo.
                 bool_ops; time_ops; address_ops;
                 get_contract_def; CameLIGO_Chain_CallContext].
 
-  Definition printWrapper (contract parameter_name storage_name : string): string :=
-    <$
-    "type return = (operation) list * (" ++ storage_name ++ " option)" ;
-    "type parameter_wrapper =" ;
-    "  Init of init_args_ty" ;
-    "| Call of " ++ parameter_name ++ " option" ;
-    "";
-    "let wrapper (param, st : parameter_wrapper * (" ++ storage_name ++ ") option) : return =" ;
-    "  match param with " ;
-    "    Init init_args -> (";
-    "  match st with ";
-    "      Some st -> (failwith (""Cannot call Init twice""): return)";
-    "    | None -> (([]: operation list), Some (init init_args)))";
-    "  | Call p -> (" ;
-    "    match st with" ;
-    "      Some st -> (match (" ++ contract ++ " dummy_chain cctx_instance " ++ " st p) with   " ;
-    "                    Some v -> (v.0, Some v.1)" ;
-    "                  | None -> (failwith ("""") : return))" ;
-    "    | None -> (failwith (""cannot call this endpoint before Init has been called""): return))"
-    $>.
+  Definition printMain (contract parameter_name storage_name : string) : string :=
+    <$ "" ;
+       "type return = (operation) list * " ++ storage_name ;
+       "" ;
+       "let main (p, st : " ++ parameter_name ++ " option * " ++ storage_name ++ ") : return = " ;
+       "   (match (" ++ contract ++ " dummy_chain cctx_instance " ++ " st p) with   " ;
+       "      Some v -> (v.0, v.1)" ;
+       "    | None -> (failwith (""Contract returned None"") : return))" $>.
 
-  Definition printMain (storage_name : string) :=
-    "let main (action, st : parameter_wrapper * " ++ storage_name ++ " option) : return = wrapper (action, st)".
-
-    Definition print_default_entry_point (state_nm : kername) (receive_nm : kername) (msg_nm : kername) :=
+  Definition print_default_entry_point (state_nm : kername) (receive_nm : kername) (msg_nm : kername) :=
   let st := print_type_name state_nm in
   let rec := print_const_name receive_nm in
   let msg := print_type_name msg_nm in
-  <$ printWrapper rec msg st;
-     "";
-     printMain st $>.
-
+  printMain rec msg st.
 End PPLigo.

--- a/extraction/theories/CameLIGOPretty.v
+++ b/extraction/theories/CameLIGOPretty.v
@@ -772,54 +772,19 @@ Section PPLigo.
       let wrap t :=
         "match " ++ t ++ " with" ++ nl ++
         "  Some v -> v"++ nl ++
-        "| None -> (failwith (""""): " ++ printed_outer_ret_ty ++ ")" in
+        "| None -> (failwith (""Init failed""): " ++ printed_outer_ret_ty ++ ")" in
       let let_inner :=
           "let " ++ decl_inner ++ " :" ++ printed_inner_ret_ty ++ " = " ++ nl
                 ++ print_term env TT ctx [] true false lam_body body_annot
                 ++ " in" in
-      (* if init takes no parameters, we give it a unit parameter  *)
-      let printed_targs_outer := match printed_targs_inner with
-                                 | _::[] | [] => let arg_name := fresh_string_name ctx nAnon in
-                                         [parens false (arg_name ++ " : unit")]
-                                 | _::xs => xs
-                                 end in
-      (* ignore the first argument because it's a call context *)
+      let printed_targs_outer := printed_targs_inner in
       let decl_outer :=
         "init " ++ concat " " printed_targs_outer ++ " : " ++ printed_outer_ret_ty in
-      let let_ctx := "let ctx = " ++ build_call_ctx ++ " in" in
-      let inner_app := "inner " ++ concat " " ( "ctx" :: tl sargs) in
-      let init_args_ty := "type init_args_ty = " ++
-        match tys with
-        | _::[] => "unit"
-        | [] => "unit"
-        | _::_ => tl tys |> map (print_box_type [] TT)
-                         |> concat " * "
-      end in
-      let init_wrapper_args_printed tys :=
-        match tys with
-        | [] => "()"
-        | [ty] => " args"
-        | tys => tys |> fold_right (fun _ '(i,s) => (i+1,s ++ " args." ++ string_of_nat i)) (0, "")
-                     |> snd
-        end in
-      let init_wrapper :=
-           "let init_wrapper (args : init_args_ty) ="
-        ++ nl
-        ++ "  init" ++ (tl tys |> init_wrapper_args_printed) in
+      let inner_app := "inner " ++ concat " " (map (string_of_name ctx) args) in
       ret ("let " ++ decl_outer ++ " = "
-                      ++ nl
-                      ++ init_prelude
-                      ++ nl
                       ++ let_inner
                       ++ nl
-                      ++ let_ctx
-                      ++ nl
-                      ++ wrap (parens false inner_app)
-                      ++ nl
-                      ++ init_args_ty
-                      ++ nl
-                      ++ init_wrapper
-                      ++ nl)
+                      ++ wrap (parens false inner_app))
     | None => fun _ => None
     end.
 


### PR DESCRIPTION
* Remove the initialisation wrapper generated by CameLIGO printing
* change the signature for `init` in the CameLIGO module: `init` doesn't take a context now;
* `init` is still present in the generated code, but it is used as a function that generated initial storage (similarly to a common LIGO development pattern)