### PR TITLE
Time tests

### DIFF
--- a/examples/AllTests.v
+++ b/examples/AllTests.v
@@ -20,21 +20,21 @@ Module Congress.
   Import CongressTests.
   Import TN.
 
-  QuickChick (
+  Time QuickChick (
     {{fun _ _ => true}}
     congress_caddr
     {{receive_state_well_behaved_P}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (forAllBlocks state_proposals_proposed_in_valid).
+  Time QuickChick (forAllBlocks state_proposals_proposed_in_valid).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (chain5 ~~> congress_has_votes_on_some_proposal).
+  Time QuickChick (chain5 ~~> congress_has_votes_on_some_proposal).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 4 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick (chain5 ~~> congress_finished_a_vote).
+  Time QuickChick (chain5 ~~> congress_finished_a_vote).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 11 tests and 0 shrinks. (0 discards) *)
 End Congress.
@@ -45,7 +45,7 @@ Module Congress_Buggy.
   Import Congress_BuggyTests.
   Import TN.
 
-  QuickChick (expectFailure (
+  Time QuickChick (expectFailure (
     {{fun _ _ => true}}
     congress_caddr
     {{receive_state_well_behaved_P}}
@@ -58,7 +58,7 @@ End Congress_Buggy.
 Module Dexter.
   Import DexterTests.
 
-  QuickChick (expectFailure tokens_to_asset_correct).
+  Time QuickChick (expectFailure tokens_to_asset_correct).
   (* *** Failed (as expected) after 1 tests and 1 shrinks. (0 discards) *)
 End Dexter.
 
@@ -69,76 +69,76 @@ Module EIP20Token.
   Import TestInfo.
   Import TN.
 
-  QuickChick (
+  Time QuickChick (
     {{fun _ _ => true}}
     contract_addr
     {{post_not_payable}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{fun _ _ => true}}
     contract_addr
     {{post_no_new_acts}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{fun _ _ => true}}
     contract_addr
     {{post_total_supply_constant}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_transfer}}
     contract_addr
     {{post_transfer_correct}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_transfer_from}}
     contract_addr
     {{post_transfer_from_correct}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_approve}}
     contract_addr
     {{post_approve_correct}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (forAllBlocks (checker_get_state sum_balances_eq_total_supply)).
+  Time QuickChick (forAllBlocks (checker_get_state sum_balances_eq_total_supply)).
   (* Passed 10000 tests (0 discards) *)
 
-  QuickChick (forAllBlocks (checker_get_state init_supply_eq_total_supply)).
+  Time QuickChick (forAllBlocks (checker_get_state init_supply_eq_total_supply)).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (expectFailure (sum_allowances_le_init_supply_P)).
+  Time QuickChick (expectFailure (sum_allowances_le_init_supply_P)).
   (* *** Failed (as expected) after 21 tests and 8 shrinks. (0 discards) *)
 
-  QuickChick (token_cb ~~> (person_has_tokens person_3 12)).
+  Time QuickChick (token_cb ~~> (person_has_tokens person_3 12)).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 1 tests and 0 shrinks. (0 discards) *)
 
   (* Test doesn't work *)(*
-  QuickChick (chain_with_token_deployed ~~> (fun lc => isSome (person_has_tokens person_3 12 lc))).*)
+  Time QuickChick (chain_with_token_deployed ~~> (fun lc => isSome (person_has_tokens person_3 12 lc))).*)
 
   (* Test doesn't work *)(*
-  QuickChick (chain_with_token_deployed ~~> person_has_tokens creator 0).*)
+  Time QuickChick (chain_with_token_deployed ~~> person_has_tokens creator 0).*)
 
   (* Test doesn't work *)(*
-  QuickChick (token_reachableFrom_implies_reachable
+  Time QuickChick (token_reachableFrom_implies_reachable
     chain_with_token_deployed
     (person_has_tokens creator 10)
     (person_has_tokens creator 0)
   ).*)
 
   (* Test doesn't work *)(*
-  QuickChick (
+  Time QuickChick (
     {
       chain_with_token_deployed
       ~~~> (person_has_tokens creator 5 o next_lc_of_lcstep)
@@ -146,7 +146,7 @@ Module EIP20Token.
     }
   ).*)
 
-  QuickChick (expectFailure reapprove_transfer_from_safe_P).
+  Time QuickChick (expectFailure reapprove_transfer_from_safe_P).
   (* *** Failed (as expected) after 1 tests and 4 shrinks. (14 discards) *)
 End EIP20Token.
 
@@ -156,14 +156,14 @@ Module Escrow.
   Import EscrowTests.
   Import MG.
 
-  QuickChick (forAllEscrowChainBuilder gEscrowTrace 7 escrow_chain escrow_correct_P).
+  Time QuickChick (forAllEscrowChainBuilder gEscrowTrace 7 escrow_chain escrow_correct_P).
   (* *** Gave up! Passed only 8529 tests
   Discarded: 20000 *)
 
-  QuickChick (forAllEscrowChainBuilder gEscrowTraceBetter 7 escrow_chain escrow_correct_P).
+  Time QuickChick (forAllEscrowChainBuilder gEscrowTraceBetter 7 escrow_chain escrow_correct_P).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick escrow_valid_steps_P.
+  Time QuickChick escrow_valid_steps_P.
   (* +++ Passed 10000 tests (0 discards) *)
 End Escrow.
 
@@ -174,20 +174,20 @@ Module FA2Token.
   Import TestInfo.
   Import TN.
 
-  QuickChick (
+  Time QuickChick (
     {{ msg_is_transfer }}
       token_contract_base_addr
     {{ post_transfer_correct }}
     chain_without_transfer_hook).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (forAllChainStatePairs transfer_balances_correct).
+  Time QuickChick (forAllChainStatePairs transfer_balances_correct).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (forAllChainStatePairs transfer_satisfies_policy_P).
+  Time QuickChick (forAllChainStatePairs transfer_satisfies_policy_P).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_update_operator}}
     token_contract_base_addr
     {{post_last_update_operator_occurrence_takes_effect}}
@@ -202,13 +202,13 @@ Module iTokenBuggy.
   Import iTokenBuggyTests.
   Import TN.
 
-  QuickChick (expectFailure token_supply_preserved).
+  Time QuickChick (expectFailure token_supply_preserved).
   (* *** Failed (as expected) after 5 tests and 1000 shrinks. (0 discards) *)
 
-  QuickChick (expectFailure (forAllBlocks (checker_get_state sum_balances_eq_init_supply_checker))).
+  Time QuickChick (expectFailure (forAllBlocks (checker_get_state sum_balances_eq_init_supply_checker))).
   (* *** Failed (as expected) after 1 tests and 7 shrinks. (0 discards) *)
 
-  QuickChick (expectFailure (
+  Time QuickChick (expectFailure (
     {{msg_is_not_mint_or_burn}}
     token_caddr
     {{sum_balances_unchanged}}
@@ -224,134 +224,134 @@ Module BAT.
   Import MG TN.
   Import BATTestCommon.
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => negb (msg_is_create_tokens state msg)}}
     contract_addr
     {{amount_is_zero}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_create_tokens}}
     contract_addr
     {{amount_is_positive}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_eip_msg ||| msg_is_create_tokens}}
     contract_addr
     {{produces_no_actions}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_refund ||| msg_is_finalize}}
     contract_addr
     {{produces_one_action}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => true}}
     contract_addr
     {{constants_unchanged}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{contract_balance_lower_bound}}).
+  Time QuickChick ({{contract_balance_lower_bound}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (expectFailure ({{contract_balance_lower_bound'}})).
+  Time QuickChick (expectFailure ({{contract_balance_lower_bound'}})).
   (* +++ Failed (as expected) after 2 tests and 7 shrinks. (0 discards) *)
 
-  QuickChick (partially_funded_cb ~~> is_fully_refunded).
+  Time QuickChick (partially_funded_cb ~~> is_fully_refunded).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 140 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick (expectFailure ({{can_always_fully_refund}})).
+  Time QuickChick (expectFailure ({{can_always_fully_refund}})).
   (* +++ Failed (as expected) after 6 tests and 7 shrinks. (0 discards) *)
 
-  QuickChick (token_cb ~~> is_finalized).
+  Time QuickChick (token_cb ~~> is_finalized).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 6 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick final_is_final.
+  Time QuickChick final_is_final.
   (* +++ Passed 10000 tests (6329 discards) *)
 
-  QuickChick can_only_finalize_once.
+  Time QuickChick can_only_finalize_once.
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick final_implies_total_supply_in_range.
+  Time QuickChick final_implies_total_supply_in_range.
   (* +++ Passed 10000 tests (6125 discards) *)
 
-  QuickChick final_implies_total_supply_constant.
+  Time QuickChick final_implies_total_supply_constant.
   (* +++ Passed 10000 tests (6246 discards) *)
 
-  QuickChick final_implies_contract_balance_is_zero.
+  Time QuickChick final_implies_contract_balance_is_zero.
   (* +++ Passed 10000 tests (6179 discards) *)
 
-  QuickChick (expectFailure ({{total_supply_bounds}})).
+  Time QuickChick (expectFailure ({{total_supply_bounds}})).
   (* +++ Failed (as expected) after 3 tests and 7 shrinks. (0 discards) *)
 
-  QuickChick ({{total_supply_eq_sum_balances}}).
+  Time QuickChick ({{total_supply_eq_sum_balances}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{paid_tokens_modulo_exchange_rate}}).
+  Time QuickChick ({{paid_tokens_modulo_exchange_rate}}).
   (* +++ Passed 10000 tests (0 discards) *)
 End BAT.
 
@@ -363,134 +363,134 @@ Module BATFixed.
   Import MG TN.
   Import BATTestCommon.
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => negb (msg_is_create_tokens state msg)}}
     contract_addr
     {{amount_is_zero}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_create_tokens}}
     contract_addr
     {{amount_is_positive}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_eip_msg ||| msg_is_create_tokens}}
     contract_addr
     {{produces_no_actions}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_refund ||| msg_is_finalize}}
     contract_addr
     {{produces_one_action}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => true}}
     contract_addr
     {{constants_unchanged}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{contract_balance_lower_bound}}).
+  Time QuickChick ({{contract_balance_lower_bound}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{contract_balance_lower_bound'}}).
+  Time QuickChick ({{contract_balance_lower_bound'}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (partially_funded_cb ~~> is_fully_refunded).
+  Time QuickChick (partially_funded_cb ~~> is_fully_refunded).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 140 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick ({{can_always_fully_refund}}).
+  Time QuickChick ({{can_always_fully_refund}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (token_cb ~~> is_finalized).
+  Time QuickChick (token_cb ~~> is_finalized).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 6 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick final_is_final.
+  Time QuickChick final_is_final.
   (* +++ Passed 10000 tests (4310 discards) *)
 
-  QuickChick can_only_finalize_once.
+  Time QuickChick can_only_finalize_once.
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick final_implies_total_supply_in_range.
+  Time QuickChick final_implies_total_supply_in_range.
   (* +++ Passed 10000 tests (4281 discards) *)
 
-  QuickChick final_implies_total_supply_constant.
+  Time QuickChick final_implies_total_supply_constant.
   (* +++ Passed 10000 tests (4223 discards)) *)
 
-  QuickChick final_implies_contract_balance_is_zero.
+  Time QuickChick final_implies_contract_balance_is_zero.
   (* +++ Passed 10000 tests (4153 discards) *)
 
-  QuickChick ({{total_supply_bounds}}).
+  Time QuickChick ({{total_supply_bounds}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{total_supply_eq_sum_balances}}).
+  Time QuickChick ({{total_supply_eq_sum_balances}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{paid_tokens_modulo_exchange_rate}}).
+  Time QuickChick ({{paid_tokens_modulo_exchange_rate}}).
   (* +++ Passed 10000 tests (0 discards) *)
 End BATFixed.
 
@@ -502,130 +502,130 @@ Module BATAltFix.
   Import MG TN.
   Import BATTestCommon.
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => negb (msg_is_create_tokens state msg)}}
     contract_addr
     {{amount_is_zero}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_create_tokens}}
     contract_addr
     {{amount_is_positive}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_eip_msg ||| msg_is_create_tokens}}
     contract_addr
     {{produces_no_actions}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{msg_is_refund ||| msg_is_finalize}}
     contract_addr
     {{produces_one_action}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (
+  Time QuickChick (
     {{fun state msg => true}}
     contract_addr
     {{constants_unchanged}}
   ).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{create_tokens_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
+  Time QuickChick ({{msg_is_create_tokens}} contract_addr {{post_create_tokens_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{finalize_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
+  Time QuickChick ({{msg_is_finalize}} contract_addr {{post_finalize_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{refund_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
+  Time QuickChick ({{msg_is_refund}} contract_addr {{post_refund_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{transfer_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
+  Time QuickChick ({{msg_is_transfer}} contract_addr {{post_transfer_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{transfer_from_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
+  Time QuickChick ({{msg_is_transfer_from}} contract_addr {{post_transfer_from_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_update_correct}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{approve_valid}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
+  Time QuickChick ({{msg_is_approve}} contract_addr {{post_approve_safe}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{contract_balance_lower_bound}}).
+  Time QuickChick ({{contract_balance_lower_bound}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (partially_funded_cb ~~> is_fully_refunded).
+  Time QuickChick (partially_funded_cb ~~> is_fully_refunded).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 13 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick ({{can_always_fully_refund}}).
+  Time QuickChick ({{can_always_fully_refund}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick (token_cb ~~> is_finalized).
+  Time QuickChick (token_cb ~~> is_finalized).
   (* Success - found witness satisfying the predicate!
   +++ Failed (as expected) after 7 tests and 0 shrinks. (0 discards) *)
 
-  QuickChick final_is_final.
+  Time QuickChick final_is_final.
   (* +++ Passed 10000 tests (4517 discards) *)
 
-  QuickChick can_only_finalize_once.
+  Time QuickChick can_only_finalize_once.
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick final_implies_total_supply_in_range.
+  Time QuickChick final_implies_total_supply_in_range.
   (* +++ Passed 10000 tests (4529 discards) *)
 
-  QuickChick final_implies_total_supply_constant.
+  Time QuickChick final_implies_total_supply_constant.
   (* +++ Passed 10000 tests (4662 discards) *)
 
-  QuickChick final_implies_contract_balance_is_zero.
+  Time QuickChick final_implies_contract_balance_is_zero.
   (* +++ Passed 10000 tests (4424 discards) *)
 
-  QuickChick ({{total_supply_bounds}}).
+  Time QuickChick ({{total_supply_bounds}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{total_supply_eq_sum_balances}}).
+  Time QuickChick ({{total_supply_eq_sum_balances}}).
   (* +++ Passed 10000 tests (0 discards) *)
 
-  QuickChick ({{paid_tokens_modulo_exchange_rate}}).
+  Time QuickChick ({{paid_tokens_modulo_exchange_rate}}).
   (* +++ Passed 10000 tests (0 discards) *)
 End BATAltFix.

--- a/examples/fa2/FA2TokenTests.v
+++ b/examples/fa2/FA2TokenTests.v
@@ -61,7 +61,6 @@ Definition token_setup (hook_addr : option Address): FA2Token.Setup := {|
   setup_tokens := FMap.add 0%N token_metadata_0 FMap.empty;
   initial_permission_policy := policy_all;
   transfer_hook_addr_ := hook_addr;
-
 |}.
 
 Definition token_contract_base_addr : Address := addr_of_Z 128%Z.

--- a/execution/test/LocalBlockchain.v
+++ b/execution/test/LocalBlockchain.v
@@ -183,7 +183,7 @@ Section ExecuteActions.
         (try rewrite FMap.find_partial_alter;
          try rewrite FMap.find_partial_alter_ne by auto;
          cbn); lia.
-  Qed.
+  Defined.
 
   Lemma set_contract_state_equiv addr state (lc : LocalChain) (env : Environment) :
     EnvironmentEquiv lc env ->
@@ -199,7 +199,7 @@ Section ExecuteActions.
     destruct_address_eq.
     - subst. now rewrite FMap.find_add.
     - rewrite FMap.find_add_ne; auto.
-  Qed.
+  Defined.
 
   Lemma add_contract_equiv addr wc (lc : LocalChain) (env : Environment) :
     EnvironmentEquiv lc env ->
@@ -214,7 +214,7 @@ Section ExecuteActions.
     destruct_address_eq.
     - subst. now rewrite FMap.find_add.
     - rewrite FMap.find_add_ne; auto.
-  Qed.
+  Defined.
 
   Local Open Scope Z.
   Lemma gtb_le x y :
@@ -225,7 +225,7 @@ Section ExecuteActions.
     rewrite Z.gtb_ltb in H.
     apply Z.ltb_ge.
     auto.
-  Qed.
+  Defined.
 
   Lemma ltb_ge x y :
     x <? y = false ->
@@ -234,7 +234,7 @@ Section ExecuteActions.
     intros H.
     apply Z.ltb_ge in H.
     lia.
-  Qed.
+  Defined.
 
   Local Hint Resolve gtb_le ltb_ge : core.
 
@@ -287,7 +287,7 @@ Section ExecuteActions.
     match goal with
     | [|- context[N.leb ?a ?b = true]] => destruct (N.leb_spec a b); auto; lia
     end.
-  Qed.
+  Defined.
 
   Local Hint Resolve get_new_contract_addr_is_contract_addr : core.
   Lemma deploy_contract_step origin from amount wc setup act lc_before new_acts lc_after :
@@ -403,7 +403,7 @@ Proof.
   apply Bool.negb_true_iff in to_acc.
   apply build_is_valid_next_block; cbn; auto.
   lia.
-Qed.
+Defined.
 
 Definition find_origin_neq_from (actions : list Action) : option Action :=
   find (fun act => negb (address_eqb (act_origin act) (act_from act))) actions.
@@ -419,7 +419,7 @@ Proof.
   assert (all_nin0 : forall x, In x actions -> (act_origin x =? act_from x)%address = true).
   { intros. now apply ssrbool.negbFE. }
   now apply Forall_forall in all_nin0.
-Qed.
+Defined.
 
 Definition find_invalid_root_action (actions : list Action) : option Action :=
   find (fun act => address_is_contract (act_from act)) actions.
@@ -433,7 +433,7 @@ Proof.
   specialize (List.find_none _ _ find_none) as all_nin.
   unfold act_is_from_account.
   now apply Forall_forall in all_nin.
-Qed.
+Defined.
 
 Definition add_new_block (header : BlockHeader) (lc : LocalChain) : LocalChain :=
   let lc := add_balance (block_creator header) (block_reward header) lc in
@@ -459,7 +459,7 @@ Proof.
     apply eq.
   - rewrite FMap.find_partial_alter_ne; auto.
     apply eq.
-Qed.
+Defined.
 
 (* The computational bits of adding a block *)
 Definition add_block_exec

--- a/execution/test/TestNotation.v
+++ b/execution/test/TestNotation.v
@@ -13,7 +13,10 @@ From Coq Require Import Bool.
     - max_acts_per_block: Defines the maximum number of actions that the generator will add per block. Default value is 2.
     - act_depth
     - DepthFirst: A boolean value denoting whether actions are executed in a depth first order (true) or breadth first order (false). Default value is true.
-    - AddrSize: The total number of valid addresses in the blockchain. The first half of the address space is reserved for user accounts while the secound half is reserved for smart contracts. Default value is 256.
+    - AddrSize: The total number of valid addresses in the blockchain. The first half of the address space is reserved
+      for user accounts while the secound half is reserved for smart contracts. Default value is 256 (overwriting this value is not recommended).
+    - BlockReward: The reward given to the address adding a block to the chain. Default value is 50.
+    - BlockCreator: The address used when adding new blocks to the chain. Default value is "creator" (address 10).
     
     These values can be overwritten between tests by: << Extract Constant max_trace_length => "3" >>
 *)

--- a/execution/test/TraceGens.v
+++ b/execution/test/TraceGens.v
@@ -30,6 +30,8 @@ Import ListNotations.
 Section TraceGens.
   Context `{Show ChainBuilder}.
   Context `{Show ChainState}.
+  Global Definition BlockReward : Amount := 50.
+  Global Definition BlockCreator : Address := creator.
 
   (* Deconstructs a ChainTrace to a list of blockheaders list of the minimum information
       needed to reconstruct a ChainTrace, that being a list of block headers and
@@ -132,8 +134,8 @@ Section TraceGens.
         {| block_height := S (chain_height chain);
           block_slot := S (current_slot chain);
           block_finalized_height := finalized_height chain;
-          block_creator := creator;
-          block_reward := 50; |} in
+          block_creator := BlockCreator;
+          block_reward := BlockReward; |} in
     builder_add_block chain header acts.
 
   Definition gAdd_block (cb : ChainBuilder)


### PR DESCRIPTION
Add the `Time` command to all property-based tests.
Also exposes block reward and block creator in TraceGens allowing users to overwrite the values between tests.