### PR TITLE
Upgrade fa2 interface

### DIFF
--- a/examples/_CoqProject
+++ b/examples/_CoqProject
@@ -32,7 +32,7 @@ bat/BATAltFixTests.v
 
 -Q fa2 ConCert.Examples.FA2
 fa2/FA2Interface.v
-fa2/LegacyFA2Interface.v
+fa2/FA2LegacyInterface.v
 fa2/FA2Token.v
 fa2/TestContracts.v
 fa2/FA2Printers.v

--- a/examples/_CoqProject
+++ b/examples/_CoqProject
@@ -32,6 +32,7 @@ bat/BATAltFixTests.v
 
 -Q fa2 ConCert.Examples.FA2
 fa2/FA2Interface.v
+fa2/LegacyFA2Interface.v
 fa2/FA2Token.v
 fa2/TestContracts.v
 fa2/FA2Printers.v

--- a/examples/dexter/Dexter.v
+++ b/examples/dexter/Dexter.v
@@ -131,9 +131,11 @@ Definition receive_balance_response (responses : list balance_of_response)
   let asset_transfer_msg := act_transfer related_exchange.(exchange_owner) tokens_price in
   let token_transfer_param := msg_transfer [{|
     from_ := related_exchange.(exchange_owner);
-    to_ := dexter_caddr;
-    transfer_token_id := related_exchange.(exchange_token_id);
-    amount := related_exchange.(tokens_sold);
+    txs := [{|
+      to_ := dexter_caddr;
+      dst_token_id := related_exchange.(exchange_token_id);
+      amount := related_exchange.(tokens_sold);
+    |}];
     sender_callback_addr := Some related_exchange.(callback_addr);
   |}] in
   let token_transfer_msg := act_call state.(fa2_caddr) 0%Z (@serialize FA2Token.Msg _ (token_transfer_param)) in

--- a/examples/dexter/Dexter.v
+++ b/examples/dexter/Dexter.v
@@ -6,7 +6,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Utils Require Import RecordUpdate.
 
 Import ListNotations.

--- a/examples/dexter/Dexter.v
+++ b/examples/dexter/Dexter.v
@@ -6,7 +6,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Utils Require Import RecordUpdate.
 
 Import ListNotations.

--- a/examples/dexter/DexterTests.v
+++ b/examples/dexter/DexterTests.v
@@ -5,7 +5,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import ResultMonad.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.Dexter Require Import Dexter.
 From ConCert.Examples.Dexter Require Import DexterGens.
 From ConCert.Utils Require Import Extras.

--- a/examples/dexter/DexterTests.v
+++ b/examples/dexter/DexterTests.v
@@ -5,7 +5,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import ResultMonad.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.Dexter Require Import Dexter.
 From ConCert.Examples.Dexter Require Import DexterGens.
 From ConCert.Utils Require Import Extras.

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -263,7 +263,7 @@ Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
       call_to_token state.(tokenAddress)
                     0
                     (FA2Token.msg_transfer
-                      [FA2Interface.build_transfer from to state.(tokenId) amount None]).
+                      [FA2Interface.build_transfer from [FA2Interface.build_transfer_destination to state.(tokenId) amount] None]).
 
     Definition xtz_transfer (to : Address) (amount : N) : option ActionBody :=
       if address_is_contract to

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -17,7 +17,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.Dexter2 Require Import Dexter2FA12.
 From Coq Require Import ZArith_base.
 From Coq Require Import List. Import ListNotations.
@@ -33,10 +33,10 @@ Open Scope N_scope.
 
 (** ** Type synonyms *)
 
-Definition update_token_pool_internal_ := list LegacyFA2Interface.balance_of_response.
-Definition token_id := LegacyFA2Interface.token_id.
-Definition token_contract_transfer := LegacyFA2Interface.transfer.
-Definition balance_of := LegacyFA2Interface.balance_of_response.
+Definition update_token_pool_internal_ := list FA2LegacyInterface.balance_of_response.
+Definition token_id := FA2LegacyInterface.token_id.
+Definition token_contract_transfer := FA2LegacyInterface.transfer.
+Definition balance_of := FA2LegacyInterface.balance_of_response.
 Definition mintOrBurn := Dexter2FA12.mintOrBurn_param.
 Definition baker_address := option Address.
 
@@ -263,7 +263,7 @@ Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
       call_to_token state.(tokenAddress)
                     0
                     (FA2Token.msg_transfer
-                      [LegacyFA2Interface.build_transfer from [LegacyFA2Interface.build_transfer_destination to state.(tokenId) amount] None]).
+                      [FA2LegacyInterface.build_transfer from [FA2LegacyInterface.build_transfer_destination to state.(tokenId) amount] None]).
 
     Definition xtz_transfer (to : Address) (amount : N) : option ActionBody :=
       if address_is_contract to
@@ -394,9 +394,9 @@ Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
       do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
       do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_UNEXPECTED_REENTRANCE_IN_UPDATE_TOKEN_POOL *)
       let balance_of_request :=
-        LegacyFA2Interface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
+        FA2LegacyInterface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
       let balance_of_param :=
-        LegacyFA2Interface.Build_balance_of_param [balance_of_request] (LegacyFA2Interface.Build_callback _ None ctx.(ctx_contract_address)) in
+        FA2LegacyInterface.Build_balance_of_param [balance_of_request] (FA2LegacyInterface.Build_callback _ None ctx.(ctx_contract_address)) in
       let op := call_to_token state.(tokenAddress) 0 (FA2Token.msg_balance_of balance_of_param) in
         Some (state<| selfIsUpdatingTokenPool := true |>, [op]).
 

--- a/examples/dexter2/Dexter2CPMM.v
+++ b/examples/dexter2/Dexter2CPMM.v
@@ -17,7 +17,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.Dexter2 Require Import Dexter2FA12.
 From Coq Require Import ZArith_base.
 From Coq Require Import List. Import ListNotations.
@@ -33,10 +33,10 @@ Open Scope N_scope.
 
 (** ** Type synonyms *)
 
-Definition update_token_pool_internal_ := list FA2Interface.balance_of_response.
-Definition token_id := FA2Interface.token_id.
-Definition token_contract_transfer := FA2Interface.transfer.
-Definition balance_of := FA2Interface.balance_of_response.
+Definition update_token_pool_internal_ := list LegacyFA2Interface.balance_of_response.
+Definition token_id := LegacyFA2Interface.token_id.
+Definition token_contract_transfer := LegacyFA2Interface.transfer.
+Definition balance_of := LegacyFA2Interface.balance_of_response.
 Definition mintOrBurn := Dexter2FA12.mintOrBurn_param.
 Definition baker_address := option Address.
 
@@ -263,7 +263,7 @@ Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
       call_to_token state.(tokenAddress)
                     0
                     (FA2Token.msg_transfer
-                      [FA2Interface.build_transfer from [FA2Interface.build_transfer_destination to state.(tokenId) amount] None]).
+                      [LegacyFA2Interface.build_transfer from [LegacyFA2Interface.build_transfer_destination to state.(tokenId) amount] None]).
 
     Definition xtz_transfer (to : Address) (amount : N) : option ActionBody :=
       if address_is_contract to
@@ -394,9 +394,9 @@ Module Dexter2 (SI : Dexter2Serializable) (NAddr : NullAddress).
       do _ <- throwIf (non_zero_amount ctx.(ctx_amount)) ; (* error_AMOUNT_MUST_BE_ZERO *)
       do _ <- throwIf state.(selfIsUpdatingTokenPool) ; (* error_UNEXPECTED_REENTRANCE_IN_UPDATE_TOKEN_POOL *)
       let balance_of_request :=
-        FA2Interface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
+        LegacyFA2Interface.Build_balance_of_request ctx.(ctx_contract_address) state.(tokenId) in
       let balance_of_param :=
-        FA2Interface.Build_balance_of_param [balance_of_request] (FA2Interface.Build_callback _ None ctx.(ctx_contract_address)) in
+        LegacyFA2Interface.Build_balance_of_param [balance_of_request] (LegacyFA2Interface.Build_callback _ None ctx.(ctx_contract_address)) in
       let op := call_to_token state.(tokenAddress) 0 (FA2Token.msg_balance_of balance_of_param) in
         Some (state<| selfIsUpdatingTokenPool := true |>, [op]).
 

--- a/examples/dexter2/Dexter2CPMMCorrect.v
+++ b/examples/dexter2/Dexter2CPMMCorrect.v
@@ -19,7 +19,7 @@ From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import InterContractCommunication.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.Dexter2 Require Import Dexter2FA12.
 From ConCert.Examples.Dexter2 Require Dexter2FA12Correct.
 From ConCert.Examples.Dexter2 Require Import Dexter2CPMM. Import DEX2.
@@ -393,7 +393,7 @@ Section Theories.
         act_call prev_state.(tokenAddress) 0%Z (serialize
           (msg_balance_of (Build_balance_of_param 
             ([Build_balance_of_request ctx.(ctx_contract_address) prev_state.(tokenId)])
-            (LegacyFA2Interface.Build_callback _ None ctx.(ctx_contract_address)))))
+            (FA2LegacyInterface.Build_callback _ None ctx.(ctx_contract_address)))))
       ].
   Proof.
     intros * receive_some.

--- a/examples/dexter2/Dexter2CPMMCorrect.v
+++ b/examples/dexter2/Dexter2CPMMCorrect.v
@@ -19,7 +19,7 @@ From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import InterContractCommunication.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.Dexter2 Require Import Dexter2FA12.
 From ConCert.Examples.Dexter2 Require Dexter2FA12Correct.
 From ConCert.Examples.Dexter2 Require Import Dexter2CPMM. Import DEX2.
@@ -393,7 +393,7 @@ Section Theories.
         act_call prev_state.(tokenAddress) 0%Z (serialize
           (msg_balance_of (Build_balance_of_param 
             ([Build_balance_of_request ctx.(ctx_contract_address) prev_state.(tokenId)])
-            (FA2Interface.Build_callback _ None ctx.(ctx_contract_address)))))
+            (LegacyFA2Interface.Build_callback _ None ctx.(ctx_contract_address)))))
       ].
   Proof.
     intros * receive_some.

--- a/examples/dexter2/Dexter2CPMMCorrect.v
+++ b/examples/dexter2/Dexter2CPMMCorrect.v
@@ -527,7 +527,7 @@ Section Theories.
       [
         (act_call prev_state.(tokenAddress) 0%Z
           (serialize (FA2Token.msg_transfer
-          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) tokens_deposited None])));
+          [build_transfer ctx.(ctx_from) [build_transfer_destination ctx.(ctx_contract_address) prev_state.(tokenId) tokens_deposited] None])));
         (act_call prev_state.(lqtAddress) 0%Z
           (serialize (Dexter2FA12.msg_mint_or_burn {| target := param.(owner); quantity := Z.of_N lqt_minted|})))
       ].
@@ -605,7 +605,7 @@ Section Theories.
           (serialize (Dexter2FA12.msg_mint_or_burn {| target := ctx.(ctx_from); quantity := - Z.of_N param.(lqtBurned)|})));
         (act_call prev_state.(tokenAddress) 0%Z
           (serialize (FA2Token.msg_transfer
-          [build_transfer ctx.(ctx_contract_address) param.(liquidity_to) prev_state.(tokenId) tokens_withdrawn None])));
+          [build_transfer ctx.(ctx_contract_address) [build_transfer_destination param.(liquidity_to) prev_state.(tokenId) tokens_withdrawn] None])));
         (act_transfer param.(liquidity_to) (N_to_amount xtz_withdrawn))
       ].
   Proof.
@@ -689,7 +689,7 @@ Section Theories.
       [
         (act_call prev_state.(tokenAddress) 0%Z
           (serialize (FA2Token.msg_transfer
-          [build_transfer ctx.(ctx_contract_address) param.(tokens_to) prev_state.(tokenId) tokens_bought None])))
+          [build_transfer ctx.(ctx_contract_address) [build_transfer_destination param.(tokens_to) prev_state.(tokenId) tokens_bought] None])))
       ].
   Proof.
     intros * receive_some.
@@ -759,7 +759,7 @@ Section Theories.
       [
         (act_call prev_state.(tokenAddress) 0%Z
           (serialize (FA2Token.msg_transfer
-          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold) None])));
+          [build_transfer ctx.(ctx_from) [build_transfer_destination ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold)] None])));
         (act_transfer param.(xtz_to) (N_to_amount xtz_bought))
       ].
   Proof.
@@ -841,7 +841,7 @@ Section Theories.
       [
         (act_call prev_state.(tokenAddress) 0%Z
           (serialize (FA2Token.msg_transfer
-          [build_transfer ctx.(ctx_from) ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold_) None])));
+          [build_transfer ctx.(ctx_from) [build_transfer_destination ctx.(ctx_contract_address) prev_state.(tokenId) param.(tokensSold_)] None])));
         (act_call param.(outputDexterContract) (N_to_amount xtz_bought)
           (serialize ((FA2Token.other_msg (XtzToToken
           {| tokens_to := param.(to_);

--- a/examples/fa2/FA2Gens.v
+++ b/examples/fa2/FA2Gens.v
@@ -4,7 +4,7 @@ From ConCert.Execution Require Import Containers.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.FA2 Require Import FA2Printers.
 From ConCert.Examples.FA2 Require Import TestContracts.
 From Coq Require Import ZArith.

--- a/examples/fa2/FA2Gens.v
+++ b/examples/fa2/FA2Gens.v
@@ -4,7 +4,7 @@ From ConCert.Execution Require Import Containers.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.FA2 Require Import FA2Printers.
 From ConCert.Examples.FA2 Require Import TestContracts.
 From Coq Require Import ZArith.

--- a/examples/fa2/FA2Gens.v
+++ b/examples/fa2/FA2Gens.v
@@ -95,10 +95,12 @@ Definition gSingleTransfer (state : FA2Token.State)
         returnGenSome
           (caller, {|
             from_ := from;
-            to_ := to;
-            transfer_token_id := tokenid;
-            amount := amount;
-            sender_callback_addr := None;
+            txs := [{|
+              to_ := to;
+              dst_token_id := tokenid;
+              amount := amount;
+            |}];
+            sender_callback_addr := None
           |})
     )
   | None => returnGen None

--- a/examples/fa2/FA2Interface.v
+++ b/examples/fa2/FA2Interface.v
@@ -24,13 +24,19 @@ Record callback (A : Type) := {
 Definition callback_addr {A : Type} (c : callback A) : Address := c.(return_addr A).
 Global Coercion callback_addr : callback >-> Address.
 
-Record transfer :=
+Record transfer_destination := 
+  build_transfer_destination {
+    to_ : Address;
+    dst_token_id : N;
+    amount : N;
+}.
+
+(*TODO : What to do with callback?*)
+Record transfer := 
   build_transfer {
     from_ : Address;
-    to_ : Address;
-    transfer_token_id : token_id;
-    amount : N;
-    sender_callback_addr : option Address;
+    txs : list transfer_destination;
+    sender_callback_addr : option Address
 }.
 
 Record balance_of_request := {
@@ -115,11 +121,15 @@ Record permissions_descriptor := {
   descr_custom : option Address;
 }.
 
+Record transfer_destination_descriptor := {
+  transfer_dst_descr_to_ : option Address;
+  transfer_dst_descr_token_id : token_id;
+  transfer_dst_descr_amount : N  
+}.
+
 Record transfer_descriptor := {
-  transfer_descr_from_ : Address;
-  transfer_descr_to_ : Address;
-  transfer_descr_token_id : token_id;
-  transfer_descr_amount : N;
+  transfer_descr_from_ : option Address;
+  transfer_descr_txs : list transfer_destination_descriptor
 }.
 
 Record transfer_descriptor_param := {
@@ -143,6 +153,7 @@ End FA2Types.
 
 Section Setters.
 
+MetaCoq Run (make_setters transfer_destination).
 MetaCoq Run (make_setters transfer).
 MetaCoq Run (make_setters balance_of_request).
 MetaCoq Run (make_setters balance_of_response).
@@ -155,6 +166,7 @@ MetaCoq Run (make_setters operator_param).
 MetaCoq Run (make_setters is_operator_response).
 MetaCoq Run (make_setters is_operator_param).
 MetaCoq Run (make_setters permissions_descriptor).
+MetaCoq Run (make_setters transfer_destination_descriptor).
 MetaCoq Run (make_setters transfer_descriptor).
 MetaCoq Run (make_setters transfer_descriptor_param).
 MetaCoq Run (make_setters set_hook_param).
@@ -164,6 +176,9 @@ End Setters.
 Section Serialization.
 Instance callback_serializable {A : Type} `{serA : Serializable A} : Serializable (callback A) :=
 Derive Serializable (callback_rect A) <(Build_callback A)>.
+
+Global Instance transfer_destination_serializable : Serializable transfer_destination :=
+  Derive Serializable transfer_destination_rect<build_transfer_destination>.
 
 Global Instance transfer_serializable : Serializable transfer :=
   Derive Serializable transfer_rect <build_transfer>.
@@ -227,6 +242,9 @@ Global Instance owner_transfer_policy_serializable : Serializable owner_transfer
 
 Global Instance permissions_descriptor_serializable : Serializable permissions_descriptor :=
   Derive Serializable permissions_descriptor_rect <Build_permissions_descriptor>.
+
+Global Instance transfer_destination_descriptor_serializable : Serializable transfer_destination_descriptor :=
+Derive Serializable transfer_destination_descriptor_rect <Build_transfer_destination_descriptor>.
 
 Global Instance transfer_descriptor_serializable : Serializable transfer_descriptor :=
   Derive Serializable transfer_descriptor_rect <Build_transfer_descriptor>.

--- a/examples/fa2/FA2LegacyInterface.v
+++ b/examples/fa2/FA2LegacyInterface.v
@@ -7,7 +7,7 @@ From ConCert.Utils Require Import RecordUpdate.
 Import ListNotations.
 
 
-Section LegacyFA2Interface.
+Section FA2LegacyInterface.
 Context {BaseTypes : ChainBase}.
 Set Primitive Projections.
 Set Nonrecursive Elimination Schemes.
@@ -31,7 +31,6 @@ Record transfer_destination :=
     amount : N;
 }.
 
-(*TODO : What to do with callback?*)
 Record transfer := 
   build_transfer {
     from_ : Address;
@@ -266,4 +265,4 @@ Global Instance set_hook_param_serializable : Serializable set_hook_param :=
 
 End Serialization.
 
-End LegacyFA2Interface.
+End FA2LegacyInterface.

--- a/examples/fa2/FA2Printers.v
+++ b/examples/fa2/FA2Printers.v
@@ -12,13 +12,20 @@ Instance showCallback {A : Type}: Show (FA2Interface.callback A) :=
   show v := "return address: " ++ show v.(return_addr A)
 |}.
 
+Instance showFA2InterfaceTransferDestination : Show FA2Interface.transfer_destination :=
+{|
+  show t := "{"
+            ++ "to_: " ++ show t.(to_) ++ sep
+            ++ "dst_token_id: " ++ show t.(dst_token_id) ++ sep
+            ++ "amount: " ++ show t.(amount) ++ sep
+            ++ "}"
+|}.
+
 Instance showFA2InterfaceTransfer : Show FA2Interface.transfer :=
 {|
   show t := "{"
             ++ "from_: " ++ show t.(from_) ++ sep
-            ++ "to_: " ++ show t.(to_) ++ sep
-            ++ "transfer_token_id: " ++ show t.(transfer_token_id) ++ sep
-            ++ "amount: " ++ show t.(amount) ++ sep
+            ++ "txs:" ++ show t.(txs) ++ sep
             ++ "callback: " ++ show t.(sender_callback_addr)
             ++ "}"
 |}.
@@ -163,13 +170,20 @@ Instance showFA2Interfacepermissions_descriptor : Show FA2Interface.permissions_
             ++ "}"
 |}.
 
+Instance showFA2Interfacetransfer_destination_descriptor : Show FA2Interface.transfer_destination_descriptor :=
+{|
+  show t := "transfer_destination_descriptor{"
+            ++ "transfer_dst_descr_to_: " ++ show t.(transfer_dst_descr_to_) ++ sep
+            ++ "transfer_dst_descr_token_id: " ++ show t.(transfer_dst_descr_token_id) ++ sep
+            ++ "transfer_dst_descr_amount: " ++ show t.(transfer_dst_descr_amount)
+            ++ "}"
+|}.
+
 Instance showFA2Interfacetransfer_descriptor : Show FA2Interface.transfer_descriptor :=
 {|
   show t := "transfer_descriptor{"
             ++ "transfer_descr_from_: " ++ show t.(transfer_descr_from_) ++ sep
-            ++ "transfer_descr_to_: " ++ show t.(transfer_descr_to_) ++ sep
-            ++ "transfer_descr_token_id: " ++ show t.(transfer_descr_token_id) ++ sep
-            ++ "transfer_descr_amount: " ++ show t.(transfer_descr_amount)
+            ++ "transfer_descr_txs: " ++ show t.(transfer_descr_txs) ++ sep
             ++ "}"
 |}.
 

--- a/examples/fa2/FA2Printers.v
+++ b/examples/fa2/FA2Printers.v
@@ -1,18 +1,18 @@
 From ConCert.Execution Require Import Blockchain.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution.Test Require Import QCTest.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.FA2 Require Import FA2Token.
 From ConCert.Examples.FA2 Require Import TestContracts.
 Local Open Scope string_scope.
 
 
-Instance showCallback {A : Type}: Show (FA2Interface.callback A) :=
+Instance showCallback {A : Type}: Show (LegacyFA2Interface.callback A) :=
 {|
   show v := "return address: " ++ show v.(return_addr A)
 |}.
 
-Instance showFA2InterfaceTransferDestination : Show FA2Interface.transfer_destination :=
+Instance showFA2InterfaceTransferDestination : Show LegacyFA2Interface.transfer_destination :=
 {|
   show t := "{"
             ++ "to_: " ++ show t.(to_) ++ sep
@@ -21,7 +21,7 @@ Instance showFA2InterfaceTransferDestination : Show FA2Interface.transfer_destin
             ++ "}"
 |}.
 
-Instance showFA2InterfaceTransfer : Show FA2Interface.transfer :=
+Instance showFA2InterfaceTransfer : Show LegacyFA2Interface.transfer :=
 {|
   show t := "{"
             ++ "from_: " ++ show t.(from_) ++ sep
@@ -30,7 +30,7 @@ Instance showFA2InterfaceTransfer : Show FA2Interface.transfer :=
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_request : Show FA2Interface.balance_of_request :=
+Instance showFA2Interfacebalance_of_request : Show LegacyFA2Interface.balance_of_request :=
 {|
   show t := "balance_of_request{"
             ++ "owner: " ++ show t.(owner) ++ sep
@@ -38,7 +38,7 @@ Instance showFA2Interfacebalance_of_request : Show FA2Interface.balance_of_reque
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_response : Show FA2Interface.balance_of_response :=
+Instance showFA2Interfacebalance_of_response : Show LegacyFA2Interface.balance_of_response :=
 {|
   show t := "balance_of_response{"
             ++ "request: " ++ show t.(request) ++ sep
@@ -46,7 +46,7 @@ Instance showFA2Interfacebalance_of_response : Show FA2Interface.balance_of_resp
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_param : Show FA2Interface.balance_of_param :=
+Instance showFA2Interfacebalance_of_param : Show LegacyFA2Interface.balance_of_param :=
 {|
   show t := "balance_of_param{"
             ++ "bal_requests: " ++ show t.(bal_requests) ++ sep
@@ -54,7 +54,7 @@ Instance showFA2Interfacebalance_of_param : Show FA2Interface.balance_of_param :
             ++ "}"
 |}.
 
-Instance showFA2Interfacetotal_supply_response : Show FA2Interface.total_supply_response :=
+Instance showFA2Interfacetotal_supply_response : Show LegacyFA2Interface.total_supply_response :=
 {|
   show t := "total_supply_response{"
             ++ "supply_resp_token_id: " ++ show t.(supply_resp_token_id) ++ sep
@@ -62,7 +62,7 @@ Instance showFA2Interfacetotal_supply_response : Show FA2Interface.total_supply_
             ++ "}"
 |}.
 
-Instance showFA2Interfacetotal_supply_param : Show FA2Interface.total_supply_param :=
+Instance showFA2Interfacetotal_supply_param : Show LegacyFA2Interface.total_supply_param :=
 {|
   show t := "total_supply_param{"
             ++ "supply_param_token_ids: " ++ show t.(supply_param_token_ids) ++ sep
@@ -70,7 +70,7 @@ Instance showFA2Interfacetotal_supply_param : Show FA2Interface.total_supply_par
             ++ "}"
 |}.
 
-Instance showFA2Interfacetoken_metadata : Show FA2Interface.token_metadata :=
+Instance showFA2Interfacetoken_metadata : Show LegacyFA2Interface.token_metadata :=
 {|
   show t := "token_metadata{"
             ++ "metadata_token_id: " ++ show t.(metadata_token_id) ++ sep
@@ -78,7 +78,7 @@ Instance showFA2Interfacetoken_metadata : Show FA2Interface.token_metadata :=
             ++ "}"
 |}.
 
-Instance showFA2Interfacetoken_metadata_param : Show FA2Interface.token_metadata_param :=
+Instance showFA2Interfacetoken_metadata_param : Show LegacyFA2Interface.token_metadata_param :=
 {|
   show t := "token_metadata_param{"
             ++ "metadata_token_ids: " ++ show t.(metadata_token_ids) ++ sep
@@ -94,7 +94,7 @@ Instance showoperator_tokens : Show operator_tokens :=
             end
 |}.
 
-Instance showFA2Interfaceoperator_param : Show FA2Interface.operator_param :=
+Instance showFA2Interfaceoperator_param : Show LegacyFA2Interface.operator_param :=
 {|
   show t := "operator_param{"
             ++ "op_param_owner: " ++ show t.(op_param_owner) ++ sep
@@ -111,7 +111,7 @@ Global Instance showupdate_operator : Show update_operator :=
             end
 |}.
 
-Instance showFA2Interfaceis_operator_response : Show FA2Interface.is_operator_response :=
+Instance showFA2Interfaceis_operator_response : Show LegacyFA2Interface.is_operator_response :=
 {|
   show t := "is_operator_response{"
             ++ "operator: " ++ show t.(operator) ++ sep
@@ -119,7 +119,7 @@ Instance showFA2Interfaceis_operator_response : Show FA2Interface.is_operator_re
             ++ "}"
 |}.
 
-Instance showFA2Interfaceis_operator_param : Show FA2Interface.is_operator_param :=
+Instance showFA2Interfaceis_operator_param : Show LegacyFA2Interface.is_operator_param :=
 {|
   show t := "is_operator_param{"
             ++ "is_operator_operator: " ++ show t.(is_operator_operator) ++ sep
@@ -152,14 +152,14 @@ Instance showowner_transfer_policy : Show owner_transfer_policy :=
             end
 |}.
 
-(* Instance showFA2Interfacecustom_permission_policy : Show FA2Interface.custom_permission_policy :=
+(* Instance showFA2Interfacecustom_permission_policy : Show LegacyFA2Interface.custom_permission_policy :=
 {|
   show t := "custom_permission_policy{"
             ++ "custom_policy_config_api: " ++ show t.(custom_policy_config_api)
             ++ "}"
 |}. *)
 
-Instance showFA2Interfacepermissions_descriptor : Show FA2Interface.permissions_descriptor :=
+Instance showFA2Interfacepermissions_descriptor : Show LegacyFA2Interface.permissions_descriptor :=
 {|
   show t := "permissions_descriptor{"
             ++ "descr_self: " ++ show t.(descr_self) ++ sep
@@ -170,7 +170,7 @@ Instance showFA2Interfacepermissions_descriptor : Show FA2Interface.permissions_
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_destination_descriptor : Show FA2Interface.transfer_destination_descriptor :=
+Instance showFA2Interfacetransfer_destination_descriptor : Show LegacyFA2Interface.transfer_destination_descriptor :=
 {|
   show t := "transfer_destination_descriptor{"
             ++ "transfer_dst_descr_to_: " ++ show t.(transfer_dst_descr_to_) ++ sep
@@ -179,7 +179,7 @@ Instance showFA2Interfacetransfer_destination_descriptor : Show FA2Interface.tra
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_descriptor : Show FA2Interface.transfer_descriptor :=
+Instance showFA2Interfacetransfer_descriptor : Show LegacyFA2Interface.transfer_descriptor :=
 {|
   show t := "transfer_descriptor{"
             ++ "transfer_descr_from_: " ++ show t.(transfer_descr_from_) ++ sep
@@ -187,7 +187,7 @@ Instance showFA2Interfacetransfer_descriptor : Show FA2Interface.transfer_descri
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_descriptor_param : Show FA2Interface.transfer_descriptor_param :=
+Instance showFA2Interfacetransfer_descriptor_param : Show LegacyFA2Interface.transfer_descriptor_param :=
 {|
   show t := "transfer_descriptor_param{"
             ++ "transfer_descr_fa2: " ++ show t.(transfer_descr_fa2) ++ sep
@@ -210,7 +210,7 @@ Instance showfa2_token_sender : Show fa2_token_sender :=
             end
 |}.
 
-Instance showFA2Interfaceset_hook_param : Show FA2Interface.set_hook_param :=
+Instance showFA2Interfaceset_hook_param : Show LegacyFA2Interface.set_hook_param :=
 {|
   show t := "set_hook_param{"
             ++ "hook_addr: " ++ show t.(hook_addr) ++ sep

--- a/examples/fa2/FA2Printers.v
+++ b/examples/fa2/FA2Printers.v
@@ -1,18 +1,18 @@
 From ConCert.Execution Require Import Blockchain.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution.Test Require Import QCTest.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.FA2 Require Import FA2Token.
 From ConCert.Examples.FA2 Require Import TestContracts.
 Local Open Scope string_scope.
 
 
-Instance showCallback {A : Type}: Show (LegacyFA2Interface.callback A) :=
+Instance showCallback {A : Type}: Show (FA2LegacyInterface.callback A) :=
 {|
   show v := "return address: " ++ show v.(return_addr A)
 |}.
 
-Instance showFA2InterfaceTransferDestination : Show LegacyFA2Interface.transfer_destination :=
+Instance showFA2InterfaceTransferDestination : Show FA2LegacyInterface.transfer_destination :=
 {|
   show t := "{"
             ++ "to_: " ++ show t.(to_) ++ sep
@@ -21,7 +21,7 @@ Instance showFA2InterfaceTransferDestination : Show LegacyFA2Interface.transfer_
             ++ "}"
 |}.
 
-Instance showFA2InterfaceTransfer : Show LegacyFA2Interface.transfer :=
+Instance showFA2InterfaceTransfer : Show FA2LegacyInterface.transfer :=
 {|
   show t := "{"
             ++ "from_: " ++ show t.(from_) ++ sep
@@ -30,7 +30,7 @@ Instance showFA2InterfaceTransfer : Show LegacyFA2Interface.transfer :=
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_request : Show LegacyFA2Interface.balance_of_request :=
+Instance showFA2Interfacebalance_of_request : Show FA2LegacyInterface.balance_of_request :=
 {|
   show t := "balance_of_request{"
             ++ "owner: " ++ show t.(owner) ++ sep
@@ -38,7 +38,7 @@ Instance showFA2Interfacebalance_of_request : Show LegacyFA2Interface.balance_of
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_response : Show LegacyFA2Interface.balance_of_response :=
+Instance showFA2Interfacebalance_of_response : Show FA2LegacyInterface.balance_of_response :=
 {|
   show t := "balance_of_response{"
             ++ "request: " ++ show t.(request) ++ sep
@@ -46,7 +46,7 @@ Instance showFA2Interfacebalance_of_response : Show LegacyFA2Interface.balance_o
             ++ "}"
 |}.
 
-Instance showFA2Interfacebalance_of_param : Show LegacyFA2Interface.balance_of_param :=
+Instance showFA2Interfacebalance_of_param : Show FA2LegacyInterface.balance_of_param :=
 {|
   show t := "balance_of_param{"
             ++ "bal_requests: " ++ show t.(bal_requests) ++ sep
@@ -54,7 +54,7 @@ Instance showFA2Interfacebalance_of_param : Show LegacyFA2Interface.balance_of_p
             ++ "}"
 |}.
 
-Instance showFA2Interfacetotal_supply_response : Show LegacyFA2Interface.total_supply_response :=
+Instance showFA2Interfacetotal_supply_response : Show FA2LegacyInterface.total_supply_response :=
 {|
   show t := "total_supply_response{"
             ++ "supply_resp_token_id: " ++ show t.(supply_resp_token_id) ++ sep
@@ -62,7 +62,7 @@ Instance showFA2Interfacetotal_supply_response : Show LegacyFA2Interface.total_s
             ++ "}"
 |}.
 
-Instance showFA2Interfacetotal_supply_param : Show LegacyFA2Interface.total_supply_param :=
+Instance showFA2Interfacetotal_supply_param : Show FA2LegacyInterface.total_supply_param :=
 {|
   show t := "total_supply_param{"
             ++ "supply_param_token_ids: " ++ show t.(supply_param_token_ids) ++ sep
@@ -70,7 +70,7 @@ Instance showFA2Interfacetotal_supply_param : Show LegacyFA2Interface.total_supp
             ++ "}"
 |}.
 
-Instance showFA2Interfacetoken_metadata : Show LegacyFA2Interface.token_metadata :=
+Instance showFA2Interfacetoken_metadata : Show FA2LegacyInterface.token_metadata :=
 {|
   show t := "token_metadata{"
             ++ "metadata_token_id: " ++ show t.(metadata_token_id) ++ sep
@@ -78,7 +78,7 @@ Instance showFA2Interfacetoken_metadata : Show LegacyFA2Interface.token_metadata
             ++ "}"
 |}.
 
-Instance showFA2Interfacetoken_metadata_param : Show LegacyFA2Interface.token_metadata_param :=
+Instance showFA2Interfacetoken_metadata_param : Show FA2LegacyInterface.token_metadata_param :=
 {|
   show t := "token_metadata_param{"
             ++ "metadata_token_ids: " ++ show t.(metadata_token_ids) ++ sep
@@ -94,7 +94,7 @@ Instance showoperator_tokens : Show operator_tokens :=
             end
 |}.
 
-Instance showFA2Interfaceoperator_param : Show LegacyFA2Interface.operator_param :=
+Instance showFA2Interfaceoperator_param : Show FA2LegacyInterface.operator_param :=
 {|
   show t := "operator_param{"
             ++ "op_param_owner: " ++ show t.(op_param_owner) ++ sep
@@ -111,7 +111,7 @@ Global Instance showupdate_operator : Show update_operator :=
             end
 |}.
 
-Instance showFA2Interfaceis_operator_response : Show LegacyFA2Interface.is_operator_response :=
+Instance showFA2Interfaceis_operator_response : Show FA2LegacyInterface.is_operator_response :=
 {|
   show t := "is_operator_response{"
             ++ "operator: " ++ show t.(operator) ++ sep
@@ -119,7 +119,7 @@ Instance showFA2Interfaceis_operator_response : Show LegacyFA2Interface.is_opera
             ++ "}"
 |}.
 
-Instance showFA2Interfaceis_operator_param : Show LegacyFA2Interface.is_operator_param :=
+Instance showFA2Interfaceis_operator_param : Show FA2LegacyInterface.is_operator_param :=
 {|
   show t := "is_operator_param{"
             ++ "is_operator_operator: " ++ show t.(is_operator_operator) ++ sep
@@ -152,14 +152,14 @@ Instance showowner_transfer_policy : Show owner_transfer_policy :=
             end
 |}.
 
-(* Instance showFA2Interfacecustom_permission_policy : Show LegacyFA2Interface.custom_permission_policy :=
+(* Instance showFA2Interfacecustom_permission_policy : Show FA2LegacyInterface.custom_permission_policy :=
 {|
   show t := "custom_permission_policy{"
             ++ "custom_policy_config_api: " ++ show t.(custom_policy_config_api)
             ++ "}"
 |}. *)
 
-Instance showFA2Interfacepermissions_descriptor : Show LegacyFA2Interface.permissions_descriptor :=
+Instance showFA2Interfacepermissions_descriptor : Show FA2LegacyInterface.permissions_descriptor :=
 {|
   show t := "permissions_descriptor{"
             ++ "descr_self: " ++ show t.(descr_self) ++ sep
@@ -170,7 +170,7 @@ Instance showFA2Interfacepermissions_descriptor : Show LegacyFA2Interface.permis
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_destination_descriptor : Show LegacyFA2Interface.transfer_destination_descriptor :=
+Instance showFA2Interfacetransfer_destination_descriptor : Show FA2LegacyInterface.transfer_destination_descriptor :=
 {|
   show t := "transfer_destination_descriptor{"
             ++ "transfer_dst_descr_to_: " ++ show t.(transfer_dst_descr_to_) ++ sep
@@ -179,7 +179,7 @@ Instance showFA2Interfacetransfer_destination_descriptor : Show LegacyFA2Interfa
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_descriptor : Show LegacyFA2Interface.transfer_descriptor :=
+Instance showFA2Interfacetransfer_descriptor : Show FA2LegacyInterface.transfer_descriptor :=
 {|
   show t := "transfer_descriptor{"
             ++ "transfer_descr_from_: " ++ show t.(transfer_descr_from_) ++ sep
@@ -187,7 +187,7 @@ Instance showFA2Interfacetransfer_descriptor : Show LegacyFA2Interface.transfer_
             ++ "}"
 |}.
 
-Instance showFA2Interfacetransfer_descriptor_param : Show LegacyFA2Interface.transfer_descriptor_param :=
+Instance showFA2Interfacetransfer_descriptor_param : Show FA2LegacyInterface.transfer_descriptor_param :=
 {|
   show t := "transfer_descriptor_param{"
             ++ "transfer_descr_fa2: " ++ show t.(transfer_descr_fa2) ++ sep
@@ -210,7 +210,7 @@ Instance showfa2_token_sender : Show fa2_token_sender :=
             end
 |}.
 
-Instance showFA2Interfaceset_hook_param : Show LegacyFA2Interface.set_hook_param :=
+Instance showFA2Interfaceset_hook_param : Show FA2LegacyInterface.set_hook_param :=
 {|
   show t := "set_hook_param{"
             ++ "hook_addr: " ++ show t.(hook_addr) ++ sep

--- a/examples/fa2/FA2Token.v
+++ b/examples/fa2/FA2Token.v
@@ -7,7 +7,7 @@ From ConCert.Execution Require Import Containers.
 From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 
 Import ListNotations.
 

--- a/examples/fa2/FA2Token.v
+++ b/examples/fa2/FA2Token.v
@@ -7,7 +7,7 @@ From ConCert.Execution Require Import Containers.
 From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 
 Import ListNotations.
 

--- a/examples/fa2/FA2Token.v
+++ b/examples/fa2/FA2Token.v
@@ -160,22 +160,26 @@ Definition try_single_transfer (caller : Address)
                                (params : transfer)
                                (state : State)
                                : option State :=
-  do ledger <- FMap.find params.(transfer_token_id) state.(assets) ;
-  let current_owner_balance := address_balance params.(transfer_token_id) params.(from_) state in
-  let new_balances := FMap.add params.(from_) (current_owner_balance - params.(amount)) ledger.(balances) in
-  let new_balances := FMap.partial_alter (fun balance => Some ((with_default 0 balance) + params.(amount))) params.(to_) new_balances in
+  do _ <- throwIf (negb (1 =? N.of_nat (length params.(txs)))) ;
+  do transfer_dst <- hd_error (params.(txs)) ;
+  do ledger <- FMap.find transfer_dst.(dst_token_id) state.(assets) ;
+  let current_owner_balance := address_balance transfer_dst.(dst_token_id) params.(from_) state in
+  let new_balances := FMap.add params.(from_) (current_owner_balance - transfer_dst.(amount)) ledger.(balances) in
+  let new_balances := FMap.partial_alter (fun balance => Some ((with_default 0 balance) + transfer_dst.(amount))) transfer_dst.(to_) new_balances in
   let new_ledger := ledger<|balances := new_balances|> in
-  Some (state<|assets ::= FMap.add params.(transfer_token_id) new_ledger|>).
+  Some (state<|assets ::= FMap.add transfer_dst.(dst_token_id) new_ledger|>).
 
 Definition transfer_check_permissions (caller : Address)
                                       (params : transfer)
                                       (policy : permissions_descriptor)
                                       (state : State)
                                       : option unit :=
+  do _ <- throwIf (negb (1 =? N.of_nat (length params.(txs)))) ;
+  do transfer_dst <- hd_error (params.(txs)) ;
   (* check for sufficient permissions *)
-  do _ <- address_has_sufficient_asset_balance params.(transfer_token_id) params.(from_) params.(amount) state ;
+  do _ <- address_has_sufficient_asset_balance transfer_dst.(dst_token_id) params.(from_) transfer_dst.(amount) state ;
   (* only allow transfers of known token_ids *)
-  do _ <- FMap.find params.(transfer_token_id) state.(tokens) ;
+  do _ <- FMap.find transfer_dst.(dst_token_id) state.(tokens) ;
   (* if caller is owner of transfer, then check policy if self_transfer is allowed *)
   if (address_eqb caller params.(from_))
   then
@@ -188,7 +192,7 @@ Definition transfer_check_permissions (caller : Address)
     (* check if operator has permission to transfer the given token_id type *)
     match op_tokens with
     | all_tokens => Some tt
-    | some_tokens token_ids => if (existsb (fun id => id =? params.(transfer_token_id)) token_ids)
+    | some_tokens token_ids => if (existsb (fun id => id =? transfer_dst.(dst_token_id)) token_ids)
                                then Some tt
                                else None
     end.
@@ -213,11 +217,14 @@ Definition call_transfer_hook (caller : Address)
                               (transfers : list transfer)
                               (state : State)
                               : ActionBody :=
+  let mk_transfer_dst_descr tr_dst := {|
+    transfer_dst_descr_to_ := Some tr_dst.(to_);
+    transfer_dst_descr_token_id := tr_dst.(dst_token_id);
+    transfer_dst_descr_amount := tr_dst.(amount)
+    |} in
   let mk_transfer_descr tr := {|
-    transfer_descr_from_ := (tr.(from_));
-    transfer_descr_to_ := (tr.(to_));
-    transfer_descr_token_id := tr.(transfer_token_id);
-    transfer_descr_amount := tr.(amount);
+    transfer_descr_from_ := Some (tr.(from_));
+    transfer_descr_txs := map mk_transfer_dst_descr tr.(txs)
     |} in
   let transfer_decr_param := {|
     transfer_descr_fa2 := caddr;
@@ -251,23 +258,30 @@ Definition handle_transfer (caller : Address)
     Some (state, [call_hook_act])
   (* if no hook is attached, send transfer message to self, and notify senders of transfer *)
   | None =>
-    let mk_transfer_descr tr := {|
-      transfer_descr_from_ := tr.(from_);
-      transfer_descr_to_ := tr.(to_);
-      transfer_descr_token_id := tr.(transfer_token_id);
-      transfer_descr_amount := tr.(amount);
+  let mk_transfer_dst_descr tr_dst := {|
+    transfer_dst_descr_to_ := Some tr_dst.(to_);
+    transfer_dst_descr_token_id := tr_dst.(dst_token_id);
+    transfer_dst_descr_amount := tr_dst.(amount)
+    |} in
+  let mk_transfer_descr tr := {|
+    transfer_descr_from_ := Some (tr.(from_));
+    transfer_descr_txs := map mk_transfer_dst_descr tr.(txs)
     |} in
     let mk_transfer_decr_param batch := {|
       transfer_descr_fa2 := caddr;
       transfer_descr_batch := batch;
       transfer_descr_operator := caller;
-    |} in
+    |} in 
     let transfer_decr_param := mk_transfer_decr_param (map mk_transfer_descr transfers) in
-    let is_from_contract descriptors := existsb (fun descr => address_is_contract descr.(transfer_descr_from_)) descriptors in
+    let is_from_contract descriptors := existsb (fun descr => 
+      match descr.(transfer_descr_from_) with
+      | Some addr => address_is_contract addr 
+      | None => false
+      end) descriptors in 
     let trx_descriptors_grouped := (group_transfer_descriptors (map mk_transfer_descr transfers)) in
     let self_transfer_act := act_call caddr 0%Z (serialize (msg_receive_hook_transfer transfer_decr_param)) in
 
-    (* let mk_sender_hook_act descr_param := act_call descr_param.(transfer_descr_operator) 0%Z (@serialize _ _ (tokens_sent descr_param)) in *)
+    (* let mk_sender_hook_act descr_param := act_call dst.(transfer_descr_operator) 0%Z (@serialize _ _ (tokens_sent descr_param)) in *)
     let mk_sender_hook_act trx :=
       match trx.(sender_callback_addr) with
       | Some callback_addr =>
@@ -290,14 +304,26 @@ Definition handle_transfer (caller : Address)
   end.
 
 Open Scope bool_scope.
-Definition mk_transfer_from_decr descr :=
-{|
-  from_ := descr.(transfer_descr_from_);
-  to_ := descr.(transfer_descr_to_);
-  transfer_token_id := descr.(transfer_descr_token_id);
-  amount := descr.(transfer_descr_amount);
-  sender_callback_addr := None (* Some param.(transfer_descr_operator) *)
-|}.
+Definition mk_transfer_destination_from_descr (dst_descr: transfer_destination_descriptor) :option transfer_destination := 
+  do to <- dst_descr.(transfer_dst_descr_to_) ;
+  Some {|
+    to_ := to;
+    dst_token_id := dst_descr.(transfer_dst_descr_token_id);
+    amount := dst_descr.(transfer_dst_descr_amount)
+  |}.
+
+Definition mk_transfer_from_descr (descr: transfer_descriptor) : option transfer :=
+  do from <- descr.(transfer_descr_from_) ;
+  let iter := (fun dst_descr acc_opt => 
+    do acc <- acc_opt;
+    do tx_dst <- mk_transfer_destination_from_descr dst_descr;
+    Some (tx_dst :: acc)) in
+  do txs_list <- fold_right iter (Some []) descr.(transfer_descr_txs);
+  Some {|
+    from_ := from;
+    txs := txs_list;
+    sender_callback_addr := None (* Some param.(transfer_descr_operator) *)
+  |}.
 
 Definition handle_transfer_hook_receive (caller : Address)
                                         (param : transfer_descriptor_param)
@@ -311,7 +337,11 @@ Definition handle_transfer_hook_receive (caller : Address)
           end)
           then Some tt
           else None  ;
-  let transfers := map mk_transfer_from_decr param.(transfer_descr_batch) in
+  let iter := (fun descr acc_opt =>
+    do acc <- acc_opt;
+    do trans <- mk_transfer_from_descr descr;
+    Some (trans :: acc)) in
+  do transfers <- fold_right iter (Some []) param.(transfer_descr_batch) ;
   try_transfer param.(transfer_descr_operator) transfers state.
 Close Scope bool_scope.
 

--- a/examples/fa2/FA2TokenTests.v
+++ b/examples/fa2/FA2TokenTests.v
@@ -4,7 +4,7 @@ From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ResultMonad.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Examples.FA2 Require Import TestContracts.
 From ConCert.Utils Require Import Extras.
 From Coq Require Import ZArith.
@@ -258,7 +258,7 @@ Definition transfer_balances_correct (old_cs new_cs : ChainState) :=
 (* +++ Passed 10000 tests (0 discards) *)
 
 
-Definition get_transfers (acts : list Action) : list (Address * list LegacyFA2Interface.transfer) :=
+Definition get_transfers (acts : list Action) : list (Address * list FA2LegacyInterface.transfer) :=
   fold_left (fun trxs act =>
     match act.(act_body) with
     | act_call _ _ msg =>

--- a/examples/fa2/FA2TokenTests.v
+++ b/examples/fa2/FA2TokenTests.v
@@ -156,23 +156,26 @@ Extract Constant max_acts_per_block => "1".
 Local Open Scope Z_scope.
 Definition transfer_state_update_correct prev_state next_state transfers :=
   let balance_diffs_map : FMap (Address * token_id) Z := fold_left (fun current_diff_map trx =>
-    (* subtract amount from sender *)
-    let m1 :=
-      let amount := Z.of_N (trx.(amount)) in
-      let from_key := (trx.(from_), trx.(transfer_token_id)) in
-      match FMap.find from_key current_diff_map with
-      | Some current_diff => FMap.add from_key (current_diff - amount) current_diff_map
-      | None => FMap.add from_key (-amount) current_diff_map
-      end in
-    (* add amount to receiver *)
-    let m2 :=
-      let amount := Z.of_N (trx.(amount)) in
-      let to_key := (trx.(to_), trx.(transfer_token_id)) in
-      match FMap.find to_key m1 with
-      | Some current_diff => FMap.add to_key (current_diff + amount) m1
-      | None => FMap.add to_key amount m1
-      end in
-    m2
+    let from := trx.(from_) in
+    let iter := (fun diff_map trx_dst =>
+      (* subtract amount from sender *)
+      let m1 :=
+        let amount := Z.of_N (trx_dst.(amount)) in
+        let from_key := (from, trx_dst.(dst_token_id)) in
+        match FMap.find from_key current_diff_map with
+        | Some current_diff => FMap.add from_key (current_diff - amount) current_diff_map
+        | None => FMap.add from_key (-amount) current_diff_map
+        end in
+      (* add amount to receiver *)
+      let m2 :=
+        let amount := Z.of_N (trx_dst.(amount)) in
+        let to_key := (trx_dst.(to_), trx_dst.(dst_token_id)) in
+        match FMap.find to_key m1 with
+        | Some current_diff => FMap.add to_key (current_diff + amount) m1
+        | None => FMap.add to_key amount m1
+        end in
+      m2) in 
+      fold_left iter trx.(txs) current_diff_map
   ) transfers FMap.empty in
   let balance_update_correct p balance_diff :=
     let addr := fst p in
@@ -276,7 +279,9 @@ Definition transfer_satisfies_policy sender trx state : Checker :=
       | Some all_tokens => checker true
       | Some (some_tokens token_ids) =>
         whenFail "operator didn't have sufficient token_id permissions"
-        (checker (existsb (N.eqb trx.(transfer_token_id)) token_ids))
+        (checker (fold_right ((fun (tx_dst : transfer_destination) (acc: bool) =>
+            if acc then (existsb (N.eqb (tx_dst.(dst_token_id))) token_ids) else false
+        )) true trx.(txs)))
       | None => checker false
       end
     | None => checker false

--- a/examples/fa2/FA2TokenTests.v
+++ b/examples/fa2/FA2TokenTests.v
@@ -4,7 +4,7 @@ From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ResultMonad.
 From ConCert.Execution.Test Require Import QCTest.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Examples.FA2 Require Import TestContracts.
 From ConCert.Utils Require Import Extras.
 From Coq Require Import ZArith.
@@ -258,7 +258,7 @@ Definition transfer_balances_correct (old_cs new_cs : ChainState) :=
 (* +++ Passed 10000 tests (0 discards) *)
 
 
-Definition get_transfers (acts : list Action) : list (Address * list FA2Interface.transfer) :=
+Definition get_transfers (acts : list Action) : list (Address * list LegacyFA2Interface.transfer) :=
   fold_left (fun trxs act =>
     match act.(act_body) with
     | act_call _ _ msg =>

--- a/examples/fa2/LegacyFA2Interface.v
+++ b/examples/fa2/LegacyFA2Interface.v
@@ -1,15 +1,13 @@
 From Coq Require Import ZArith.
 From Coq Require Import List.
-From Coq Require Import String.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import Blockchain.
 From ConCert.Utils Require Import RecordUpdate.
-From ConCert.Execution Require Import Containers.
 
 Import ListNotations.
 
 
-Section FA2Interface.
+Section LegacyFA2Interface.
 Context {BaseTypes : ChainBase}.
 Set Primitive Projections.
 Set Nonrecursive Elimination Schemes.
@@ -33,10 +31,12 @@ Record transfer_destination :=
     amount : N;
 }.
 
+(*TODO : What to do with callback?*)
 Record transfer := 
   build_transfer {
     from_ : Address;
     txs : list transfer_destination;
+    sender_callback_addr : option Address
 }.
 
 Record balance_of_request := {
@@ -54,20 +54,72 @@ Record balance_of_param := {
   bal_callback : callback (list balance_of_response);
 }.
 
+Record total_supply_response := {
+  supply_resp_token_id : token_id;
+  total_supply : N;
+}.
+
+Record total_supply_param := {
+  supply_param_token_ids : list token_id;
+  supply_param_callback : callback (list total_supply_response);
+}.
+
 Record token_metadata := {
   metadata_token_id : token_id;
-  metadata_token_info : FMap string N
+  metadata_decimals : N;
 }.
+
+Record token_metadata_param := {
+  metadata_token_ids : list token_id;
+  metadata_callback : callback (list token_metadata);
+}.
+
+Inductive operator_tokens  :=
+  | all_tokens : operator_tokens
+  | some_tokens : list token_id -> operator_tokens. (* a set could be used here instead of list?*)
 
 Record operator_param := {
   op_param_owner : Address;
   op_param_operator : Address;
-  op_param_token_id : token_id;
+  op_param_tokens : operator_tokens;
 }.
 
 Inductive update_operator :=
   | add_operator : operator_param -> update_operator
   | remove_operator : operator_param -> update_operator.
+
+Record is_operator_response := {
+  operator : operator_param;
+  is_operator : bool;
+}.
+
+Record is_operator_param := {
+  is_operator_operator : operator_param;
+  is_operator_callback : callback (is_operator_response);
+}.
+
+(* permission policy definition *)
+
+Inductive self_transfer_policy :=
+  | self_transfer_permitted : self_transfer_policy
+  | self_transfer_denied : self_transfer_policy.
+
+Inductive operator_transfer_policy :=
+  | operator_transfer_permitted : operator_transfer_policy
+  | operator_transfer_denied : operator_transfer_policy.
+
+Inductive owner_transfer_policy :=
+  | owner_no_op : owner_transfer_policy
+  | optional_owner_hook : owner_transfer_policy
+  | required_owner_hook : owner_transfer_policy.
+
+Record permissions_descriptor := {
+  descr_self : self_transfer_policy;
+  descr_operator : operator_transfer_policy;
+  descr_receiver : owner_transfer_policy;
+  descr_sender : owner_transfer_policy;
+  descr_custom : option Address;
+}.
 
 Record transfer_destination_descriptor := {
   transfer_dst_descr_to_ : option Address;
@@ -92,6 +144,11 @@ Inductive fa2_token_receiver :=
 Inductive fa2_token_sender :=
   | tokens_sent : transfer_descriptor_param -> fa2_token_sender.
 
+Record set_hook_param := {
+  hook_addr : Address;
+  hook_permissions_descriptor : permissions_descriptor;
+}.
+
 End FA2Types.
 
 Section Setters.
@@ -101,11 +158,18 @@ MetaCoq Run (make_setters transfer).
 MetaCoq Run (make_setters balance_of_request).
 MetaCoq Run (make_setters balance_of_response).
 MetaCoq Run (make_setters balance_of_param).
+MetaCoq Run (make_setters total_supply_response).
+MetaCoq Run (make_setters total_supply_param).
 MetaCoq Run (make_setters token_metadata).
+MetaCoq Run (make_setters token_metadata_param).
 MetaCoq Run (make_setters operator_param).
+MetaCoq Run (make_setters is_operator_response).
+MetaCoq Run (make_setters is_operator_param).
+MetaCoq Run (make_setters permissions_descriptor).
 MetaCoq Run (make_setters transfer_destination_descriptor).
 MetaCoq Run (make_setters transfer_descriptor).
 MetaCoq Run (make_setters transfer_descriptor_param).
+MetaCoq Run (make_setters set_hook_param).
 
 End Setters.
 
@@ -131,17 +195,53 @@ Instance bal_of_param_callback_serializable : Serializable (callback (list balan
 Global Instance balance_of_param_serializable : Serializable balance_of_param :=
   Derive Serializable balance_of_param_rect <Build_balance_of_param>.
 
+Global Instance total_supply_response_serializable : Serializable total_supply_response :=
+  Derive Serializable total_supply_response_rect <Build_total_supply_response>.
+
+Instance supply_param_callback_serializable : Serializable (callback (list total_supply_response)) :=
+  Derive Serializable (callback_rect (list total_supply_response)) <(Build_callback (list total_supply_response))>.
+
+Global Instance total_supply_param_serializable : Serializable total_supply_param :=
+  Derive Serializable total_supply_param_rect <Build_total_supply_param>.
+
 Global Instance token_metadata_serializable : Serializable token_metadata :=
   Derive Serializable token_metadata_rect <Build_token_metadata>.
 
 Instance metadata_callback_serializable : Serializable (callback (list token_metadata)) :=
   Derive Serializable (callback_rect (list token_metadata)) <(Build_callback (list token_metadata))>.
 
+Global Instance token_metadata_param_serializable : Serializable token_metadata_param :=
+  Derive Serializable token_metadata_param_rect <Build_token_metadata_param>.
+
+Global Instance operator_tokens_serializable : Serializable operator_tokens :=
+  Derive Serializable operator_tokens_rect <all_tokens, some_tokens>.
+
 Global Instance operator_param_serializable : Serializable operator_param :=
   Derive Serializable operator_param_rect <Build_operator_param>.
 
 Global Instance update_operator_serializable : Serializable update_operator :=
   Derive Serializable update_operator_rect <add_operator, remove_operator>.
+
+Global Instance is_operator_response_serializable : Serializable is_operator_response :=
+  Derive Serializable is_operator_response_rect <Build_is_operator_response>.
+
+Instance is_operator_param_callback_serializable : Serializable (callback is_operator_response) :=
+  Derive Serializable (callback_rect is_operator_response) <(Build_callback is_operator_response)>.
+
+Global Instance is_operator_param_serializable : Serializable is_operator_param :=
+  Derive Serializable is_operator_param_rect <Build_is_operator_param>.
+
+Global Instance self_transfer_policy_serializable : Serializable self_transfer_policy :=
+  Derive Serializable self_transfer_policy_rect <self_transfer_permitted, self_transfer_denied>.
+
+Global Instance operator_transfer_policy_serializable : Serializable operator_transfer_policy :=
+  Derive Serializable operator_transfer_policy_rect <operator_transfer_permitted, operator_transfer_denied>.
+
+Global Instance owner_transfer_policy_serializable : Serializable owner_transfer_policy :=
+  Derive Serializable owner_transfer_policy_rect <owner_no_op , optional_owner_hook, required_owner_hook>.
+
+Global Instance permissions_descriptor_serializable : Serializable permissions_descriptor :=
+  Derive Serializable permissions_descriptor_rect <Build_permissions_descriptor>.
 
 Global Instance transfer_destination_descriptor_serializable : Serializable transfer_destination_descriptor :=
 Derive Serializable transfer_destination_descriptor_rect <Build_transfer_destination_descriptor>.
@@ -161,6 +261,9 @@ Global Instance fa2_token_sender_serializable : Serializable fa2_token_sender :=
 Instance transfer_descriptor_param_callback_serializable : Serializable (callback transfer_descriptor_param) :=
   Derive Serializable (callback_rect transfer_descriptor_param) <(Build_callback transfer_descriptor_param)>.
 
+Global Instance set_hook_param_serializable : Serializable set_hook_param :=
+  Derive Serializable set_hook_param_rect <Build_set_hook_param>.
+
 End Serialization.
 
-End FA2Interface.
+End LegacyFA2Interface.

--- a/examples/fa2/TestContracts.v
+++ b/examples/fa2/TestContracts.v
@@ -144,7 +144,8 @@ Definition check_transfer_permissions (tr : transfer_descriptor)
                                       (operator : Address)
                                       (state : HookState)
                                       : option unit :=
-  if (address_eqb tr.(transfer_descr_from_) operator)
+  do from <- tr.(transfer_descr_from_) ;
+  if (address_eqb from operator)
   then if (FA2Token.policy_disallows_self_transfer state.(hook_policy))
     then None
     else Some tt

--- a/examples/fa2/TestContracts.v
+++ b/examples/fa2/TestContracts.v
@@ -3,7 +3,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
+From ConCert.Examples.FA2 Require Import FA2LegacyInterface.
 From ConCert.Utils Require Import RecordUpdate.
 
 From Coq Require Import List.

--- a/examples/fa2/TestContracts.v
+++ b/examples/fa2/TestContracts.v
@@ -3,7 +3,7 @@ From ConCert.Execution Require Import Monads.
 From ConCert.Execution Require Import Serializable.
 From ConCert.Execution Require Import ContractCommon.
 From ConCert.Examples.FA2 Require Import FA2Token.
-From ConCert.Examples.FA2 Require Import FA2Interface.
+From ConCert.Examples.FA2 Require Import LegacyFA2Interface.
 From ConCert.Utils Require Import RecordUpdate.
 
 From Coq Require Import List.


### PR DESCRIPTION
Updates FA2Interface to follow the [TZip-12 standard](https://gitlab.com/tezos/tzip/-/tree/master/proposals/tzip-12). The changes that are compatible with both old and new code is in the LegacyFA2Interface, and the FA2Interface has had deprecated fields removed to provide a good base for FA2 contracts to expand on going forward. Solves #163 