### PR TITLE
Fix coqdocjs css

### DIFF
--- a/extra/resources/coqdocjs/coqdoc.css
+++ b/extra/resources/coqdocjs/coqdoc.css
@@ -205,3 +205,7 @@ ul.doclist {
 html {
     scroll-padding-top: 50px;
 }
+
+.section {
+    position: static!important;
+}

--- a/extra/resources/coqdocjs/coqdoc.css
+++ b/extra/resources/coqdocjs/coqdoc.css
@@ -201,3 +201,7 @@ ul.doclist {
     text-align: center;
     color: darkblue;
 }
+
+html {
+    scroll-padding-top: 50px;
+}


### PR DESCRIPTION
Fixes the following issues related to coqdocjs:
* Clicking an anchor link will position the linked reference behind the header
* The `Show/Hide Proofs` button cannot be clicked while an element with the `section` class is located behind it
* Elements with `section` class are positioned over the header