### PR TITLE
Link external documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ html: all
 		--external https://plv.mpi-sws.org/coqdoc/stdpp stdpp \
 		--external https://metacoq.github.io/html MetaCoq \
 		--external https://coq-community.org/coq-ext-lib/v0.11.6 ExtLib \
+		--coqlib http://coq.inria.fr/distrib/V8.11.2/stdlib \
 		-R utils/theories ConCert.Utils \
 		-R execution/theories ConCert.Execution \
 		-R execution/test ConCert.Execution.Test \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ html: all
 	coqdoc --html --interpolate --parse-comments \
 		--with-header extra/header.html --with-footer extra/footer.html \
 		--toc \
+		--external https://plv.mpi-sws.org/coqdoc/stdpp stdpp \
 		-R utils/theories ConCert.Utils \
 		-R execution/theories ConCert.Execution \
 		-R execution/test ConCert.Execution.Test \

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ html: all
 		--with-header extra/header.html --with-footer extra/footer.html \
 		--toc \
 		--external https://plv.mpi-sws.org/coqdoc/stdpp stdpp \
+		--external https://metacoq.github.io/html MetaCoq \
 		-R utils/theories ConCert.Utils \
 		-R execution/theories ConCert.Execution \
 		-R execution/test ConCert.Execution.Test \

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ html: all
 		--toc \
 		--external https://plv.mpi-sws.org/coqdoc/stdpp stdpp \
 		--external https://metacoq.github.io/html MetaCoq \
+		--external https://coq-community.org/coq-ext-lib/v0.11.6 ExtLib \
 		-R utils/theories ConCert.Utils \
 		-R execution/theories ConCert.Execution \
 		-R execution/test ConCert.Execution.Test \


### PR DESCRIPTION
Link external library documentation for coq-stdpp, MetaCoq, and ExtLib.
Documentation could not be linked for QuickChick, bignums and equations because they don't host coqdoc pages.