### PR TITLE
Fix documentation TOC width

### DIFF
--- a/extra/resources/coqdocjs/coqdocjs.css
+++ b/extra/resources/coqdocjs/coqdocjs.css
@@ -120,6 +120,7 @@ html, body {
     padding: 16px;
     padding-top: 2em;
     padding-bottom: 2em;
+    padding-left: min(255px, 16vw);
     margin-left: auto;
     margin-right: auto;
     max-width: 60em;

--- a/extra/resources/toc/toc.css
+++ b/extra/resources/toc/toc.css
@@ -3,6 +3,7 @@
     width: min(250px, 15vw);
     position: fixed;
     border: 1px solid #ddd;
+    border-left-width: 0px;
     color: #333;
     margin-top: 55px;
     line-height: 2;

--- a/extra/resources/toc/toc.css
+++ b/extra/resources/toc/toc.css
@@ -1,6 +1,6 @@
 .toc {
     background: #fefefe;
-    width: 250px;
+    width: min(250px, 15vw);
     position: fixed;
     border: 1px solid #ddd;
     color: #333;


### PR DESCRIPTION
Make the width of the table of content adjust dynamically based on screen width.
Fixes TOC and main content overlapping on narrow screens.