### PR TITLE
Disable dependency graph in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,6 @@ jobs:
         rm -rf docs/graphs
         mkdir -p docs
         mkdir -p docs/graphs
-        make file-dependency-graph
-        mv file-dep.svg docs/graphs/index.svg
 
         make dependency-graphs
         mv utils/svg/* docs/graphs/


### PR DESCRIPTION
Broken because `COQDEP` removed support for the `-dumpgraph` option in 8.12.
This was used in CI for generating file-level dependency graphs.