### PR TITLE
Fix stdlib url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ html: all
 		--external https://plv.mpi-sws.org/coqdoc/stdpp stdpp \
 		--external https://metacoq.github.io/html MetaCoq \
 		--external https://coq-community.org/coq-ext-lib/v0.11.6 ExtLib \
-		--coqlib http://coq.inria.fr/distrib/V8.11.2/stdlib \
 		-R utils/theories ConCert.Utils \
 		-R execution/theories ConCert.Execution \
 		-R execution/test ConCert.Execution.Test \


### PR DESCRIPTION
URLs in the generated coqdoc were pointing to the wrong version of documentation for Coq stdlib.

Removed the `--coqlib` argument since the default value is the correct URL.