### PR TITLE
Remove docker image from CI

### DIFF
--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "coq-concert"
+version: "dev"
+synopsis: "A framework for smart contract verification in Coq"
+description: "A framework for smart contract verification in Coq"
+maintainer: "Danil Annenkov <danil.v.annenkov@gmail.com>"
+authors: "The COBRA team"
+license: "MIT"
+homepage: "https://github.com/AU-COBRA/ConCert"
+doc: "https://au-cobra.github.io/ConCert/toc.html"
+bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
+depends: [
+  "coq" {= "8.16.1"}
+  "coq-bignums" {= "8.16.0"}
+  "coq-equations" {= "1.3+8.16"}
+  "coq-metacoq-erasure" {= "1.1.1+8.16"}
+  "coq-metacoq-pcuic" {= "1.1.1+8.16"}
+  "coq-metacoq-safechecker" {= "1.1.1+8.16"}
+  "coq-metacoq-template" {= "1.1.1+8.16"}
+  "coq-quickchick" {= "1.6.4"}
+  "coq-stdpp" {= "1.8.0"}
+]
+build: [
+  [make]
+  [make "examples"] {with-test}
+  [make "html"] {with-doc}
+]
+install: [
+  [make "install"]
+  [make "-C" "examples" "install"] {with-test}
+]
+dev-repo: "git+https://github.com/AU-COBRA/ConCert.git"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,3 +85,49 @@ jobs:
           echo "::group::Build examples"
           opam exec -- make -j2 examples
           echo "::endgroup::"
+
+      - name: Build documentation
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          echo "::group::Running coqdoc"
+          opam exec -- make -j2 html
+          echo "::endgroup::"
+
+          echo "::group::Install dependencies"
+          opam install -y coq-dpdgraph
+          sudo apt install -y graphviz
+          echo "::endgroup::"
+
+          echo "::group::Generate dependency graphs"
+          rm -rf docs/graphs
+          mkdir -p docs
+          mkdir -p docs/graphs
+
+          opam exec -- make dependency-graphs
+          mv utils/svg/* docs/graphs/
+          mv execution/svg/* docs/graphs/
+          mv embedding/svg/* docs/graphs/
+          mv extraction/svg/* docs/graphs/
+          mv examples/svg/* docs/graphs/
+          echo "::endgroup::"
+
+      - name: Prepare documentation for deployment
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+
+  deploy-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,148 +22,66 @@ on:
     - 'extra/docker/**'
 permissions:
   contents: read
+env:
+  OCAML_COMILER_VERSION: "4.13.1"
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    container:
-      image: aucobra/concert:deps-8.16.1-with-compilers
-      options: --user root
     steps:
-    - name: Checkout branch ${{ github.ref_name }}
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: Setup environment
-      run: |
-        echo "::group::Setting up switch"
-        echo "HOME=/home/coq" >> $GITHUB_ENV
-        export HOME=/home/coq
-        echo "/home/coq/.cargo/bin" >> $GITHUB_PATH
-        PATH=/home/coq/.cargo/bin:$PATH
-        eval $(opam env --switch=${COMPILER} --set-switch)
-        env
-        opam switch
-        echo "::endgroup::"
+      - name: Checkout branch ${{ github.ref_name }}
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-        echo "::group::Setting up problem matcher"
-        echo "::add-matcher::./.github/coq-errors.json"
-        echo "::endgroup::"
-    - name: Build core
-      run: |
-        echo "::group::Setting up switch"
-        eval $(opam env --switch=${COMPILER} --set-switch)
-        echo "::endgroup::"
+      - name: Restore opam cache
+        id: opam-cache
+        uses: actions/cache@v3
+        with:
+          path: "~/.opam"
+          key: opam-${{env.OCAML_COMILER_VERSION}}-${{hashFiles('.github/coq-concert.opam.locked')}}
+          restore-keys: |
+            opam-${{env.OCAML_COMILER_VERSION}}-
 
-        echo "::group::Build utilities"
-        make -j2 utils
-        echo "::endgroup::"
+      - name: Set up OCaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{env.OCAML_COMILER_VERSION}}
 
-        echo "::group::Build execution layer"
-        make -j2 execution
-        echo "::endgroup::"
+      - name: Build dependencies
+        if: ${{ ! steps.opam-cache.outputs.cache-hit }}
+        run: |
+          opam repo add coq-released https://coq.inria.fr/opam/released
+          opam install --deps-only -j2 .github/coq-concert.opam.locked
+          opam clean -a -c -s --logs
 
-        echo "::group::Build embedding layer"
-        make -j2 embedding
-        echo "::endgroup::"
+      - name: Set up environment
+        run: |
+          echo "::group::Setting up problem matcher"
+          echo "::add-matcher::./.github/coq-errors.json"
+          echo "::endgroup::"
 
-        echo "::group::Build extraction layer"
-        make -j2 typed-extraction extraction
-        echo "::endgroup::"
-    - name: Build examples
-      run: |
-        echo "::group::Setting up switch"
-        eval $(opam env --switch=${COMPILER} --set-switch)
-        echo "::endgroup::"
+      - name: Build core
+        run: |
+          echo "::group::Build utilities"
+          opam exec -- make -j2 utils
+          echo "::endgroup::"
 
-        echo "::group::Build examples"
-        make -j2 examples
-        echo "::endgroup::"
-    - name: Test extraction
-      run: |
-        echo "::group::Setting up switch"
-        eval $(opam env --switch=${COMPILER} --set-switch)
-        echo "::endgroup::"
+          echo "::group::Build execution layer"
+          opam exec -- make -j2 execution
+          echo "::endgroup::"
 
-        echo "::group::Running tests"
-        make -j2 test-extraction
-        echo "::endgroup::"
+          echo "::group::Build embedding layer"
+          opam exec -- make -j2 embedding
+          echo "::endgroup::"
 
-        echo "::group::Cleaning up"
-        make -j2 clean-extraction-out-files
-        make -j2 clean-compiled-extraction
-        echo "::endgroup::"
-    - name: Build documentation
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      run: |
-        echo "::group::Setting up switch"
-        eval $(opam env --switch=${COMPILER} --set-switch)
-        echo "::endgroup::"
+          echo "::group::Build extraction layer"
+          opam exec -- make -j2 typed-extraction extraction
+          echo "::endgroup::"
 
-        echo "::group::Running coqdoc"
-        make -j2 html
-        echo "::endgroup::"
-
-        echo "::group::Install dependencies"
-        opam install -y coq-dpdgraph
-        sudo apt install -y graphviz
-        echo "::endgroup::"
-
-        echo "::group::Generate dependency graphs"
-        rm -rf docs/graphs
-        mkdir -p docs
-        mkdir -p docs/graphs
-
-        make dependency-graphs
-        mv utils/svg/* docs/graphs/
-        mv execution/svg/* docs/graphs/
-        mv embedding/svg/* docs/graphs/
-        mv extraction/svg/* docs/graphs/
-        mv examples/svg/* docs/graphs/
-        echo "::endgroup::"
-    - name: Upload Liquidity extraction logs
-      uses: actions/upload-artifact@v3
-      with:
-        name: Liquidity logs
-        path: extraction/tests/extracted-code/liquidity-extract/liquidity.log
-        retention-days: 14
-    - name: Prepare extraction results
-      if: github.event_name == 'push' && github.repository == 'AU-COBRA/ConCert' && github.ref == 'refs/heads/master'
-      run: |
-        cp LICENSE extraction/tests/extracted-code/LICENSE
-        cp extra/extraction-results.md extraction/tests/extracted-code/README.md
-        cp .gitattributes extraction/tests/extracted-code/.gitattributes
-        find extraction/tests/extracted-code -name 'placeholder' -delete
-        find extraction/tests/extracted-code/rust-extract -name '*.main' -delete
-    - name: Push to the extraction results repository
-      # don't push the extraction results on pull requests and push only from the master branch of the AU-COBRA/ConCert repo.
-      if: github.event_name == 'push' && github.repository == 'AU-COBRA/ConCert' && github.ref == 'refs/heads/master'
-      uses: cpina/github-action-push-to-another-repository@main
-      env:
-        SSH_DEPLOY_KEY: ${{ secrets.EXTRACTION_RESULTS_DEPLOY_KEY }}
-      with:
-        source-directory: 'extraction/tests/extracted-code'
-        destination-github-username: 'AU-COBRA'
-        destination-repository-name: 'extraction-results'
-        user-email: danil.v.annenkov@gmail.com
-        commit-message: See ORIGIN_COMMIT from $GITHUB_REF
-        target-branch: master
-    - name: Prepare documentation for deployment
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: docs
-  deploy-docs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
+      - name: Build examples
+        run: |
+          echo "::group::Build examples"
+          opam exec -- make -j2 examples
+          echo "::endgroup::"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ permissions:
   contents: read
 env:
   OCAML_COMILER_VERSION: "4.13.1"
+  JOBS: 2
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,7 +54,8 @@ jobs:
         if: ${{ ! steps.opam-cache.outputs.cache-hit }}
         run: |
           opam repo add coq-released https://coq.inria.fr/opam/released
-          opam install --deps-only -j2 .github/coq-concert.opam.locked
+          opam install --deps-only -j${{ env.JOBS }} .github/coq-concert.opam.locked
+          opam install -y -j${{ env.JOBS }} coq-dpdgraph
           opam clean -a -c -s --logs
 
       - name: Set up environment
@@ -65,36 +67,113 @@ jobs:
       - name: Build core
         run: |
           echo "::group::Build utilities"
-          opam exec -- make -j2 utils
+          opam exec -- make -j${{ env.JOBS }} utils
           echo "::endgroup::"
 
           echo "::group::Build execution layer"
-          opam exec -- make -j2 execution
+          opam exec -- make -j${{ env.JOBS }} execution
           echo "::endgroup::"
 
           echo "::group::Build embedding layer"
-          opam exec -- make -j2 embedding
+          opam exec -- make -j${{ env.JOBS }} embedding
           echo "::endgroup::"
 
           echo "::group::Build extraction layer"
-          opam exec -- make -j2 typed-extraction extraction
+          opam exec -- make -j${{ env.JOBS }} typed-extraction extraction
           echo "::endgroup::"
 
       - name: Build examples
         run: |
           echo "::group::Build examples"
-          opam exec -- make -j2 examples
+          opam exec -- make -j${{ env.JOBS }} examples
           echo "::endgroup::"
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Set up Concordium tools
+        run: |
+          curl -L -O https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0
+          sudo chmod +x cargo-concordium_1.0.0
+          sudo mv cargo-concordium_1.0.0 /usr/local/bin/cargo-concordium
+
+      - name: Set up LIGO v0.59.0
+        run: |
+          curl -L -O https://gitlab.com/ligolang/ligo/-/jobs/3553205311/artifacts/raw/ligo
+          sudo chmod +x ./ligo
+          sudo mv ligo /usr/local/bin/
+
+      - name: Set up Elm
+        run: |
+          curl -L -o elm.gz https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz
+          gunzip elm.gz
+          sudo chmod +x elm
+          sudo mv elm /usr/local/bin/
+      - name: Set up elm-test
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up elm-test
+        run: |
+          npm install -g elm-test@0.19.1-revision9
+
+      - name: Set up Liquidity
+        run: |
+          sudo chmod +x ./extra/docker/liquidity
+          sudo mv extra/docker/liquidity /usr/local/bin/
+
+      - name: Test extraction
+        run: |
+          echo "::group::Running tests"
+          make -j${{ env.JOBS }} test-extraction
+          echo "::endgroup::"
+
+      - name: Upload Liquidity extraction logs
+        if: false # Do we still want these logs?
+        uses: actions/upload-artifact@v3
+        with:
+          name: Liquidity logs
+          path: extraction/tests/extracted-code/liquidity-extract/liquidity.log
+          retention-days: 14
+
+      - name: Prepare extraction results
+        if: github.event_name == 'push' && github.repository == 'AU-COBRA/ConCert' && github.ref == 'refs/heads/master'
+        run: |
+          echo "::group::Cleaning up extracted code"
+          make -j${{ env.JOBS }} clean-extraction-out-files
+          make -j${{ env.JOBS }} clean-compiled-extraction
+          find extraction/tests/extracted-code -name 'placeholder' -delete
+          find extraction/tests/extracted-code/rust-extract -name '*.main' -delete
+          echo "::endgroup::"
+
+          cp LICENSE extraction/tests/extracted-code/LICENSE
+          cp extra/extraction-results.md extraction/tests/extracted-code/README.md
+          cp .gitattributes extraction/tests/extracted-code/.gitattributes
+
+      - name: Push to the extraction results repository
+        # don't push the extraction results on pull requests and push only from the master branch of the AU-COBRA/ConCert repo.
+        if: github.event_name == 'push' && github.repository == 'AU-COBRA/ConCert' && github.ref == 'refs/heads/master'
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.EXTRACTION_RESULTS_DEPLOY_KEY }}
+        with:
+          source-directory: 'extraction/tests/extracted-code'
+          destination-github-username: 'AU-COBRA'
+          destination-repository-name: 'extraction-results'
+          user-email: danil.v.annenkov@gmail.com
+          commit-message: See ORIGIN_COMMIT from $GITHUB_REF
+          target-branch: master
 
       - name: Build documentation
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           echo "::group::Running coqdoc"
-          opam exec -- make -j2 html
+          opam exec -- make -j${{ env.JOBS }} html
           echo "::endgroup::"
 
           echo "::group::Install dependencies"
-          opam install -y coq-dpdgraph
           sudo apt install -y graphviz
           echo "::endgroup::"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           ocaml-version: ${{env.OCAML_COMILER_VERSION}}
 
       - name: Build dependencies
-        if: ${{ ! steps.opam-cache.outputs.cache-hit }}
+        #if: ${{ !steps.opam-cache.outputs.cache-hit }}
         run: |
           opam repo add coq-released https://coq.inria.fr/opam/released
           opam install --deps-only -j${{ env.JOBS }} .github/coq-concert.opam.locked

--- a/.github/workflows/lint-opam.yml
+++ b/.github/workflows/lint-opam.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up opam
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.14.x
+          ocaml-compiler: 4.13.x
           opam-repositories: | 
             coq-released: https://coq.inria.fr/opam/released
             default: https://opam.ocaml.org

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -1,0 +1,30 @@
+name: Refresh cache
+on:
+  schedule:
+    - cron: 0 1 * * MON
+permissions:
+  contents: read
+env:
+  OCAML_COMILER_VERSION: "4.13.1"
+jobs:
+  cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch ${{ github.ref_name }}
+        uses: actions/checkout@v3
+
+      - name: Restore opam cache
+        id: opam-cache
+        uses: actions/cache@v3
+        with:
+          path: "~/.opam"
+          fail-on-cache-miss: true
+          key: opam-${{env.OCAML_COMILER_VERSION}}-${{hashFiles('.github/coq-concert.opam.locked')}}
+          restore-keys: |
+            opam-${{env.OCAML_COMILER_VERSION}}-
+
+      - name: Set up OCaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{env.OCAML_COMILER_VERSION}}
+      - run: opam list


### PR DESCRIPTION
Due to the Docker Free Teams subscription being removed, we might not be able to rely on Docker images in our CI in the future.

This PR reimplements the current CI without the deps Docker image. We cache dependencies to reduce the running time of the CI. The running time of CI is unchanged when there is an exact cache hit. We incrementally rebuild the cache when dependencies in the opam file change. A complete cache rebuild takes ~40 minutes which is faster than building the old Docker image.
