### PR TITLE
Fix MetaCoq utils imports

### DIFF
--- a/embedding/theories/Misc.v
+++ b/embedding/theories/Misc.v
@@ -1,6 +1,6 @@
 (** * Some facts not found in the standard library *)
 From ConCert.Utils Require Import Automation.
-From MetaCoq Require Import utils.
+From MetaCoq.Utils Require Import utils.
 From Coq Require Import List.
 From Coq Require Import Lia.
 


### PR DESCRIPTION
Building fails when `coq-metacoq-quotation` is installed because the import statement `From MetaCoq Require Import utils` isn't specific enough.