### PR TITLE
Update dependencies (Coq 8.18)

### DIFF
--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -11,14 +11,14 @@ doc: "https://au-cobra.github.io/ConCert/toc.html"
 bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
 depends: [
   "coq" {= "8.18.0"}
-  "coq-bignums" {= "9.0.0+coq8.17"}
-  "coq-metacoq-common" {= "1.2.1+8.17"}
-  "coq-metacoq-erasure" {= "1.2.1+8.17"}
-  "coq-metacoq-pcuic" {= "1.2.1+8.17"}
-  "coq-metacoq-safechecker" {= "1.2.1+8.17"}
-  "coq-metacoq-template" {= "1.2.1+8.17"}
-  "coq-metacoq-template-pcuic" {= "1.2.1+8.17"}
-  "coq-metacoq-utils" {= "1.2.1+8.17"}
+  "coq-bignums" {= "9.0.0+coq8.18"}
+  "coq-metacoq-common" {= "1.2.1+8.18"}
+  "coq-metacoq-erasure" {= "1.2.1+8.18"}
+  "coq-metacoq-pcuic" {= "1.2.1+8.18"}
+  "coq-metacoq-safechecker" {= "1.2.1+8.18"}
+  "coq-metacoq-template" {= "1.2.1+8.18"}
+  "coq-metacoq-template-pcuic" {= "1.2.1+8.18"}
+  "coq-metacoq-utils" {= "1.2.1+8.18"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
   "coq-quickchick" {= "dev"}

--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -37,10 +37,10 @@ dev-repo: "git+https://github.com/AU-COBRA/ConCert.git"
 pin-depends: [
   [
     "coq-rust-extraction.dev"
-    "git+https://github.com/AU-COBRA/coq-rust-extraction.git#f31a52ba2c1bddd42e9f9df8fca6c297ac359fae"
+    "git+https://github.com/AU-COBRA/coq-rust-extraction.git#0053733e56008c917bf43d12e8bf0616d3b9a856"
   ]
   [
     "coq-elm-extraction.dev"
-    "git+https://github.com/AU-COBRA/coq-elm-extraction.git#0c0a733486f915162a194ee646d5f11d2ffc5cc0"
+    "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"
   ]
 ]

--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -21,7 +21,7 @@ depends: [
   "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
-  "coq-quickchick" {= "2.0.0"}
+  "coq-quickchick" {= "dev"}
   "coq-stdpp" {= "1.8.0"}
 ]
 build: [
@@ -42,5 +42,9 @@ pin-depends: [
   [
     "coq-elm-extraction.dev"
     "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"
+  ]
+  [
+    "coq-quickchick.dev"
+    "git+https://github.com/4ever2/QuickChick.git#bc61d58045feeb754264df9494965c280e266e1c"
   ]
 ]

--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -12,13 +12,13 @@ bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
 depends: [
   "coq" {= "8.17.0"}
   "coq-bignums" {= "9.0.0+coq8.17"}
-  "coq-metacoq-common" {= "1.2+8.17"}
-  "coq-metacoq-erasure" {= "1.2+8.17"}
-  "coq-metacoq-pcuic" {= "1.2+8.17"}
-  "coq-metacoq-safechecker" {= "1.2+8.17"}
-  "coq-metacoq-template" {= "1.2+8.17"}
-  "coq-metacoq-template-pcuic" {= "1.2+8.17"}
-  "coq-metacoq-utils" {= "1.2+8.17"}
+  "coq-metacoq-common" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-erasure" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-pcuic" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-safechecker" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-template" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-template-pcuic" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
   "coq-quickchick" {= "2.0.0"}

--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -10,7 +10,7 @@ homepage: "https://github.com/AU-COBRA/ConCert"
 doc: "https://au-cobra.github.io/ConCert/toc.html"
 bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
 depends: [
-  "coq" {= "8.17.0"}
+  "coq" {= "8.18.0"}
   "coq-bignums" {= "9.0.0+coq8.17"}
   "coq-metacoq-common" {= "1.2.1+8.17"}
   "coq-metacoq-erasure" {= "1.2.1+8.17"}

--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -12,17 +12,17 @@ bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
 depends: [
   "coq" {= "8.17.0"}
   "coq-bignums" {= "9.0.0+coq8.17"}
-  "coq-metacoq-common" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-erasure" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-pcuic" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-safechecker" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-template" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-template-pcuic" {>= "1.2" & < "1.3~"}
-  "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-common" {= "1.2.1+8.17"}
+  "coq-metacoq-erasure" {= "1.2.1+8.17"}
+  "coq-metacoq-pcuic" {= "1.2.1+8.17"}
+  "coq-metacoq-safechecker" {= "1.2.1+8.17"}
+  "coq-metacoq-template" {= "1.2.1+8.17"}
+  "coq-metacoq-template-pcuic" {= "1.2.1+8.17"}
+  "coq-metacoq-utils" {= "1.2.1+8.17"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
   "coq-quickchick" {= "dev"}
-  "coq-stdpp" {= "1.8.0"}
+  "coq-stdpp" {= "1.9.0"}
 ]
 build: [
   [make]

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -17,13 +17,13 @@ depends: [
   "coq" {>= "8.17" & < "8.18~"}
   "coq-bignums" {>= "8"}
   "coq-quickchick" {= "2.0.0"}
-  "coq-metacoq-utils" {= "1.2+8.17"}
-  "coq-metacoq-common" {= "1.2+8.17"}
-  "coq-metacoq-template" {= "1.2+8.17"}
-  "coq-metacoq-template-pcuic" {= "1.2+8.17"}
-  "coq-metacoq-pcuic" {= "1.2+8.17"}
-  "coq-metacoq-safechecker" {= "1.2+8.17"}
-  "coq-metacoq-erasure" {= "1.2+8.17"}
+  "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-common" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-template" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-template-pcuic" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-pcuic" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-safechecker" {>= "1.2" & < "1.3~"}
+  "coq-metacoq-erasure" {>= "1.2" & < "1.3~"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
   "coq-stdpp" {>= "1.6.0" & <= "1.8.0"}

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -16,7 +16,7 @@ doc: "https://au-cobra.github.io/ConCert/toc.html"
 depends: [
   "coq" {>= "8.17" & < "8.18~"}
   "coq-bignums" {>= "8"}
-  "coq-quickchick" {= "2.0.0"}
+  "coq-quickchick" {= "dev"}
   "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
   "coq-metacoq-common" {>= "1.2" & < "1.3~"}
   "coq-metacoq-template" {>= "1.2" & < "1.3~"}
@@ -32,6 +32,7 @@ depends: [
 pin-depends: [
   ["coq-rust-extraction.dev" "git+https://github.com/AU-COBRA/coq-rust-extraction.git#0053733e56008c917bf43d12e8bf0616d3b9a856"]
   ["coq-elm-extraction.dev" "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"]
+  ["coq-quickchick.dev" "git+https://github.com/4ever2/QuickChick.git#bc61d58045feeb754264df9494965c280e266e1c"]
 ]
 
 build: [

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -26,7 +26,7 @@ depends: [
   "coq-metacoq-erasure" {>= "1.2" & < "1.3~"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
-  "coq-stdpp" {>= "1.6.0" & <= "1.8.0"}
+  "coq-stdpp" {= "1.9.0"}
 ]
 
 pin-depends: [

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -30,8 +30,8 @@ depends: [
 ]
 
 pin-depends: [
-  ["coq-rust-extraction.dev" "git+https://github.com/AU-COBRA/coq-rust-extraction.git#f31a52ba2c1bddd42e9f9df8fca6c297ac359fae"]
-  ["coq-elm-extraction.dev" "git+https://github.com/AU-COBRA/coq-elm-extraction.git#0c0a733486f915162a194ee646d5f11d2ffc5cc0"]
+  ["coq-rust-extraction.dev" "git+https://github.com/AU-COBRA/coq-rust-extraction.git#0053733e56008c917bf43d12e8bf0616d3b9a856"]
+  ["coq-elm-extraction.dev" "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"]
 ]
 
 build: [

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/AU-COBRA/ConCert/issues"
 doc: "https://au-cobra.github.io/ConCert/toc.html"
 
 depends: [
-  "coq" {>= "8.17" & < "8.18~"}
+  "coq" {>= "8.17" & < "8.19~"}
   "coq-bignums" {>= "8"}
   "coq-quickchick" {= "dev"}
   "coq-metacoq-utils" {>= "1.2" & < "1.3~"}

--- a/embedding/theories/EnvSubst.v
+++ b/embedding/theories/EnvSubst.v
@@ -110,7 +110,7 @@ Module NamelessSubst.
   Lemma lookup_i_of_val_env ρ n v :
     lookup_i ρ n = Some v -> lookup_i (exprs ρ) n = Some (of_val_i v).
   Proof.
-    revert dependent n.
+    generalize dependent n.
     induction ρ; intros n0 Hρ.
     + easy.
     + destruct a; simpl in *.
@@ -125,7 +125,7 @@ Module NamelessSubst.
     {v | lookup_i ρ n = Some v /\ (eRel n).[exprs ρ] = of_val_i v}.
   Proof.
     intros Hlt.
-    revert dependent n.
+    generalize dependent n.
     induction ρ; intros n1 Hlt.
     + easy.
     + destruct (Nat.eqb n1 0) eqn:Hn1.

--- a/embedding/theories/pcuic/PCUICCorrectness.v
+++ b/embedding/theories/pcuic/PCUICCorrectness.v
@@ -45,10 +45,10 @@ Theorem expr_to_term_sound (n : nat) (ρ : env val) Σ1 Σ2
   iclosed_n 0 e2 = true ->
   Σ2 |- t⟦e2⟧Σ1 ⇓ t⟦of_val_i v⟧Σ1.
 Proof.
-  revert dependent v.
-  revert dependent ρ.
-  revert dependent e2.
-  revert dependent e1.
+  generalize dependent v.
+  generalize dependent ρ.
+  generalize dependent e2.
+  generalize dependent e1.
   induction n.
   - now intros.
   - intros e1 e2 ρ v Hsync Hgeok Hρ_ok He Henv Hc; destruct e1.
@@ -378,7 +378,7 @@ Proof.
                    extended_subst xs k = rev (reln [] k xs)).
         { intros xs k Hvass. rewrite reln_alt_eq. rewrite app_nil_r.
           rewrite rev_involutive.
-          revert dependent k.
+          generalize dependent k.
           induction xs; intros k; cbn; auto.
           inversion Hvass; subst; cbn.
           replace (k+1) with (1+k) by lia.

--- a/embedding/theories/pcuic/PCUICCorrectness.v
+++ b/embedding/theories/pcuic/PCUICCorrectness.v
@@ -240,7 +240,7 @@ Proof.
           remember ((n0,_) :: (e2,_) :: ρ') as ρ''.
           eapply IHn with (ρ := ρ''); subst; eauto with hints.
           rewrite <- subst_env_compose_2;
-            (simpl; eauto using vars_to_apps_iclosed_n with hints).
+            (simpl; eauto using vars_to_apps_iclosed_n with hints; auto with bool hints).
           cbn.
           now repeat rewrite subst_env_i_ty_closed_0_eq by auto.
       * rename e0 into n0.

--- a/embedding/theories/pcuic/PCUICCorrectnessAux.v
+++ b/embedding/theories/pcuic/PCUICCorrectnessAux.v
@@ -310,7 +310,7 @@ Lemma type_eval_value Σ ρ ty ty_v n :
   ty_val ty_v.
 Proof.
   intros Hok He.
-  revert dependent ty_v. revert n.
+  generalize dependent ty_v. revert n.
   induction ty; intros.
   + simpl in *. inversion He; eauto with hints.
   + simpl in *.
@@ -545,7 +545,7 @@ Lemma subst_closed_map ts1 ts2 k :
   forallb (closedn k) ts2 ->
   map (subst ts1 k) ts2 = ts2.
 Proof.
-  intros H. revert dependent k. revert ts1.
+  intros H. generalize dependent k. revert ts1.
   induction ts2; intros; auto.
   simpl in *. propify. destruct_hyps.
   f_equal; eauto with hints.
@@ -583,7 +583,7 @@ Proof.
   intros Hgeok Hr. unfold resolve_inductive in *.
   destruct (lookup_global Σ ind) eqn:Hlg; tryfalse.
   destruct g; tryfalse. inversion Hr; subst; clear Hr.
-  revert dependent cs.
+  generalize dependent cs.
   induction Σ; intros; tryfalse.
   cbn in *. destruct a. cbn in *.
   destruct (e0 =? ind)%string; now propify.
@@ -623,7 +623,7 @@ Proof.
   intros Hlen Htys.
   apply forallb_Forall in Htys.
   apply Forall_map_inv in Htys.
-  revert dependent vs.
+  generalize dependent vs.
   induction tys; intros.
   - now destruct vs; tryfalse.
   - destruct vs; tryfalse; cbn in *.
@@ -967,7 +967,7 @@ Lemma map_subst_env_ty_closed n m ρ l0 :
   forallb (iclosed_ty n) l0 ->
   map (subst_env_i_ty (m + n) ρ) l0 = l0.
 Proof.
-  intros H. revert dependent n. revert m ρ. induction l0; intros m ρ n Hc; simpl; auto.
+  intros H. generalize dependent n. revert m ρ. induction l0; intros m ρ n Hc; simpl; auto.
   simpl in *. propify. destruct_hyps. f_equal; eauto with hints.
 Qed.
 
@@ -1212,7 +1212,7 @@ Lemma iclosed_ty_expr_env_ok :
   forall (n : nat) (ρ : env expr) e,
     iclosed_n n e -> ty_expr_env_ok ρ n e.
 Proof.
-  intros. revert dependent n. revert ρ.
+  intros. generalize dependent n. revert ρ.
   induction e using expr_elim_case; intros ?? Hc; eauto.
   + simpl in *. unfold is_true in *. propify.
     destruct_and_split; auto.
@@ -1401,7 +1401,7 @@ Lemma eval_ge_val_ok n ρ Σ e v :
   expr_eval_i Σ n ρ e = Ok v ->
   ge_val_ok Σ v.
 Proof.
-  revert dependent ρ. revert dependent v. revert dependent e.
+  generalize dependent ρ. generalize dependent v. generalize dependent e.
   induction n; intros e v ρ Hok He; tryfalse.
   destruct e; unfold expr_eval_i in *; simpl in *; inversion He; tryfalse.
   + destruct (lookup_i ρ n0) eqn:Hlook; simpl in *; inversion He; subst.
@@ -1631,7 +1631,7 @@ Lemma eval_val_ok n ρ Σ e v :
   expr_eval_i Σ n ρ e = Ok v ->
   val_ok Σ v.
 Proof.
-  revert dependent ρ. revert dependent v. revert dependent e.
+  generalize dependent ρ. generalize dependent v. generalize dependent e.
   induction n; intros e v ρ Hty_ok Hok Hc He; tryfalse.
   destruct e.
   + unfold expr_eval_i in *. simpl in *.
@@ -1841,9 +1841,9 @@ Lemma mkApps_atom_inv l1 l2 t1 t2 :
   l1 = l2 /\ t1 = t2.
 Proof.
   intros H1 H2 Hmk.
-  revert dependent t1.
-  revert dependent t2.
-  revert dependent l2.
+  generalize dependent t1.
+  generalize dependent t2.
+  generalize dependent l2.
   induction l1 using MCList.rev_ind; intros; destruct l2 using MCList.rev_ind.
   + inversion Hmk. easy.
   + simpl in *. subst. rewrite mkApps_unfold in *; tryfalse.
@@ -1867,7 +1867,7 @@ Lemma nth_error_map_exists {A B} (f : A -> B) (l : list A) n p:
   exists p0 : A, p = f p0.
 Proof.
   intros H.
-  revert dependent l.
+  generalize dependent l.
   induction n; simpl in *; intros l H; destruct l eqn:H1; inversion H; eauto.
 Qed.
 

--- a/embedding/theories/pcuic/PCUICFacts.v
+++ b/embedding/theories/pcuic/PCUICFacts.v
@@ -104,7 +104,7 @@ Section Values.
     AllEnv P ρ -> lookup_i ρ n = Some e -> P e.
   Proof.
     intros Hfe Hl.
-    revert dependent n.
+    generalize dependent n.
     induction Hfe; intros n Hl.
     + inversion Hl.
     + simpl in *. destruct x; destruct (Nat.eqb n 0); inversion Hl; subst; eauto.
@@ -480,8 +480,8 @@ Section Values.
   Lemma lookup_ind_nth_error_False (ρ : env A) n m a key :
     lookup_with_ind_rec (1+n+m) ρ key = Some (n, a) -> False.
   Proof.
-    revert dependent m.
-    revert dependent n.
+    generalize dependent m.
+    generalize dependent n.
     induction ρ as [ |a0 ρ0]; intros n m H; tryfalse.
     simpl in *.
     destruct a0; destruct (s =? key).
@@ -494,7 +494,7 @@ Section Values.
     lookup_with_ind_rec (1+n) ρ key = Some (1+i, a) <->
     lookup_with_ind_rec n ρ key = Some (i, a).
   Proof.
-    split; revert dependent i; revert dependent n;
+    split; generalize dependent i; generalize dependent n;
     induction ρ; intros i1 n1 H; tryfalse; simpl in *;
       destruct a0; destruct ( s =? key); inversion H; eauto.
   Qed.
@@ -502,7 +502,7 @@ Section Values.
   Lemma lookup_ind_nth_error (ρ : env A) i a key :
     lookup_with_ind ρ key = Some (i,a) -> nth_error ρ i = Some (key,a).
   Proof.
-    revert dependent ρ.
+    generalize dependent ρ.
     induction i; simpl; intros ρ0 H.
     + destruct ρ0; tryfalse. unfold lookup_with_ind in H. simpl in *.
       destruct p as (nm,a0); destruct (nm =? key) eqn:Heq; try rewrite String.eqb_eq in *; subst.
@@ -563,7 +563,7 @@ Section Values.
     map fst l1 = map fst l2 ->
     find (p ∘ fst) l1 = None -> find (p ∘ fst) l2 = None.
   Proof.
-    revert dependent l2.
+    generalize dependent l2.
     induction l1 as [ | ab l1']; intros l2 Hmap Hfnd.
     + destruct l2; simpl in *; easy.
     + destruct l2; simpl in *; tryfalse.
@@ -592,7 +592,7 @@ Section Values.
     exists v2, find (p ∘ fst) l2 = Some v2
                /\ fst v1 = fst v1.
   Proof.
-    revert dependent l2.
+    generalize dependent l2.
     revert v1.
     induction l1 as [ | ab l1']; intros v1 l2 Hmap Hfnd.
     + destruct l2; simpl in *; easy.

--- a/examples/bat/BATAltFixCorrect.v
+++ b/examples/bat/BATAltFixCorrect.v
@@ -617,7 +617,9 @@ Section Theories.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add_existing; eauto.
       erewrite sumN_split with (x := (ctx_from ctx, _)) (y := (ctx_from ctx, _)) by eauto.
-      now rewrite sumN_swap, fin_maps.map_to_list_delete, N.add_comm.
+      rewrite sumN_swap.
+      rewrite <- sumN_inv.
+      now rewrite fin_maps.map_to_list_delete.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add; auto.
       now rewrite N.add_comm.
@@ -635,7 +637,9 @@ Section Theories.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add_existing; eauto.
       erewrite sumN_split with (x := ((batFundDeposit prev_state), _)) (y := ((batFundDeposit prev_state), _)) by eauto.
-      now rewrite sumN_swap, fin_maps.map_to_list_delete, N.add_comm.
+      rewrite sumN_swap.
+      rewrite <- sumN_inv.
+      now rewrite fin_maps.map_to_list_delete.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add; auto.
       now rewrite N.add_comm.
@@ -652,9 +656,14 @@ Section Theories.
     result_to_option.
     setoid_rewrite FMap.elements_add_existing; eauto.
     simpl with_default.
+    rewrite N.add_comm. 
+    cbn.
+    rewrite <- N.add_sub_assoc. 2: lia.
+    rewrite (N.add_comm (t mod tokenExchangeRate prev_state) _).
+    rewrite N.add_sub, N.add_comm.
     change t with ((fun '(_, v) => v) (ctx_from ctx, t)).
-    rewrite sumN_inv, sumN_swap, fin_maps.map_to_list_delete by auto. cbn.
-    now rewrite N.add_comm, N.add_sub.
+    rewrite sumN_inv.
+    now rewrite fin_maps.map_to_list_delete.
   Qed.
 
   Lemma init_preserves_balances_sum : forall state chain ctx setup,

--- a/examples/bat/BATAltFixCorrect.v
+++ b/examples/bat/BATAltFixCorrect.v
@@ -738,7 +738,7 @@ Section Theories.
         rewrite <- N.add_sub_swap, balance_sum, N.sub_add.
         now rewrite N.add_sub.
         apply N_add_le.
-        now apply N.mod_le.
+        now apply N.Div0.mod_le.
         apply balance_le_sum_balances.
     - contract_induction; intros;
         only 1: instantiate (CallFacts := fun _ _ cstate _ _ => cstate.(tokenExchangeRate) <> 0);
@@ -767,7 +767,7 @@ Section Theories.
     - apply try_create_tokens_total_supply_correct in receive_some.
       rewrite <- receive_some. apply N.le_add_r.
     - apply try_finalize_total_supply_correct in receive_some. lia.
-    - specialize try_refund_is_some as [_ refund_implications].
+    - edestruct try_refund_is_some as [_ refund_implications].
       rewrite receive_some in refund_implications.
       now destruct refund_implications; eauto.
   Qed.
@@ -948,7 +948,7 @@ Section Theories.
       + (* Prove that there is enough balance to evaluate action *)
         now apply account_balance_nonnegative.
       + (* Prove that receive action returns Some *)
-        specialize (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
+        edestruct (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
         * unfold Blockchain.receive.
           rewrite receive_some.
           now contract_simpl.
@@ -1139,7 +1139,7 @@ Section Theories.
                 lia.
           }
 
-          specialize deployed_implies_constants_valid as
+          edestruct deployed_implies_constants_valid as
               (cstate' & contract_state' & _ & _ & echange_rate_nonzero & can_hit_fund_min); eauto.
           cbn in contract_state'.
           rewrite contract_state in contract_state'.
@@ -1290,7 +1290,7 @@ Section Theories.
       - now destruct_address_eq.
       - now destruct_address_eq.
     }
-    specialize constants_are_constant as
+    edestruct constants_are_constant as
       (dep_info & cstate' & deploy_info' & deployed_state' & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
     unfold contract_state in deployed_state'. cbn in deployed_state'.
     rewrite deployed_state, deserialize_serialize in deployed_state'.
@@ -1489,7 +1489,7 @@ Section Theories.
         now rewrite IH, no_new_acts.
       + apply try_create_tokens_only_change_token_state in receive_some as finalized_unchanged.
         apply try_create_tokens_acts_correct in receive_some as no_new_acts.
-        specialize try_create_tokens_is_some as (_ & (_ & _ & _ & funding_active & _)); eauto.
+        edestruct try_create_tokens_is_some as (_ & (_ & _ & _ & funding_active & _)); eauto.
         rewrite <- finalized_unchanged in not_finalized.
         destruct not_finalized as [not_finalized _].
         rewrite no_new_acts, IH; auto.
@@ -1497,7 +1497,7 @@ Section Theories.
         now destruct not_finalized as [not_finalized _].
       + apply try_refund_only_change_token_state in receive_some as finalized_unchanged.
         apply try_refund_total_supply_correct in receive_some as new_supply.
-        specialize try_refund_is_some as
+        edestruct try_refund_is_some as
           (_ & (_ & _ & funding_over%Nat.lt_nge & goal_not_hit & _)); eauto.
         destruct not_finalized as [_ [funding_not_over | goal_hit]].
         * now rewrite <- finalized_unchanged in funding_not_over.
@@ -1514,7 +1514,7 @@ Section Theories.
       split.
       + eapply bat_no_self_calls'; eauto.
         now constructor.
-      + specialize sum_balances_eq_total_supply as
+      + edestruct sum_balances_eq_total_supply as
           (? & ? & ?); eauto.
         now constructor.
         easy.
@@ -1626,16 +1626,16 @@ Section Theories.
     - solve_facts.
       destruct_and_split.
       + now apply Z.ge_le.
-      + specialize deployed_implies_constants_valid as
+      + edestruct deployed_implies_constants_valid as
           (cstate' & deployed_state' & _ & _ & exchange_rate_nonzero & _ & _); eauto.
         now constructor.
         easy.
-      + specialize sum_balances_eq_total_supply as
+      + edestruct sum_balances_eq_total_supply as
           (cstate' & deployed_state' & ?); eauto.
         now constructor.
         easy.
       + intros.
-        specialize funding_period_no_acts as (cstate' & deployed_state' & no_acts); eauto.
+        edestruct funding_period_no_acts as (cstate' & deployed_state' & no_acts); eauto.
         now constructor.
         now apply no_acts.
       + eapply bat_no_self_calls'; eauto.
@@ -1657,11 +1657,11 @@ Section Theories.
     intros * reach deployed can_receive_funds.
     assert (trace := reach).
     destruct trace as [trace].
-    specialize contract_balance_bound as
+    edestruct contract_balance_bound as
       (cstate & dep_info & deployed_state & deployed_info &
       contract_balance_bound_finalized & contract_balance_bound); eauto.
     apply deployment_amount_nonnegative in deployed_info as dep_amount_nonnegative.
-    specialize deployed_implies_constants_valid as
+    edestruct deployed_implies_constants_valid as
       (cstate' & deployed_state' & _ & _ & exchange_rate_nonzero & _); eauto.
     rewrite deployed_state in deployed_state'.
     inversion deployed_state'.
@@ -1694,7 +1694,7 @@ Section Theories.
           apply N2Z.is_nonneg.
     }
     intros origin.
-    destruct can_receive_funds as [receive_not_contract | (wc & cstate' & deployed' & deployed_state' & new_state & receive_some )].
+    edestruct can_receive_funds as [receive_not_contract | (wc & cstate' & deployed' & deployed_state' & new_state & receive_some )].
     - eexists.
       constructor.
       eapply eval_transfer; auto.

--- a/examples/bat/BATCommon.v
+++ b/examples/bat/BATCommon.v
@@ -208,7 +208,7 @@ Section BATCommon.
     eapply N.add_le_mono_r.
     rewrite N.mul_comm, <- N.div_mod'.
     apply N_le_sub.
-    - now apply N.mod_le.
+    - now apply N.Div0.mod_le.
     - now apply N.sub_le_mono_l,
                 N.lt_le_incl,
                 N.mod_lt.

--- a/examples/bat/BATCorrect.v
+++ b/examples/bat/BATCorrect.v
@@ -600,7 +600,9 @@ Section Theories.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add_existing; eauto.
       erewrite sumN_split with (x := (ctx_from ctx, _)) (y := (ctx_from ctx, _)) by eauto.
-      now rewrite sumN_swap, fin_maps.map_to_list_delete, N.add_comm.
+      rewrite sumN_swap.
+      rewrite <- sumN_inv.
+      now rewrite fin_maps.map_to_list_delete.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add; auto.
       now rewrite N.add_comm.
@@ -624,8 +626,11 @@ Section Theories.
     result_to_option.
     setoid_rewrite FMap.elements_add_existing; eauto.
     simpl with_default.
+    cbn.
+    rewrite N.add_0_l.
     change t with ((fun '(_, v) => v) (ctx_from ctx, t)).
-    now rewrite sumN_inv, sumN_swap, fin_maps.map_to_list_delete.
+    rewrite sumN_inv.
+    now rewrite fin_maps.map_to_list_delete.
   Qed.
 
   Lemma init_preserves_balances_sum : forall state chain ctx setup,

--- a/examples/bat/BATCorrect.v
+++ b/examples/bat/BATCorrect.v
@@ -701,7 +701,7 @@ Section Theories.
     - apply try_create_tokens_total_supply_correct in receive_some.
       rewrite <- receive_some. apply N.le_add_r.
     - apply try_finalize_preserves_total_supply in receive_some. lia.
-    - specialize try_refund_is_some as [_ refund_implications].
+    - edestruct try_refund_is_some as [_ refund_implications].
       rewrite receive_some in refund_implications.
       now destruct refund_implications.
   Qed.
@@ -881,8 +881,8 @@ Section Theories.
       + (* Prove that there is enough balance to evaluate action *)
         now apply account_balance_nonnegative.
       + (* Prove that receive action returns Some *)
-        specialize (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
-        * specialize try_finalize_isFinalized_correct as [_ finalized_new_cstate]; eauto.
+        edestruct (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
+        * edestruct try_finalize_isFinalized_correct as [_ finalized_new_cstate]; eauto.
           now erewrite <- (try_finalize_only_change_isFinalized _ _ _ _ _ receive_some),
                       finalized_new_cstate, (try_finalize_acts_correct _ _ _ _ _ receive_some) in receive_some.
         * repeat split; eauto.
@@ -1202,7 +1202,7 @@ Section Theories.
     update_all.
 
     deploy_contract BAT.contract; eauto; try lia; try now apply account_balance_nonnegative.
-    specialize constants_are_constant as (dep_info & cstate' & deploy_info' & deployed_state' & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
+    edestruct constants_are_constant as (dep_info & cstate' & deploy_info' & deployed_state' & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
     unfold contract_state in deployed_state'. cbn in deployed_state'.
     rewrite deployed_state, deserialize_serialize in deployed_state'.
     inversion deployed_state'. subst cstate'. clear deployed_state'.
@@ -1272,7 +1272,7 @@ Section Theories.
       eapply eval_call with (msg := Some _); eauto.
       + lia.
       + now apply Z.ge_le, account_balance_nonnegative.
-      + specialize try_refund_is_some as [[new_cstate [resp_acts receive_some]] _]; cycle 1.
+      + edestruct try_refund_is_some as [[new_cstate [resp_acts receive_some]] _]; cycle 1.
         * apply wc_receive_to_receive.
           unfold Blockchain.receive.
           rewrite receive_some.

--- a/examples/bat/BATFixedCorrect.v
+++ b/examples/bat/BATFixedCorrect.v
@@ -745,7 +745,7 @@ Section Theories.
     - apply try_create_tokens_total_supply_correct in receive_some.
       rewrite <- receive_some. apply N.le_add_r.
     - apply try_finalize_preserves_total_supply in receive_some. lia.
-    - specialize try_refund_is_some as [_ refund_implications].
+    - edestruct try_refund_is_some as [_ refund_implications].
       rewrite receive_some in refund_implications.
       now destruct refund_implications.
   Qed.
@@ -925,8 +925,8 @@ Section Theories.
       + (* Prove that there is enough balance to evaluate action *)
         now apply account_balance_nonnegative.
       + (* Prove that receive action returns Some *)
-        specialize (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
-        * specialize try_finalize_isFinalized_correct as [_ finalized_new_cstate]; eauto.
+        edestruct (try_finalize_is_some cstate bstate0) as ((new_cstate & new_act & receive_some) & _); cycle 1.
+        * edestruct try_finalize_isFinalized_correct as [_ finalized_new_cstate]; eauto.
           now erewrite <- (try_finalize_only_change_isFinalized _ _ _ _ _ receive_some),
                       finalized_new_cstate, (try_finalize_acts_correct _ _ _ _ _ receive_some) in receive_some.
         * easy.
@@ -1119,7 +1119,7 @@ Section Theories.
                 lia.
           }
 
-          specialize deployed_implies_constants_valid as
+          edestruct deployed_implies_constants_valid as
               (cstate' & contract_state' & _ & _ & _ & echange_rate_nonzero & can_hit_fund_min); eauto.
           cbn in contract_state'.
           rewrite contract_state in contract_state'.
@@ -1279,7 +1279,7 @@ Section Theories.
       - now destruct_address_eq.
       - now destruct_address_eq.
     }
-    specialize constants_are_constant as
+    edestruct constants_are_constant as
       (dep_info & cstate' & deploy_info' & deployed_state' & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
     unfold contract_state in deployed_state'. cbn in deployed_state'.
     rewrite deployed_state, deserialize_serialize in deployed_state'.
@@ -1479,13 +1479,13 @@ Section Theories.
         apply try_create_tokens_only_change_token_state in receive_some as finalized_unchanged.
         rewrite <- finalized_unchanged in *. cbn.
         now rewrite <- balance_preserved.
-        specialize try_create_tokens_is_some as (_ & (_ & _ & _ & _ & _ & from_not_batfund)); eauto.
+        edestruct try_create_tokens_is_some as (_ & (_ & _ & _ & _ & _ & from_not_batfund)); eauto.
       + now apply try_finalize_isFinalized_correct in receive_some.
       + eapply try_refund_preserves_other_balances in receive_some as balance_preserved.
         apply try_refund_only_change_token_state in receive_some as finalized_unchanged.
         rewrite <- finalized_unchanged in *. cbn.
         now rewrite <- balance_preserved.
-        specialize try_refund_is_some as (_ & (_ & _ & _ & _ & from_not_batfund & _)); eauto.
+        edestruct try_refund_is_some as (_ & (_ & _ & _ & _ & from_not_batfund & _)); eauto.
       + now contract_simpl.
   Qed.
 
@@ -1523,7 +1523,7 @@ Section Theories.
         rewrite N.add_comm.
         now apply N_add_le.
       + now contract_simpl.
-      + specialize try_refund_is_some as (_ & (_ & not_finalized & _ & _ & from_not_batfund & _)); eauto.
+      + edestruct try_refund_is_some as (_ & (_ & not_finalized & _ & _ & from_not_batfund & _)); eauto.
         apply receive_preserves_constants in receive_some as constants_unchanged.
         destruct constants_unchanged as (_ & _ & _ & _ & _ & _ & _ & init_supply_unchanged).
         erewrite <- try_refund_total_supply_correct, <- init_supply_unchanged; eauto.
@@ -1576,7 +1576,7 @@ Section Theories.
         now rewrite IH, no_new_acts.
       + apply try_create_tokens_only_change_token_state in receive_some as finalized_unchanged.
         apply try_create_tokens_acts_correct in receive_some as no_new_acts.
-        specialize try_create_tokens_is_some as (_ & (_ & _ & _ & funding_active & _)); eauto.
+        edestruct try_create_tokens_is_some as (_ & (_ & _ & _ & funding_active & _)); eauto.
         rewrite <- finalized_unchanged in not_finalized.
         destruct not_finalized as [not_finalized _].
         rewrite no_new_acts, IH; auto.
@@ -1584,7 +1584,7 @@ Section Theories.
         now destruct not_finalized as [not_finalized _].
       + apply try_refund_only_change_token_state in receive_some as finalized_unchanged.
         apply try_refund_total_supply_correct in receive_some as new_supply.
-        specialize try_refund_is_some as
+        edestruct try_refund_is_some as
           (_ & (_ & _ & funding_over%Nat.lt_nge & goal_not_hit & _)); eauto.
         destruct not_finalized as [_ [funding_not_over | goal_hit]].
         * now rewrite <- finalized_unchanged in funding_not_over.
@@ -1638,7 +1638,7 @@ Section Theories.
           setoid_rewrite EIP20TokenCorrect.add_is_partial_alter_plus; auto.
           subst. clear addr_from.
           setoid_rewrite FMap.find_add. cbn.
-          now rewrite N.add_mod, IH, N.add_mod_idemp_r, N.mod_add by assumption.
+          now rewrite N.Div0.add_mod, IH, N.Div0.add_mod_idemp_r, N.Div0.mod_add by assumption.
         * erewrite <- try_create_tokens_preserves_other_balances; eauto.
       + now apply try_finalize_isFinalized_correct in receive_some.
       + eapply try_refund_only_change_token_state in receive_some as finalized_unchanged.
@@ -1651,7 +1651,7 @@ Section Theories.
     - now destruct facts.
     - solve_facts.
       split.
-      * specialize deployed_implies_constants_valid as
+      * edestruct deployed_implies_constants_valid as
           (cstate' & deployed_state' & _ & _ & _ & exchange_rate_nonzero & _); eauto.
         now constructor.
         easy.
@@ -1765,7 +1765,7 @@ Section Theories.
           rewrite <- from_balance in *.
           apply tokens_bound in from_ne_batfund as tokens_bound'; auto.
           apply tokens_modulo_exchange_rate in from_ne_batfund as tokens_modulo_exchange_rate'; auto.
-          rewrite <- N.div_exact, N.mul_comm, from_balance in tokens_modulo_exchange_rate' by auto.
+          rewrite <- N.Div0.div_exact, N.mul_comm, from_balance in tokens_modulo_exchange_rate' by auto.
           setoid_rewrite <- tokens_modulo_exchange_rate'.
           rewrite from_balance in *.
           cbn in *.
@@ -1781,18 +1781,18 @@ Section Theories.
       + now apply deployed_implies_constants_valid in deployed0 as
         (cstate' & deployed_state' & _ & _ & _ & exchange_rate_nonzero & _).
       + intros not_finalized from_not_batfund.
-        specialize token_balances_divisible as (cstate' & deployed_cstate' & ?); eauto.
+        edestruct token_balances_divisible as (cstate' & deployed_cstate' & ?); eauto.
         now constructor.
         rewrite deployed_state0 in deployed_cstate'.
         inversion deployed_cstate'.
         now subst cstate'.
       + intros not_finalized from_not_batfund.
-        specialize no_init_supply_refund as (cstate' & deployed_cstate' & batfund_balance); eauto.
+        edestruct no_init_supply_refund as (cstate' & deployed_cstate' & batfund_balance); eauto.
         now constructor.
         rewrite deployed_state0 in deployed_cstate'.
         inversion deployed_cstate'.
         subst cstate'. clear deployed_cstate'.
-        specialize sum_balances_eq_total_supply as (cstate' & deployed_cstate' & sum_eq_total); eauto.
+        edestruct sum_balances_eq_total_supply as (cstate' & deployed_cstate' & sum_eq_total); eauto.
         now constructor.
         rewrite deployed_state0 in deployed_cstate'.
         inversion deployed_cstate'.
@@ -1802,7 +1802,7 @@ Section Theories.
         rewrite sum_eq_total.
         now apply balance_le_sum_balances_ne.
       + intros.
-        specialize funding_period_no_acts as (cstate' & deployed_state' & no_acts); eauto.
+        edestruct funding_period_no_acts as (cstate' & deployed_state' & no_acts); eauto.
         now constructor.
         now apply no_acts.
       + eapply bat_no_self_calls'; eauto.
@@ -1823,11 +1823,11 @@ Section Theories.
     intros * reach deployed can_receive_funds.
     assert (trace := reach).
     destruct trace as [trace].
-    specialize contract_balance_bound as
+    edestruct contract_balance_bound as
       (cstate & dep_info & deployed_state & deployed_info &
       contract_balance_bound_finalized & contract_balance_bound); eauto.
     apply deployment_amount_nonnegative in deployed_info as dep_amount_nonnegative.
-    specialize deployed_implies_constants_valid as
+    edestruct deployed_implies_constants_valid as
       (cstate' & deployed_state' & _ & _ & _ & exchange_rate_nonzero & _); eauto.
     rewrite deployed_state in deployed_state'.
     inversion deployed_state'.
@@ -1860,7 +1860,7 @@ Section Theories.
           apply N2Z.is_nonneg.
     }
     intros origin.
-    destruct can_receive_funds as [receive_not_contract | (wc & cstate' & deployed' & deployed_state' & new_state & receive_some )].
+    edestruct can_receive_funds as [receive_not_contract | (wc & cstate' & deployed' & deployed_state' & new_state & receive_some )].
     - eexists.
       constructor.
       eapply eval_transfer; auto.

--- a/examples/bat/BATFixedCorrect.v
+++ b/examples/bat/BATFixedCorrect.v
@@ -619,7 +619,9 @@ Section Theories.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add_existing; eauto.
       erewrite sumN_split with (x := (ctx_from ctx, _)) (y := (ctx_from ctx, _)) by eauto.
-      now rewrite sumN_swap, fin_maps.map_to_list_delete, N.add_comm.
+      rewrite sumN_swap.
+      rewrite <- sumN_inv.
+      now rewrite fin_maps.map_to_list_delete.
     - setoid_rewrite from_balance.
       setoid_rewrite FMap.elements_add; auto.
       now rewrite N.add_comm.
@@ -643,8 +645,11 @@ Section Theories.
     result_to_option.
     setoid_rewrite FMap.elements_add_existing; eauto.
     simpl with_default.
+    cbn.
+    rewrite N.add_0_l.
     change t with ((fun '(_, v) => v) (ctx_from ctx, t)).
-    now rewrite sumN_inv, sumN_swap, fin_maps.map_to_list_delete.
+    rewrite sumN_inv.
+    now rewrite fin_maps.map_to_list_delete.
   Qed.
 
   Lemma init_preserves_balances_sum : forall state chain ctx setup,

--- a/examples/boardroomVoting/BoardroomVoting.v
+++ b/examples/boardroomVoting/BoardroomVoting.v
@@ -776,7 +776,7 @@ Module BoardroomVoting (Params : BoardroomParams).
             now setoid_rewrite perm'.
           * now rewrite FMap.length_elements, <- len_pks.
           * now rewrite FMap.length_elements, <- len_pks.
-          * auto.
+          * now rewrite FMap.length_elements, <- len_pks.
           * intros [k v] kvpin.
             apply FMap.In_elements in kvpin.
             specialize (addrs _ _ kvpin).

--- a/examples/cis1/CIS1Spec.v
+++ b/examples/cis1/CIS1Spec.v
@@ -611,7 +611,7 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
   Proof.
     intros Hin.
     destruct Hin as [Hin | Hbal].
-    revert dependent owner.
+    generalize dependent owner.
     -induction owners; intros owner Hin Hnodup.
      + inversion Hin.
      + inversion Hin; subst; clear Hin.
@@ -655,7 +655,7 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
     sum_balances st token_id owners1 = sum_balances st token_id owners2.
   Proof.
     intros Hnodup1 Hnodup2 Hiff.
-    revert dependent owners2.
+    generalize dependent owners2.
     induction owners1; intros.
     + cbn in *. destruct owners2; auto.
       destruct (Hiff a); cbn in *.
@@ -783,8 +783,8 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
       forall token_id,
         token_id_exists prev_st token_id = token_id_exists next_st token_id.
   Proof.
-    revert dependent prev_st.
-    revert dependent ops.
+    generalize dependent prev_st.
+    generalize dependent ops.
     cbn.
     induction transfers.
     - intros ops prev_st spec token_id.
@@ -810,9 +810,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
       ~ In (token_id, addr) (transfer_to params) ->
     get_balance_opt prev_st token_id addr = get_balance_opt next_st token_id addr.
   Proof.
-    revert dependent next_st.
-    revert dependent prev_st.
-    revert dependent ops.
+    generalize dependent next_st.
+    generalize dependent prev_st.
+    generalize dependent ops.
     induction transfers.
     - cbn; intros ops prev_st next_st spec addr token_id.
       destruct spec. cbn in *; now subst.
@@ -925,9 +925,9 @@ Module CIS1Balances (cis1_types : CIS1Types) (cis1_view : CIS1View cis1_types).
     sum_balances prev_st token_id owners1 = sum_balances next_st token_id owners2.
   Proof.
     destruct spec as [Htr Hcalls].
-    revert dependent prev_st.
-    revert dependent next_st.
-    revert dependent ops.
+    generalize dependent prev_st.
+    generalize dependent next_st.
+    generalize dependent ops.
     induction transfers; intros ops ? next_st prev_st Htr ? ?.
     - cbn in *. now subst.
     - cbn in *.

--- a/examples/cis1/CIS1Utils.v
+++ b/examples/cis1/CIS1Utils.v
@@ -61,7 +61,7 @@ Module RemoveProperties.
   Lemma remove_all_In {A} (eq_dec : forall x y : A, {x = y} + {x <> y}) (to_remove : list A) (xs : list A) :
     Forall (fun x => ~ In x (remove_all eq_dec to_remove xs)) to_remove.
   Proof.
-    revert dependent xs.
+    generalize dependent xs.
     induction to_remove; simpl; auto.
     constructor; eauto with hints.
     unshelve eapply (@Forall_impl _ _ _ _ _ (IHto_remove xs)).

--- a/examples/cis1/Cis1wccd.v
+++ b/examples/cis1/Cis1wccd.v
@@ -503,8 +503,8 @@ Module WccdReceiveSpec <: CIS1ReceiveSpec WccdTypes WccdView.
       destruct (Bool.bool_dec (address_is_contract send_results_to)) eqn:Haddr;
         inversion Hparams; subst; clear Hparams.
       cbn.
-      revert dependent next_st.
-      revert dependent send_results_to.
+      generalize dependent next_st.
+      generalize dependent send_results_to.
       induction query.
       - now intros ? ? ? Hparams; cbn in *.
       - intros. cbn.
@@ -536,8 +536,8 @@ Module WccdReceiveSpec <: CIS1ReceiveSpec WccdTypes WccdView.
         inversion Hreceive; subst; clear Hreceive.
         constructor.
         * cbn.
-          revert dependent next_st.
-          revert dependent prev_st.
+          generalize dependent next_st.
+          generalize dependent prev_st.
           induction params.
           ** cbn in *. congruence.
           ** intros prev_st next_st Hreceive.
@@ -550,8 +550,8 @@ Module WccdReceiveSpec <: CIS1ReceiveSpec WccdTypes WccdView.
              *** cbn in *. now apply wccd_transfer_single_cis1.
              *** now eapply IHparams.
         * cbn.
-          revert dependent prev_st.
-          revert dependent next_st.
+          generalize dependent prev_st.
+          generalize dependent next_st.
           induction params.
           ** intros; cbn; auto.
           ** intros; cbn -[wccd_transfer_single] in *.
@@ -592,8 +592,8 @@ Module WccdReceiveSpec <: CIS1ReceiveSpec WccdTypes WccdView.
              now rewrite fin_maps.lookup_insert_ne.
         * destruct (AddressMap.find _ _) eqn:Haddr; inversion Hreceive; subst; clear Hreceive.
           destruct a as [bal ops]; cbn in *.
-          revert dependent ops.
-          revert dependent prev_st.
+          generalize dependent ops.
+          generalize dependent prev_st.
           induction params; intros prev_st ops Haddr.
           ** cbn.
              unfold AddressMap.add,AddressMap.find in *.

--- a/examples/congress/Congress_Buggy.v
+++ b/examples/congress/Congress_Buggy.v
@@ -312,6 +312,9 @@ Section Theories.
   Instance Base : ChainBase := LocalChainBase AddrSize.
   Instance Builder : ChainBuilderType := LocalChainBuilderImpl AddrSize true.
 
+  Definition get_new_contract_addr (n : N) : option Address :=
+      BoundedN.of_N (@ContractAddrBase AddrSize + n)%N.
+
   Open Scope nat.
   Definition exploit_example : option (Address * Builder) :=
     let chain := builder_initial in
@@ -335,9 +338,9 @@ Section Theories.
     let dep_congress := create_deployment 50 contract {| setup_rules := rules |} in
     let dep_exploit := create_deployment 0 exploit_contract tt in
     do chain <- add_block chain [dep_congress; dep_exploit];
-    let contracts := map fst (FMap.elements (lc_contracts (lcb_lc chain))) in
-    let exploit := nth 0 contracts creator in
-    let congress := nth 1 contracts creator in
+      (* Some (creator, chain). *)
+    do exploit <- get_new_contract_addr 1;
+    do congress <- get_new_contract_addr 0;
     (* Add creator to congress, create a proposal to transfer *)
     (* some money to exploit contract, vote for the proposal, and execute the proposal *)
     let add_creator := add_member creator in
@@ -350,7 +353,7 @@ Section Theories.
     do chain <- add_block chain act_bodies;
     Some (congress, chain).
 
-  Definition unpacked_exploit_example : Address * Builder :=
+   Definition unpacked_exploit_example : Address * Builder :=
     unpack_option exploit_example.
 
   Definition num_acts_created_in_proposals (calls : list (ContractCallInfo Msg)) :=

--- a/examples/congress/LocalBlockchainTests.v
+++ b/examples/congress/LocalBlockchainTests.v
@@ -3,6 +3,7 @@ implementation, showing that everything computes from within Coq. It
 also contains specializations of the results proven in Congress.v to
 our particular implementations of blockchains. *)
 
+From ConCert.Utils Require Import Automation.
 From ConCert.Execution Require Import Monad.
 From ConCert.Execution Require Import Blockchain.
 From ConCert.Execution Require Import Containers.
@@ -137,8 +138,8 @@ Section LocalBlockchainTests.
                  build_act person_1 person_1 (add_person person_2)] in
     unpack_result (add_block chain4 acts).
 
-  Goal (FMap.elements (congress_state chain5).(members)) = [(person_1, tt); (person_2, tt)].
-  Proof. vm_compute. reflexivity. Qed.
+  Goal Permutation.Permutation (FMap.elements (congress_state chain5).(members)) [(person_1, tt); (person_2, tt)].
+  Proof. vm_compute. perm_simplify. Qed.
   Goal (env_account_balances chain5 congress_1) = 5%Z.
   Proof. vm_compute. reflexivity. Qed.
 

--- a/examples/congress/tests/Congress_BuggyTests.v
+++ b/examples/congress/tests/Congress_BuggyTests.v
@@ -41,9 +41,8 @@ Definition exploit_example : option (Address * ChainBuilder) :=
   let dep_congress := create_deployment 50 contract {| setup_rules := rules |} in
   let dep_exploit := create_deployment 0 exploit_contract tt in
   do chain <- add_block chain [dep_congress; dep_exploit];
-  let contracts := map fst (FMap.elements (get_contracts chain)) in
-  let exploit := nth 0 contracts creator in
-  let congress := nth 1 contracts creator in
+  let exploit := addr_of_N 129%N in
+  let congress := addr_of_N 128%N in
   (* Add creator to congress *)
   let add_creator := add_member creator in
   let act_bodies :=

--- a/examples/counter/extraction/CounterSubsetTypesLIGO.v
+++ b/examples/counter/extraction/CounterSubsetTypesLIGO.v
@@ -48,7 +48,7 @@ Module CounterRefinementTypes.
     st + inc.
   Next Obligation.
     destruct inc;
-    propify; lia.
+    propify; cbn; lia.
   Qed.
 
   Program Definition dec_counter (st : storage) (dec : {z : Z | 0 <? z}) :
@@ -56,7 +56,7 @@ Module CounterRefinementTypes.
     st - dec.
   Next Obligation.
     destruct dec;
-    propify; lia.
+    propify; cbn; lia.
   Qed.
 
   Definition counter (msg : msg)

--- a/examples/counter/extraction/CounterSubsetTypesLiquidity.v
+++ b/examples/counter/extraction/CounterSubsetTypesLiquidity.v
@@ -47,14 +47,16 @@ Module CounterRefinementTypes.
     {new_st : storage | st <? new_st} :=
     st + inc.
   Next Obligation.
-    now unfold is_true in *.
+    destruct inc;
+    propify; cbn; lia.
   Qed.
 
   Program Definition dec_counter (st : storage) (dec : {z : Z | 0 <? z}) :
     {new_st : storage | new_st <? st} :=
     st - dec.
   Next Obligation.
-    now unfold is_true in *.
+    destruct dec;
+    propify; cbn; lia.
   Qed.
 
   Definition counter (msg : msg)

--- a/examples/crowdfunding/CrowdfundingCorrect.v
+++ b/examples/crowdfunding/CrowdfundingCorrect.v
@@ -209,7 +209,7 @@ Module CrowdfundingProperties.
       sum_map (add_map k (n0+v') m) = (v' + v)%Z.
   Proof.
     intros; subst.
-    revert dependent n0. revert v' k.
+    generalize dependent n0. revert v' k.
     induction m; intros; subst.
     + inversion H.
     + simpl in *. destruct (k =? n) eqn:Hkn.
@@ -223,7 +223,7 @@ Module CrowdfundingProperties.
       sum_map (add_map k v' m) = (v' + v)%Z.
   Proof.
     intros; subst.
-    revert dependent k. revert v'.
+    generalize dependent k. revert v'.
     induction m; intros; subst.
     + reflexivity.
     + simpl in *. destruct (k =? n) eqn:Hkn.
@@ -237,7 +237,7 @@ Module CrowdfundingProperties.
     sum_map (add_map k 0 m) = (v - z)%Z.
   Proof.
     intros; subst.
-    revert dependent k. revert z.
+    generalize dependent k. revert z.
     induction m; intros; subst; tryfalse.
     simpl in *. destruct (k =? n) eqn:Hkn.
     + inversion H; subst.
@@ -361,7 +361,7 @@ Module CrowdfundingProperties.
       map_forallb (Z.leb 0%Z) (add_map k (n0+v') m).
   Proof.
     intros; subst.
-    revert dependent n0. revert k.
+    generalize dependent n0. revert k.
     induction m; intros k n0 Hlook; subst.
     + inversion Hlook.
     + simpl in *. destruct (k =? n) eqn:Hkn.

--- a/examples/dexter2/Dexter2CPMMCorrect.v
+++ b/examples/dexter2/Dexter2CPMMCorrect.v
@@ -958,17 +958,17 @@ Section Theories.
   Ltac rewrite_receive_is_some :=
     match goal with
     | [ H : receive_cpmm _ _ _ _ = Ok _ |- _ ] =>
-      first [specialize set_baker_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize set_manager_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize set_lqt_address_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize default_entrypoint_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize update_token_pool_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize update_token_pool_internal_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize add_liquidity_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize remove_liquidity_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize xtz_to_token_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize token_to_xtz_is_some as (_ & []); [now (do 2 eexists; apply H) |]
-            |specialize token_to_token_is_some as (_ & []); [now (do 2 eexists; apply H) |] ];
+      first [edestruct set_baker_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct set_manager_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct set_lqt_address_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct default_entrypoint_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct update_token_pool_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct update_token_pool_internal_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct add_liquidity_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct remove_liquidity_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct xtz_to_token_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct token_to_xtz_is_some as (_ & []); [now (do 2 eexists; apply H) |]
+            |edestruct token_to_token_is_some as (_ & []); [now (do 2 eexists; apply H) |] ];
       destruct_hyps; subst
     end.
   (* end hide *)
@@ -1254,7 +1254,7 @@ Section Theories.
       + split.
         * now apply Z.ge_le.
         * specialize (account_balance_nonnegative bstate_from to_addr) as ?H.
-          specialize xtz_pool_bound as (? & deployed_state' & ?); eauto.
+          edestruct xtz_pool_bound as (? & deployed_state' & ?); eauto.
           cbn in *.
           rewrite deployed_state in deployed_state'.
           rewrite deployed_state in deployed_state0.
@@ -1538,7 +1538,7 @@ Section Theories.
       inversion deployed0.
       subst.
       clear deployed0.
-      specialize outgoing_acts_no_mint_before_set_lqt_addr as (state & state_deployed & ?); eauto.
+      edestruct outgoing_acts_no_mint_before_set_lqt_addr as (state & state_deployed & ?); eauto.
       rewrite deployed_state0 in state_deployed.
       now inversion state_deployed.
   Qed.

--- a/examples/dexter2/Dexter2FA12Correct.v
+++ b/examples/dexter2/Dexter2FA12Correct.v
@@ -282,7 +282,7 @@ Section Theories.
     - now contract_simpl.
     - contract_simpl.
       rewrite !FMap.find_update_eq.
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** [try_transfer] removes empty entries from balance map *)
@@ -297,12 +297,12 @@ Section Theories.
     rewrite N.ltb_ge in *.
     destruct (address_eqb_spec param.(from) param.(to)) as [<-|]; auto.
     - rewrite !FMap.find_update_eq.
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
     - rewrite !FMap.find_update_ne by auto.
       rewrite !FMap.find_update_eq.
       rewrite !FMap.find_update_ne with (map := prev_state.(tokens)) by auto.
-      specialize (maybe_cases ) as [[-> ?H] | [-> ?H]];
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      edestruct maybe_cases as [[-> ?H] | [-> ?H]];
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** If the requirements are met then receive on transfer msg must succeed and
@@ -420,7 +420,7 @@ Section Theories.
     contract_simpl.
     cbn.
     rewrite FMap.find_update_eq.
-    now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+    now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** If the requirements are met then receive on approve msg must succeed and
@@ -520,7 +520,7 @@ Section Theories.
     rewrite Z.ltb_ge in *.
     cbn.
     rewrite FMap.find_update_eq.
-    now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+    now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** If the requirements are met then receive on mint_or_burn msg must succeed and
@@ -883,7 +883,7 @@ Section Theories.
       /\ env_account_balances bstate caddr = deploy_info.(deployment_amount).
   Proof.
     intros * deployed.
-    specialize contract_balance_bound' as (dep_info & deployment_info_eq & balance_bound); eauto.
+    edestruct contract_balance_bound' as (dep_info & deployment_info_eq & balance_bound); eauto.
     eexists.
     rewrite deployment_info_eq.
     split; eauto.
@@ -999,9 +999,9 @@ Section Theories.
             -- now rewrite fin_maps.delete_notin.
             -- FMap_simpl_step.
           * unfold FMap.update.
-            specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ?H] | [-> _]].
             -- apply N.eq_add_0 in H3 as []; subst. 
-               specialize maybe_cases as [[-> ?H] | [-> _]].
+               edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   change 0 with ((fun '(_, v) => v) (to, 0)).
@@ -1017,7 +1017,7 @@ Section Theories.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
                   rewrite fin_maps.map_to_list_delete; auto.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -1038,8 +1038,8 @@ Section Theories.
                   rewrite fin_maps.map_to_list_delete; auto.
           * rewrite N.add_0_l.
             unfold FMap.update.
-            specialize maybe_cases as [[-> ->] | [-> _]].
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ->] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   rewrite fin_maps.delete_notin.
@@ -1051,7 +1051,7 @@ Section Theories.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
                   rewrite fin_maps.map_to_list_delete; auto.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -1067,9 +1067,9 @@ Section Theories.
                   rewrite <- (sumN_split _ _ _ (from, n)) by lia.
                   rewrite fin_maps.map_to_list_delete; auto.
           * unfold FMap.update.
-            specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ?H] | [-> _]].
             -- apply N.eq_add_0 in H3 as []; subst. 
-               specialize maybe_cases as [[-> ?H] | [-> _]].
+               edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   change 0 with ((fun '(_, v) => v) (to, 0)).
@@ -1082,7 +1082,7 @@ Section Theories.
                   rewrite sumN_inv, fin_maps.map_to_list_delete.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -1102,12 +1102,12 @@ Section Theories.
                   auto.
           * rewrite N.add_0_l.
             unfold FMap.update.
-            specialize maybe_cases as [[-> ->] | [-> _]].
+            edestruct maybe_cases as [[-> ->] | [-> _]].
             -- rewrite N.sub_0_r. cbn.
                rewrite fin_maps.delete_notin.
                2: FMap_simpl_step.
                rewrite fin_maps.delete_notin; auto. 
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step. cbn.
@@ -1133,7 +1133,7 @@ Section Theories.
           specialize (balance_le_sum_balances param.(target) cstate) as n_le_supply.
           rewrite target_balance in n_le_supply.
           cbn in n_le_supply.
-          specialize maybe_cases as [[-> quantity_eq] | [-> _]]; cbn.
+          edestruct maybe_cases as [[-> quantity_eq] | [-> _]]; cbn.
         -- cbn in *.
             rewrite <- N2Z.id in quantity_eq.
             apply Z2N.inj in quantity_eq; auto.
@@ -1154,7 +1154,7 @@ Section Theories.
             apply N.add_sub_eq_r.
             change n with ((fun '(_, v) => v) (target param, n)).
             now rewrite sumN_inv, fin_maps.map_to_list_delete by assumption.
-        * specialize maybe_cases as [[-> quantity_eq] | [-> _]]; cbn;
+        * edestruct maybe_cases as [[-> quantity_eq] | [-> _]]; cbn;
           unfold sum_balances in IH.
         -- rewrite fin_maps.delete_notin by auto.
             cbn in *.
@@ -1327,7 +1327,7 @@ Section Theories.
       + cbn.
         apply try_mint_or_burn_total_supply_correct in receive_some as state_eq.
         * rewrite <- state_eq, IH.
-          specialize (try_mint_or_burn_is_some) as (_ & (_ & <- & _)); eauto.
+          edestruct (try_mint_or_burn_is_some) as (_ & (_ & <- & _)); eauto.
           rewrite address_eq_refl.
           cbn. lia.
         * rewrite balances_eq_total_supply.
@@ -1342,7 +1342,7 @@ Section Theories.
     - now destruct facts.
     - solve_facts.
       split.
-      + specialize sum_balances_eq_total_supply as (? & ? & ?); eauto.
+      + edestruct sum_balances_eq_total_supply as (? & ? & ?); eauto.
         now constructor.
         easy.
       + rewrite deployed in *.

--- a/examples/dexter2/Dexter2FA12Correct.v
+++ b/examples/dexter2/Dexter2FA12Correct.v
@@ -919,6 +919,29 @@ Section Theories.
     - apply N.le_0_l.
   Qed.
 
+  Ltac FMap_simpl_step :=
+    match goal with
+      | |- context [ FMap.find ?x (FMap.add ?x _ _) ] => setoid_rewrite FMap.find_add
+      | H : FMap.find ?t ?m = Some _ |- FMap.find ?t ?m = Some _ => cbn; rewrite H; f_equal; lia
+      | H : ?x <> ?y |- context [ FMap.find ?x (FMap.add ?y _ _) ] => setoid_rewrite FMap.find_add_ne; eauto
+      | H : ?y <> ?x |- context [ FMap.find ?x (FMap.add ?y _ _) ] => setoid_rewrite FMap.find_add_ne; eauto
+      | H : FMap.find ?x _ = Some _ |- context [ FMap.elements (FMap.add ?x _ _) ] => setoid_rewrite FMap.elements_add_existing; eauto
+      | |- context [ FMap.add ?x _ (FMap.add ?x _ _) ] => setoid_rewrite FMap.add_add
+      | H : FMap.find ?x _ = None |- context [ FMap.elements (FMap.add ?x _ _) ] => setoid_rewrite FMap.elements_add; eauto
+      | |- context [ FMap.remove ?x (FMap.add ?x _ _) ] => rewrite fin_maps.delete_insert_delete
+      | |- context [ FMap.find ?x (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter
+      | H : ?x' <> ?x |- context [ FMap.find ?x' (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter_ne; auto
+      | H : ?x <> ?x' |- context [ FMap.find ?x' (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter_ne
+      | H : context [ AddressMap.find _ _ ] |- _ => rewrite AddressMap_find_convertible in H
+      | H : context [ AddressMap.add _ _ _ ] |- _ => rewrite AddressMap_add_convertible in H
+      | |- context [ AddressMap.find _ _ ] => rewrite AddressMap_find_convertible
+      | |- context [ AddressMap.add _ _ _ ] => rewrite AddressMap_add_convertible
+      | H : ?x <> ?y |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
+      | H : ?y <> ?x |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
+    end.
+
+  Tactic Notation "FMap_simpl" := repeat (FMap_simpl_step; cbn).
+
   (** [total_supply] is always equal to the sum of all account token balances *)
   Lemma sum_balances_eq_total_supply : forall bstate caddr,
     reachable bstate ->
@@ -948,45 +971,155 @@ Section Theories.
           [rewrite FMap.find_update_eq | rewrite FMap.find_update_ne by auto];
           destruct (FMap.find (from param) _) eqn:from_balance;
           destruct (FMap.find (to param) (tokens cstate)) eqn:to_balance;
-          destruct param; cbn in *;
-            unshelve (repeat match goal with
-              | H : ?x = ?y |- context [ ?x ] => rewrite H
-              | H : _ <= 0 |- _ => apply N.lt_eq_cases in H as [H | H]; try lia; subst
-              | |- context [ FMap.find ?x (FMap.add ?x _ _) ] => rewrite FMap.find_add
-              | |- context [ FMap.add ?x _ (FMap.add ?x _ _) ] => rewrite FMap.add_add
-              | H : ?x <> ?y |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-              | H : ?y <> ?x |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-              | H : ?x <> ?y |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
-              | H : ?y <> ?x |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
-              | H : FMap.find ?x _ = Some _ |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add_existing; eauto
-              | H : FMap.find ?x _ = None |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add; eauto
-              | |- context [ FMap.remove ?x (FMap.add ?x _ _) ] => rewrite fin_maps.delete_insert_delete
-              | H : FMap.find ?x ?m = Some _ |- context [ sumN _ ((_, _) :: FMap.elements (FMap.remove ?x ?m)) ] => rewrite fin_maps.map_to_list_delete; auto
-              | H : FMap.find ?x _ = Some ?n |- context [ sumN _ ((?x, ?n) :: (_, _) :: FMap.elements (FMap.remove ?x _)) ] => rewrite sumN_swap, fin_maps.map_to_list_delete; auto
-              | |- context [ sumN _ ((?t, ?n + ?m) :: _) ] => erewrite sumN_split with (x := (t, n)) (y := (_, m)) by lia
-              | |- context [ sumN _ ((_, 0) :: (?x, ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n)) by auto
-              | |- context [ sumN _ ((_, ?n) :: (?x, ?m - ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n + m - n))
-              | |- context [ sumN _ ((?x, ?m - ?n) :: (_, ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n + m - n))
-              | |- context [ with_default _ None ] => unfold with_default
-              | |- context [ with_default _ (Some _) ] => unfold with_default
-              | |- context [ FMap.update _ None _ ] => unfold FMap.update
-              | |- context [ FMap.update _ (Some _) _ ] => unfold FMap.update
-              | |- context [ 0 + _ ] => rewrite N.add_0_l
-              | |- context [ _ + 0 ] => rewrite N.add_0_r
-              | |- context [ 0 - _ ] => rewrite N.sub_0_l
-              | |- context [ _ - 0 ] => rewrite N.sub_0_r
-              | H : ?x <= ?y, G : ?y - ?x = 0 |- _ => rewrite N.sub_0_le in G; apply N.le_antisymm in G
-              | H : ?x + ?y = 0 |- _ => apply N.eq_add_0 in H as []
-              | H : ?x = 0 |- _ => subst x
-              | |- context [ FMap.update ?k _ (FMap.update ?k _ _) ] => rewrite FMap.map_update_idemp
-              | H : ?y <= ?x |- context [ maybe (with_default 0 (maybe (?x - ?y)) + ?y) ] => apply maybe_sub_add in H as [[-> ->] | ->]
-              | H : FMap.find ?x ?m = Some 0 |- context [ FMap.elements (FMap.remove ?x _) ] =>
-                  rewrite <- N.add_0_r; change 0 with ((fun '(_, v) => v) (x, 0)); rewrite sumN_inv; rewrite fin_maps.map_to_list_delete
-              | H : FMap.find ?k ?m = None |- context [ FMap.remove ?k _ ] => rewrite fin_maps.delete_notin
-              | |- context [ maybe _ ] => specialize maybe_cases as [[-> ?H] | [-> _]]
-              | H : ?y <> ?x |- context [ sumN _ ((?x, ?n) :: FMap.elements (FMap.remove ?y _)) ] =>
-                  cbn; rewrite N.add_comm; change n with ((fun '(_, v) => v) (y, n)); rewrite sumN_inv
-            end); try easy.
+          destruct param; cbn in *.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> ->] | ->].
+            -- rewrite <- N.add_0_r.
+               change 0 with ((fun '(_, v) => v) (from, 0)).
+               rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+            -- FMap_simpl_step.
+               rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> ->] | ->].
+            -- rewrite <- N.add_0_r.
+               change 0 with ((fun '(_, v) => v) (from, 0)).
+               rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+            -- FMap_simpl_step.
+               rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> _] | ->].
+            -- now rewrite fin_maps.delete_notin.
+            -- FMap_simpl_step.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> _] | ->].
+            -- now rewrite fin_maps.delete_notin.
+            -- FMap_simpl_step.
+          * unfold FMap.update.
+            specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- apply N.eq_add_0 in H3 as []; subst. 
+               specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (from, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  rewrite fin_maps.map_to_list_delete; auto.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, n) (to, n0)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  change n with ((fun '(_, v) => v) (from, n)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, value) (to, n0)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, n)) by lia.
+                  rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite N.add_0_l.
+            unfold FMap.update.
+            specialize maybe_cases as [[-> ->] | [-> _]].
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  rewrite fin_maps.delete_notin.
+                  2: FMap_simpl_step.
+                  change 0 with ((fun '(_, v) => v) (from, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite fin_maps.delete_notin.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  rewrite fin_maps.map_to_list_delete; auto.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  change n with ((fun '(_, v) => v) (from, n)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, n)) by lia.
+                  rewrite fin_maps.map_to_list_delete; auto.
+          * unfold FMap.update.
+            specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- apply N.eq_add_0 in H3 as []; subst. 
+               specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite fin_maps.delete_notin; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite N.add_0_r.
+                  rewrite fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite fin_maps.delete_notin; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, value) (to, n)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, 0)) by lia.
+                  auto.
+          * rewrite N.add_0_l.
+            unfold FMap.update.
+            specialize maybe_cases as [[-> ->] | [-> _]].
+            -- rewrite N.sub_0_r. cbn.
+               rewrite fin_maps.delete_notin.
+               2: FMap_simpl_step.
+               rewrite fin_maps.delete_notin; auto. 
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step. cbn.
+                  rewrite fin_maps.delete_notin; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, 0)) by lia.
+                  auto.
       + erewrite <- try_approve_preserves_total_supply; eauto.
         unfold sum_balances.
         erewrite <- try_approve_preserves_balances; eauto.

--- a/examples/eip20/EIP20TokenCorrect.v
+++ b/examples/eip20/EIP20TokenCorrect.v
@@ -195,29 +195,59 @@ Section Theories.
     rewrite add_is_partial_alter_plus; auto.
     edestruct (address_eqb from to) eqn:from_to_eq;
       destruct FMap.find eqn:from_prev;
-      destruct_address_eq; try discriminate; subst; cbn in *;
-      repeat match goal with
-      | H : _ <= 0 |- _ => apply N.lt_eq_cases in H as [H | H]; try lia; subst
-      | |- context [ with_default _ (FMap.find to balances) ] => destruct (FMap.find to balances) eqn:to_prev; cbn
-      | |- context [ FMap.find ?x (FMap.add ?x _ _) ] => rewrite FMap.find_add
-      | H : FMap.find ?t ?m = Some _ |- FMap.find ?t ?m = Some _ => cbn; rewrite H; f_equal; lia
-      | H : ?x <> ?y |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-      | H : ?y <> ?x |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-      | H : FMap.find ?x _ = Some _ |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add_existing; eauto
-      | |- context [ FMap.add ?x _ (FMap.add ?x _ _) ] => rewrite FMap.add_add
-      | H : FMap.find ?x _ = None |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add; eauto
-      | |- context [ FMap.remove ?x (FMap.add ?x _ _) ] => rewrite fin_maps.delete_insert_delete
-      | H : FMap.find ?x ?m = Some _ |- context [ sumN _ ((_, _) :: FMap.elements (FMap.remove ?x ?m)) ] => rewrite fin_maps.map_to_list_delete; auto
-      | H : FMap.find ?x _ = Some ?n |- context [ sumN _ ((?x, ?n) :: FMap.elements (FMap.remove ?x _)) ] => rewrite fin_maps.map_to_list_delete; auto
-      | H : FMap.find ?x _ = Some ?n |- context [ sumN _ ((?x, ?n) :: (_, _) :: FMap.elements (FMap.remove ?x _)) ] => rewrite sumN_swap, fin_maps.map_to_list_delete; auto
-      | |- context [ _ + 0 ] => rewrite N.add_0_r
-      | |- context [ 0 + _ ] => rewrite N.add_0_l
-      | |- context [ sumN _ ((?t, ?n + ?m) :: _) ] => erewrite sumN_split with (x := (t, n)) (y := (_, m)) by lia
-      | |- context [ sumN _ ((_, ?n) :: (_, ?m - ?n) :: _) ] => erewrite <- sumN_split with (z := (_, n + m - n)) by lia
-    end.
-    Unshelve. eauto.
+      destruct_address_eq; try discriminate; subst; cbn in *.
+      - do 3 FMap_simpl_step.
+        simpl with_default.
+        rewrite N.sub_add by assumption.
+        rewrite fin_maps.map_to_list_delete; auto.
+      - do 3 FMap_simpl_step.
+        simpl with_default.
+        rewrite N.sub_add by assumption.
+        reflexivity.
+      - FMap_simpl_step.
+        destruct (FMap.find to balances) eqn:to_prev; cbn.
+        + FMap_simpl_step.
+          2: FMap_simpl_step.
+          rewrite (sumN_split _ (to, amount) (to, n1)) by lia.
+          rewrite <- sumN_inv.
+          rewrite fin_maps.map_to_list_delete; auto.
+          2: FMap_simpl_step.
+          FMap_simpl_step.
+          cbn.
+          rewrite <- N.add_assoc.
+          rewrite (N.add_comm _ amount).
+          rewrite N.add_assoc.
+          rewrite N.sub_add by assumption.
+          rewrite N.add_comm.
+          change (n) with ((fun '(_, v) => v) (from, n)).
+          rewrite sumN_inv.
+          rewrite fin_maps.map_to_list_delete; auto.
+        + FMap_simpl_step.
+          2: FMap_simpl_step.
+          rewrite N.add_0_l. cbn.
+          rewrite FMap.elements_add_existing; eauto.
+          rewrite N.add_comm.
+          change (amount) with ((fun '(_, v) => v) (from, amount)).
+          rewrite sumN_inv.
+          rewrite <- (sumN_split _ _ _ (from, n - amount + amount)) by lia.
+          rewrite N.sub_add by assumption.
+          rewrite fin_maps.map_to_list_delete; auto.
+      - FMap_simpl_step.
+        destruct (FMap.find to balances) eqn:to_prev; cbn.
+        + FMap_simpl_step.
+          2: FMap_simpl_step.
+          rewrite (sumN_split _ (to, amount) (to, n0)) by lia.
+          rewrite <- sumN_inv.
+          rewrite fin_maps.map_to_list_delete; auto.
+          2: FMap_simpl_step.
+          FMap_simpl_step.
+          cbn. lia.
+        + FMap_simpl_step.
+          2: FMap_simpl_step.
+          cbn.
+          FMap_simpl_step.
+          cbn. lia.
   Qed.
-
   (* end hide *)
 
 

--- a/examples/fa1_2/FA1_2Correct.v
+++ b/examples/fa1_2/FA1_2Correct.v
@@ -259,7 +259,7 @@ Section Theories.
     - now contract_simpl.
     - contract_simpl.
       rewrite !FMap.find_update_eq.
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** [try_transfer] removes empty entries from balance map *)
@@ -274,12 +274,12 @@ Section Theories.
     rewrite N.ltb_ge in *.
     destruct (address_eqb_spec param.(from) param.(to)) as [<-|]; auto.
     - rewrite !FMap.find_update_eq.
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
     - rewrite !FMap.find_update_ne by auto.
       rewrite !FMap.find_update_eq.
       rewrite !FMap.find_update_ne with (map := prev_state.(tokens)) by auto.
-      specialize (maybe_cases ) as [[-> ?H] | [-> ?H]];
-      now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+      edestruct maybe_cases as [[-> ?H] | [-> ?H]];
+      now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** If the requirements are met then receive on transfer msg must succeed and
@@ -396,7 +396,7 @@ Section Theories.
     contract_simpl.
     cbn.
     rewrite FMap.find_update_eq.
-    now specialize (maybe_cases ) as [[-> ?H] | [-> ?H]].
+    now edestruct maybe_cases as [[-> ?H] | [-> ?H]].
   Qed.
 
   (** If the requirements are met then receive on approve msg must succeed and
@@ -758,8 +758,8 @@ Section Theories.
       env_account_balances bstate caddr = 0%Z.
   Proof.
     intros * trace deployed.
-    specialize contract_balance_bound' as (dep_info & deployment_info_eq & balance_bound); eauto.
-    specialize contract_initial_balance_bound as (dep_info' & deployment_info_eq' & balance_init_bound); eauto.
+    edestruct contract_balance_bound' as (dep_info & deployment_info_eq & balance_bound); eauto.
+    edestruct contract_initial_balance_bound as (dep_info' & deployment_info_eq' & balance_init_bound); eauto.
     rewrite deployment_info_eq in deployment_info_eq'.
     Unshelve. all: eauto.
     injection deployment_info_eq' as ->.
@@ -876,9 +876,9 @@ Section Theories.
             -- now rewrite fin_maps.delete_notin.
             -- FMap_simpl_step.
           * unfold FMap.update.
-            specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ?H] | [-> _]].
             -- apply N.eq_add_0 in H3 as []; subst. 
-               specialize maybe_cases as [[-> ?H] | [-> _]].
+               edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   change 0 with ((fun '(_, v) => v) (to, 0)).
@@ -894,7 +894,7 @@ Section Theories.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
                   rewrite fin_maps.map_to_list_delete; auto.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -915,8 +915,8 @@ Section Theories.
                   rewrite fin_maps.map_to_list_delete; auto.
           * rewrite N.add_0_l.
             unfold FMap.update.
-            specialize maybe_cases as [[-> ->] | [-> _]].
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ->] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   rewrite fin_maps.delete_notin.
@@ -928,7 +928,7 @@ Section Theories.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
                   rewrite fin_maps.map_to_list_delete; auto.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -944,9 +944,9 @@ Section Theories.
                   rewrite <- (sumN_split _ _ _ (from, n)) by lia.
                   rewrite fin_maps.map_to_list_delete; auto.
           * unfold FMap.update.
-            specialize maybe_cases as [[-> ?H] | [-> _]].
+            edestruct maybe_cases as [[-> ?H] | [-> _]].
             -- apply N.eq_add_0 in H3 as []; subst. 
-               specialize maybe_cases as [[-> ?H] | [-> _]].
+               edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   rewrite <- N.add_0_r.
                   change 0 with ((fun '(_, v) => v) (to, 0)).
@@ -959,7 +959,7 @@ Section Theories.
                   rewrite sumN_inv, fin_maps.map_to_list_delete.
                   2: FMap_simpl_step.
                   FMap_simpl_step.
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step.
@@ -979,12 +979,12 @@ Section Theories.
                   auto.
           * rewrite N.add_0_l.
             unfold FMap.update.
-            specialize maybe_cases as [[-> ->] | [-> _]].
+            edestruct maybe_cases as [[-> ->] | [-> _]].
             -- rewrite N.sub_0_r. cbn.
                rewrite fin_maps.delete_notin.
                2: FMap_simpl_step.
                rewrite fin_maps.delete_notin; auto. 
-            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- edestruct maybe_cases as [[-> ?H] | [-> _]].
               --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
                   FMap_simpl_step.
                   2: FMap_simpl_step. cbn.

--- a/examples/fa1_2/FA1_2Correct.v
+++ b/examples/fa1_2/FA1_2Correct.v
@@ -796,6 +796,29 @@ Section Theories.
     - apply N.le_0_l.
   Qed.
 
+  Ltac FMap_simpl_step :=
+    match goal with
+      | |- context [ FMap.find ?x (FMap.add ?x _ _) ] => setoid_rewrite FMap.find_add
+      | H : FMap.find ?t ?m = Some _ |- FMap.find ?t ?m = Some _ => cbn; rewrite H; f_equal; lia
+      | H : ?x <> ?y |- context [ FMap.find ?x (FMap.add ?y _ _) ] => setoid_rewrite FMap.find_add_ne; eauto
+      | H : ?y <> ?x |- context [ FMap.find ?x (FMap.add ?y _ _) ] => setoid_rewrite FMap.find_add_ne; eauto
+      | H : FMap.find ?x _ = Some _ |- context [ FMap.elements (FMap.add ?x _ _) ] => setoid_rewrite FMap.elements_add_existing; eauto
+      | |- context [ FMap.add ?x _ (FMap.add ?x _ _) ] => setoid_rewrite FMap.add_add
+      | H : FMap.find ?x _ = None |- context [ FMap.elements (FMap.add ?x _ _) ] => setoid_rewrite FMap.elements_add; eauto
+      | |- context [ FMap.remove ?x (FMap.add ?x _ _) ] => rewrite fin_maps.delete_insert_delete
+      | |- context [ FMap.find ?x (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter
+      | H : ?x' <> ?x |- context [ FMap.find ?x' (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter_ne; auto
+      | H : ?x <> ?x' |- context [ FMap.find ?x' (FMap.partial_alter _ ?x _) ] => setoid_rewrite FMap.find_partial_alter_ne
+      | H : context [ AddressMap.find _ _ ] |- _ => rewrite AddressMap_find_convertible in H
+      | H : context [ AddressMap.add _ _ _ ] |- _ => rewrite AddressMap_add_convertible in H
+      | |- context [ AddressMap.find _ _ ] => rewrite AddressMap_find_convertible
+      | |- context [ AddressMap.add _ _ _ ] => rewrite AddressMap_add_convertible
+      | H : ?x <> ?y |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
+      | H : ?y <> ?x |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
+    end.
+
+  Tactic Notation "FMap_simpl" := repeat (FMap_simpl_step; cbn).
+
   (** [total_supply] is always equal to the sum of all account token balances *)
   Lemma sum_balances_eq_total_supply : forall bstate caddr,
     reachable bstate ->
@@ -825,45 +848,155 @@ Section Theories.
           [rewrite FMap.find_update_eq | rewrite FMap.find_update_ne by auto];
           destruct (FMap.find (from param) _) eqn:from_balance;
           destruct (FMap.find (to param) (tokens cstate)) eqn:to_balance;
-          destruct param; cbn in *;
-            unshelve (repeat match goal with
-              | H : ?x = ?y |- context [ ?x ] => rewrite H
-              | H : _ <= 0 |- _ => apply N.lt_eq_cases in H as [H | H]; try lia; subst
-              | |- context [ FMap.find ?x (FMap.add ?x _ _) ] => rewrite FMap.find_add
-              | |- context [ FMap.add ?x _ (FMap.add ?x _ _) ] => rewrite FMap.add_add
-              | H : ?x <> ?y |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-              | H : ?y <> ?x |- context [ FMap.find ?x (FMap.add ?y _ _) ] => rewrite FMap.find_add_ne; eauto
-              | H : ?x <> ?y |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
-              | H : ?y <> ?x |- context [ FMap.find ?x (FMap.remove ?y _) ] => rewrite FMap.find_remove_ne; eauto
-              | H : FMap.find ?x _ = Some _ |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add_existing; eauto
-              | H : FMap.find ?x _ = None |- context [ FMap.elements (FMap.add ?x _ _) ] => rewrite FMap.elements_add; eauto
-              | |- context [ FMap.remove ?x (FMap.add ?x _ _) ] => rewrite fin_maps.delete_insert_delete
-              | H : FMap.find ?x ?m = Some _ |- context [ sumN _ ((_, _) :: FMap.elements (FMap.remove ?x ?m)) ] => rewrite fin_maps.map_to_list_delete; auto
-              | H : FMap.find ?x _ = Some ?n |- context [ sumN _ ((?x, ?n) :: (_, _) :: FMap.elements (FMap.remove ?x _)) ] => rewrite sumN_swap, fin_maps.map_to_list_delete; auto
-              | |- context [ sumN _ ((?t, ?n + ?m) :: _) ] => erewrite sumN_split with (x := (t, n)) (y := (_, m)) by lia
-              | |- context [ sumN _ ((_, 0) :: (?x, ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n)) by auto
-              | |- context [ sumN _ ((_, ?n) :: (?x, ?m - ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n + m - n))
-              | |- context [ sumN _ ((?x, ?m - ?n) :: (_, ?n) :: _) ] => erewrite <- sumN_split with (z := (x, n + m - n))
-              | |- context [ with_default _ None ] => unfold with_default
-              | |- context [ with_default _ (Some _) ] => unfold with_default
-              | |- context [ FMap.update _ None _ ] => unfold FMap.update
-              | |- context [ FMap.update _ (Some _) _ ] => unfold FMap.update
-              | |- context [ 0 + _ ] => rewrite N.add_0_l
-              | |- context [ _ + 0 ] => rewrite N.add_0_r
-              | |- context [ 0 - _ ] => rewrite N.sub_0_l
-              | |- context [ _ - 0 ] => rewrite N.sub_0_r
-              | H : ?x <= ?y, G : ?y - ?x = 0 |- _ => rewrite N.sub_0_le in G; apply N.le_antisymm in G
-              | H : ?x + ?y = 0 |- _ => apply N.eq_add_0 in H as []
-              | H : ?x = 0 |- _ => subst x
-              | |- context [ FMap.update ?k _ (FMap.update ?k _ _) ] => rewrite FMap.map_update_idemp
-              | H : ?y <= ?x |- context [ maybe (with_default 0 (maybe (?x - ?y)) + ?y) ] => apply maybe_sub_add in H as [[-> ->] | ->]
-              | H : FMap.find ?x ?m = Some 0 |- context [ FMap.elements (FMap.remove ?x _) ] =>
-                  rewrite <- N.add_0_r; change 0 with ((fun '(_, v) => v) (x, 0)); rewrite sumN_inv; rewrite fin_maps.map_to_list_delete
-              | H : FMap.find ?k ?m = None |- context [ FMap.remove ?k _ ] => rewrite fin_maps.delete_notin
-              | |- context [ maybe _ ] => specialize maybe_cases as [[-> ?H] | [-> _]]
-              | H : ?y <> ?x |- context [ sumN _ ((?x, ?n) :: FMap.elements (FMap.remove ?y _)) ] =>
-                  cbn; rewrite N.add_comm; change n with ((fun '(_, v) => v) (y, n)); rewrite sumN_inv
-            end); try easy.
+          destruct param; cbn in *.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> ->] | ->].
+            -- rewrite <- N.add_0_r.
+               change 0 with ((fun '(_, v) => v) (from, 0)).
+               rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+            -- FMap_simpl_step.
+               rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> ->] | ->].
+            -- rewrite <- N.add_0_r.
+               change 0 with ((fun '(_, v) => v) (from, 0)).
+               rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+            -- FMap_simpl_step.
+               rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> _] | ->].
+            -- now rewrite fin_maps.delete_notin.
+            -- FMap_simpl_step.
+          * rewrite FMap.map_update_idemp.
+            unfold FMap.update.
+            apply maybe_sub_add in H1 as [[-> _] | ->].
+            -- now rewrite fin_maps.delete_notin.
+            -- FMap_simpl_step.
+          * unfold FMap.update.
+            specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- apply N.eq_add_0 in H3 as []; subst. 
+               specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (from, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  rewrite fin_maps.map_to_list_delete; auto.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, n) (to, n0)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  change n with ((fun '(_, v) => v) (from, n)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, value) (to, n0)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, n)) by lia.
+                  rewrite fin_maps.map_to_list_delete; auto.
+          * rewrite N.add_0_l.
+            unfold FMap.update.
+            specialize maybe_cases as [[-> ->] | [-> _]].
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  rewrite fin_maps.delete_notin.
+                  2: FMap_simpl_step.
+                  change 0 with ((fun '(_, v) => v) (from, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite fin_maps.delete_notin.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  rewrite fin_maps.map_to_list_delete; auto.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  change n with ((fun '(_, v) => v) (from, n)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, n)) by lia.
+                  rewrite fin_maps.map_to_list_delete; auto.
+          * unfold FMap.update.
+            specialize maybe_cases as [[-> ?H] | [-> _]].
+            -- apply N.eq_add_0 in H3 as []; subst. 
+               specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite fin_maps.delete_notin; auto.
+              --- rewrite N.sub_0_r.
+                  rewrite <- N.add_0_r.
+                  change 0 with ((fun '(_, v) => v) (to, 0)).
+                  rewrite sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite N.add_0_r.
+                  rewrite fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  rewrite fin_maps.delete_notin; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite (sumN_split _ (to, value) (to, n)) by lia.
+                  rewrite <- sumN_inv, fin_maps.map_to_list_delete.
+                  2: FMap_simpl_step.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, 0)) by lia.
+                  auto.
+          * rewrite N.add_0_l.
+            unfold FMap.update.
+            specialize maybe_cases as [[-> ->] | [-> _]].
+            -- rewrite N.sub_0_r. cbn.
+               rewrite fin_maps.delete_notin.
+               2: FMap_simpl_step.
+               rewrite fin_maps.delete_notin; auto. 
+            -- specialize maybe_cases as [[-> ?H] | [-> _]].
+              --- rewrite N.sub_0_le in H3; apply N.le_antisymm in H3; auto; subst.
+                  FMap_simpl_step.
+                  2: FMap_simpl_step. cbn.
+                  rewrite fin_maps.delete_notin; auto.
+              --- FMap_simpl_step.
+                  2: FMap_simpl_step.
+                  rewrite <- sumN_inv.
+                  FMap_simpl_step.
+                  change value with ((fun '(_, v) => v) (from, value)).
+                  rewrite sumN_inv.
+                  rewrite <- (sumN_split _ _ _ (from, 0)) by lia.
+                  auto.
       + erewrite <- try_approve_preserves_total_supply; eauto.
         unfold sum_balances.
         erewrite <- try_approve_preserves_balances; eauto.

--- a/examples/piggybank/PiggyBankCorrect.v
+++ b/examples/piggybank/PiggyBankCorrect.v
@@ -249,7 +249,7 @@ Section SafetyProperties.
       env_account_balances bstate caddr = cstate.(balance).
   Proof.
     intros * trace reach deployed.
-    specialize balance_on_chain' as (cstate & balance); eauto.
+    edestruct balance_on_chain' as (cstate & balance); eauto.
     intros Hact. rewrite Hact in balance. cbn in *.
     now exists cstate.
   Qed.
@@ -330,9 +330,9 @@ Section SafetyProperties.
       | H : Some ?x = Some _ |- _ => inversion H; subst x; clear H
       end.
       + rewrite address_eq_refl. intros state_intact.
-        specialize balance_on_chain' as (state1 & construct1 & balance); eauto.
+        edestruct balance_on_chain' as (state1 & construct1 & balance); eauto.
         now constructor.
-        specialize no_outgoing_actions_when_intact as (state2 & [construct2 act]); eauto.
+        edestruct no_outgoing_actions_when_intact as (state2 & [construct2 act]); eauto.
         now constructor.
         unfold contract_state in *.
         destruct (env_contract_states bstate_from to_addr); try discriminate.
@@ -356,7 +356,7 @@ Section SafetyProperties.
           congruence.
         ** discriminate.
         * cbn. lia.
-      + specialize no_outgoing_actions_when_intact as (? & ?); eauto.
+      + edestruct no_outgoing_actions_when_intact as (? & ?); eauto.
         * now constructor.
         * intros intact. destruct H.
           unfold contract_state in *.
@@ -389,7 +389,7 @@ Section SafetyProperties.
       (env_account_balances bstate caddr = 0)%Z).
   Proof.
     intros * trace reach deployed act.
-    specialize balance_is_zero_when_smashed' as (cstate & deploy & balance); eauto.
+    edestruct balance_is_zero_when_smashed' as (cstate & deploy & balance); eauto.
     rewrite act, Z.sub_0_r in balance.
     exists cstate.
     split; eauto.

--- a/execution/theories/BuildUtils.v
+++ b/execution/theories/BuildUtils.v
@@ -606,7 +606,7 @@ Proof.
     + now apply finalized_heigh_chain_height.
     + apply NPeano.Nat.sub_0_le in slot_hit.
       rewrite_environment_equiv. cbn. lia.
-  - specialize forward_time_exact with (slot := slot) as
+  - specialize (forward_time_exact bstate reward creator slot) as
       (bstate' & header & reach' & header_valid & slot_hit' & queue' & env_eq); eauto.
     lia.
     do 2 eexists.
@@ -932,7 +932,7 @@ Ltac forward_time slot_ :=
   | Hqueue : (chain_state_queue ?bstate) = [],
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize (forward_time bstate) with (slot := slot_)
+      edestruct (forward_time bstate) with (slot := slot_)
         as [new_bstate [new_header [new_reach [new_header_valid [new_slot_hit [new_queue new_env_eq]]]]]]
   end.
 
@@ -948,7 +948,7 @@ Ltac forward_time_exact slot_ :=
   | Hqueue : (chain_state_queue ?bstate) = [],
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize (forward_time_exact bstate) with (slot := slot_)
+      edestruct (forward_time_exact bstate) with (slot := slot_)
         as [new_bstate [new_header [new_reach [new_header_valid [new_slot_hit [new_queue new_env_eq]]]]]]
   end.
 
@@ -961,7 +961,7 @@ Ltac add_block acts_ slot_ :=
   | Hqueue : (chain_state_queue ?bstate) = [],
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize add_block with (acts := acts_) (slot_incr := slot_)
+      edestruct add_block with (acts := acts_) (slot_incr := slot_)
         as [new_bstate [new_reach [new_queue new_env_eq]]];
       [apply Hreach | apply Hqueue| | | | | |]
   end.
@@ -976,7 +976,7 @@ Ltac evaluate_action contract_ :=
   | Hqueue : (chain_state_queue ?bstate) = _,
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize (evaluate_action contract_) as
+      edestruct (evaluate_action contract_) as
         [new_bstate [new_reach [new_deployed_state [new_queue new_env_eq]]]];
       [apply Hreach | rewrite Hqueue | | | | | | ]
   end.
@@ -990,7 +990,7 @@ Ltac evaluate_transfer :=
   | Hqueue : (chain_state_queue ?bstate) = _,
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize evaluate_transfer as
+      edestruct evaluate_transfer as
         [new_bstate [new_reach [new_queue new_env_eq]]];
       [apply Hreach | rewrite Hqueue | | | | ]
   end.
@@ -1004,7 +1004,7 @@ Ltac discard_invalid_action :=
   | Hqueue : (chain_state_queue ?bstate) = _,
     Hreach : reachable ?bstate |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize discard_invalid_action as
+      edestruct discard_invalid_action as
         [new_bstate [new_reach [new_queue new_env_eq]]];
       [apply Hreach | rewrite Hqueue | | | ]
   end.
@@ -1022,7 +1022,7 @@ Ltac empty_queue H :=
       pattern (bstate) in H;
       match type of H with
       | ?f bstate =>
-        specialize (empty_queue bstate f) as
+        edestruct (empty_queue bstate f) as
           [new_bstate [new_reach [temp_H new_queue]]];
         [apply Hreach | apply Hempty | apply H |
         clear H;
@@ -1049,7 +1049,7 @@ Ltac deploy_contract contract_ :=
     Haddress : address_is_contract ?caddr = true,
     Hdeployed : env_contracts ?bstate.(chain_state_env) ?caddr = None |-
     exists bstate', reachable_through ?bstate bstate' /\ _ =>
-      specialize (deploy_contract contract_) as
+      edestruct (deploy_contract contract_) as
         (new_bstate & trace & new_reach & new_contract_deployed &
           new_deployed_state & deploy_info & new_queue & new_env_eq);
       [apply Hreach | rewrite Hqueue | | |

--- a/execution/theories/ContractCommon.v
+++ b/execution/theories/ContractCommon.v
@@ -73,9 +73,9 @@ Section Utility.
     specialize (maybe_cases (n - value)) as [[-> n_eq_value] | [-> _]]; cbn.
     - rewrite N.sub_0_le in n_eq_value.
       erewrite (N.le_antisymm _ n) by eassumption.
-      now specialize (maybe_cases) as [[-> ?H] | [-> _]]; cbn.
+      now edestruct maybe_cases as [[-> ?H] | [-> _]]; cbn.
     - rewrite N.sub_add by auto.
-      now specialize (maybe_cases) as [[-> ?H] | [-> _]]; cbn.
+      now edestruct maybe_cases as [[-> ?H] | [-> _]]; cbn.
   Qed.
   Close Scope N_scope.
 

--- a/utils/theories/Automation.v
+++ b/utils/theories/Automation.v
@@ -243,7 +243,7 @@ Ltac destruct_and_split :=
 
 Tactic Notation "tryfalse" :=
   try solve [
-    elimtype False;
+    cut False; only 1: (let hn := fresh "H" in intro hn; elim hn; try clear hn);
     try solve [assumption | discriminate | congruence]
   ].
 

--- a/utils/theories/Env.v
+++ b/utils/theories/Env.v
@@ -64,9 +64,10 @@ Fixpoint remove_by_key {A} (key : string) (ρ : env A) : env A :=
 Lemma lookup_i_length {A} (ρ : env A) n :
   (n <? length ρ) = true -> {e | lookup_i ρ n = Some e}.
 Proof.
-  intros H. revert dependent n.
+  intros H. generalize dependent n.
   induction ρ; intros; propify; simpl in *.
-  elimtype False. lia.
+  cut False; only 1: (let hn := fresh "H" in intro hn; elim hn; try clear hn).
+  lia.
   destruct a. destruct n.
   + simpl; eauto.
   + simpl.
@@ -79,7 +80,7 @@ Qed.
 Lemma lookup_i_length_false {A} (ρ : env A) n :
   (n <? length ρ) = false -> lookup_i ρ n = None.
 Proof.
-  intros H. revert dependent n.
+  intros H. generalize dependent n.
   induction ρ; intros; propify; simpl in *; auto.
   destruct a. destruct n.
   + simpl; eauto.


### PR DESCRIPTION
Add compatibility for
* Coq 8.18
* Metacoq 1.2.1

Update std++ to 1.9.0

We rely on a pinned Quickchick commit because of a Coq bug in 8.17.1+ that makes it impossible to require both Quickchick and Equations in the same file. This bug should be fixed in 8.18.1. 