### PR TITLE
Fix Concordium test dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Test extraction
         run: |
           echo "::group::Running tests"
+          git config --global url.https://github.com/.insteadOf git@github.com:
           make -j${{ env.JOBS }} test-extraction
           echo "::endgroup::"
 

--- a/extraction/tests/extracted-code/concordium-extract/concert-std/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/concert-std/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-bumpalo = "3.5.0"
+bumpalo = "=3.5.0"
 concert-std-derive = { path = "../concert-std-derive" }
 immutable-map = "0.1.2"
+
+[patch.crates-io]
+concordium-std-derive = { git = "https://github.com/Concordium/concordium-rust-smart-contracts", rev="4d4b024b547a1f120f6d6951cbc409c94f8f146a" }
 
 [dependencies.concordium-std]
 version = "2.0.0"

--- a/extraction/tests/extracted-code/concordium-extract/counter-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/counter-extracted/Cargo.toml
@@ -11,9 +11,11 @@ std = ["concordium-std/std"]
 
 [dependencies]
 concert-std = { path = "../concert-std" }
-bumpalo = "3.5.0"
+bumpalo = "=3.5.0"
 immutable-map = "0.1.2"
 
+[patch.crates-io]
+concordium-std-derive = { git = "https://github.com/Concordium/concordium-rust-smart-contracts", rev="4d4b024b547a1f120f6d6951cbc409c94f8f146a" }
 
 [dependencies.concordium-std]
 version = "2.0.0"

--- a/extraction/tests/extracted-code/concordium-extract/escrow-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/escrow-extracted/Cargo.toml
@@ -11,8 +11,11 @@ std = ["concordium-std/std"]
 
 [dependencies]
 concert-std = { path = "../concert-std" }
-bumpalo = "3.5.0"
+bumpalo = "=3.5.0"
 immutable-map = "0.1.2"
+
+[patch.crates-io]
+concordium-std-derive = { git = "https://github.com/Concordium/concordium-rust-smart-contracts", rev="4d4b024b547a1f120f6d6951cbc409c94f8f146a" }
 
 [dependencies.concordium-std]
 version = "2.0.0"

--- a/extraction/tests/extracted-code/concordium-extract/interp-extracted/Cargo.toml
+++ b/extraction/tests/extracted-code/concordium-extract/interp-extracted/Cargo.toml
@@ -11,8 +11,11 @@ std = ["concordium-std/std"]
 
 [dependencies]
 concert-std = { path = "../concert-std" }
-bumpalo = "3.5.0"
+bumpalo = "=3.5.0"
 immutable-map = "0.1.2"
+
+[patch.crates-io]
+concordium-std-derive = { git = "https://github.com/Concordium/concordium-rust-smart-contracts", rev="4d4b024b547a1f120f6d6951cbc409c94f8f146a" }
 
 [dependencies.concordium-std]
 version = "2.0.0"


### PR DESCRIPTION
The `concordium-std-derive` dependency used in testing the extracted consortium smart contracts was yanked from crates.io.
We fix this by depending on the specific commit rather than a released version.