### PR TITLE
Use QuickChick 2.0.4

### DIFF
--- a/.github/coq-concert.opam.locked
+++ b/.github/coq-concert.opam.locked
@@ -21,7 +21,7 @@ depends: [
   "coq-metacoq-utils" {= "1.2.1+8.18"}
   "coq-rust-extraction" {= "dev"}
   "coq-elm-extraction" {= "dev"}
-  "coq-quickchick" {= "dev"}
+  "coq-quickchick" {= "2.0.4"}
   "coq-stdpp" {= "1.9.0"}
 ]
 build: [
@@ -42,9 +42,5 @@ pin-depends: [
   [
     "coq-elm-extraction.dev"
     "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"
-  ]
-  [
-    "coq-quickchick.dev"
-    "git+https://github.com/4ever2/QuickChick.git#bc61d58045feeb754264df9494965c280e266e1c"
   ]
 ]

--- a/coq-concert.opam
+++ b/coq-concert.opam
@@ -16,7 +16,7 @@ doc: "https://au-cobra.github.io/ConCert/toc.html"
 depends: [
   "coq" {>= "8.17" & < "8.19~"}
   "coq-bignums" {>= "8"}
-  "coq-quickchick" {= "dev"}
+  "coq-quickchick" {>= "2.0.4"}
   "coq-metacoq-utils" {>= "1.2" & < "1.3~"}
   "coq-metacoq-common" {>= "1.2" & < "1.3~"}
   "coq-metacoq-template" {>= "1.2" & < "1.3~"}
@@ -32,7 +32,6 @@ depends: [
 pin-depends: [
   ["coq-rust-extraction.dev" "git+https://github.com/AU-COBRA/coq-rust-extraction.git#0053733e56008c917bf43d12e8bf0616d3b9a856"]
   ["coq-elm-extraction.dev" "git+https://github.com/AU-COBRA/coq-elm-extraction.git#903320120e3f36d7857161e5680fabeb6e743c6b"]
-  ["coq-quickchick.dev" "git+https://github.com/4ever2/QuickChick.git#bc61d58045feeb754264df9494965c280e266e1c"]
 ]
 
 build: [


### PR DESCRIPTION
The new QuickChick 2.0.4 release now contains a permanent fix for the Equations incompatibility issue.
So we can now stop relying on our workaround.