### PR TITLE
[8.20] Update rust setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,10 +144,10 @@ jobs:
           path: extraction/tests/extracted-code
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.69.0
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
       - name: Set up Concordium tools
         run: |
           curl -L -O https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0


### PR DESCRIPTION
We switch to using `dtolnay/rust-toolchain` for configuring Rust in CI.
This is necessary since the old setup uses features that are deprecated and set to be removed.