### PR TITLE
Fix install make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 	rm -rf docs
 .PHONY: clean
 
-install: all
+install: core
 	+make -C utils install
 	+make -C execution install
 	+make -C embedding install


### PR DESCRIPTION
Install should only depend on core since we don't include examples in the opam package.