### PR TITLE
Use QuickChick's `QCDerive` in the Show printers (required from QuickChick 2.2.0)

### DIFF
--- a/examples/escrow/tests/EscrowPrinters.v
+++ b/examples/escrow/tests/EscrowPrinters.v
@@ -11,11 +11,11 @@ Local Open Scope string_scope.
 (* TODO: reenable deprecated-dirpath-Coq warning once Quickchick is updated with full Rocq support *)
 (* TODO: reenable non-recursive warning once fixed upstream in Quickchick*)
 #[warnings="-non-recursive,-deprecated-dirpath-Coq"]
-Derive Show for NextStep.
+QCDerive Show for NextStep.
 (* TODO: reenable deprecated-dirpath-Coq warning once Quickchick is updated with full Rocq support *)
 (* TODO: reenable non-recursive warning once fixed upstream in Quickchick*)
 #[warnings="-non-recursive,-deprecated-dirpath-Coq"]
-Derive Show for Msg.
+QCDerive Show for Msg.
 
 #[export]
 Instance showEscrowSetup : Show Setup :=

--- a/execution/test/ChainPrinters.v
+++ b/execution/test/ChainPrinters.v
@@ -23,15 +23,15 @@ Open Scope string_scope.
 
 Definition sep : string := ", ".
 
-(* Derive Show for positive. *)
+(* QCDerive Show for positive. *)
 (* TODO: reenable deprecated-dirpath-Coq warning once Quickchick is updated with full Rocq support *)
 #[warnings=",-deprecated-dirpath-Coq"]
-Derive Show for SerializedType.
+QCDerive Show for SerializedType.
 
 (* TODO: reenable deprecated-dirpath-Coq warning once Quickchick is updated with full Rocq support *)
 (* TODO: reenable non-recursive warning once fixed upstream in Quickchick*)
 #[warnings="-non-recursive,-deprecated-dirpath-Coq"]
-Derive Show for result.
+QCDerive Show for result.
 
 #[export]
 Instance showActionEvaluationError

--- a/execution/test/TestUtils.v
+++ b/execution/test/TestUtils.v
@@ -173,7 +173,7 @@ Open Scope string_scope.
 (* TODO: reenable deprecated-dirpath-Coq warning once Quickchick is updated with full Rocq support *)
 (* TODO: reenable non-recursive warning once fixed upstream in Quickchick*)
 #[warnings="-non-recursive,-deprecated-dirpath-Coq"]
-Derive Show for unit.
+QCDerive Show for unit.
 
 Definition deserialize_to_string {ty : Type}
                                 `{Serializable ty}


### PR DESCRIPTION
The five `Derive Show for …` commands in the printer files stop working once QuickChick 2.2.0 or newer is in the switch. Each one fails like this:

```
File "./execution/test/TestUtils.v", line 175, characters 0-74:
Error: No derive declared for Show
```

**That message does not come from QuickChick, and that is the confusing part.** It comes from Equations, which also defines a `Derive` vernac. QuickChick removed its bare `Derive` command in 2.2.0, so the command name falls through to Equations, which owns the grammar in these files (`From ConCert.Execution Require Import Blockchain.` pulls Equations in transitively — importing it alone is enough to reproduce the message). Equations then correctly reports that `Show` is not one of *its* derivations. So the error names a plugin that is not the one that changed.

QuickChick anticipated this collision. `plugin/driver.mlg` has carried a second, unambiguous spelling since well before the removal, with this comment:

```
(* To disambiguate from Derive in other plugins like Equations *)
VERNAC COMMAND EXTEND QCDerive CLASSIFIED AS SIDEFF
   | ["QCDerive" constr(class_name) "for" constr(inductive)] -> ...
```

## What the change does

Three files, six lines: every `Derive Show for X.` becomes `QCDerive Show for X.`.

- `execution/test/TestUtils.v` — 1 line
- `execution/test/ChainPrinters.v` — 2 lines, plus the commented-out `(* Derive Show for positive. *)` kept consistent
- `examples/escrow/tests/EscrowPrinters.v` — 2 lines

Nothing else changes: the surrounding `#[warnings="-non-recursive,-deprecated-dirpath-Coq"]` attributes, the generated instances and their names are all untouched.

## This does not need the `coq-quickchick` bound to move

`QCDerive` exists in every published QuickChick version at or above your declared floor of `2.0.4`. That set is exactly five versions, and I read `plugin/driver.mlg` at each of the five tags:

| coq-quickchick | bare `Derive` (`QuickChickDerive`) | `QCDerive` |
|---|---|---|
| 2.0.4 | present | present |
| 2.0.5 | present | present |
| 2.1.0 | present | present |
| 2.1.1 | present | present |
| 2.2.0 | **removed** | present |

So the patch is a no-op in behaviour at `2.1.1`, which is what `.github/rocq-concert.opam.locked` pins, and it is required from `2.2.0` on. `"coq-quickchick" {>= "2.0.4"}` stays correct as written.

**Your CI is not red today** — it resolves 2.1.1, where the bare `Derive` still exists. This is a forward-compatibility change, not a repair of something currently broken for you.

## Measured

Each of the three files compiled standalone, pristine and patched, against a switch running QuickChick at `dev`:

| file | pristine | patched |
|---|---|---|
| `execution/test/TestUtils.v` | exit 1, 1 error (line 175) | **exit 0, 0 errors** |
| `execution/test/ChainPrinters.v` | exit 1, 1 error (line 28) | **exit 0, 0 errors** |
| `examples/escrow/tests/EscrowPrinters.v` | exit 1, 1 error (line 13) | **exit 0, 0 errors** |

All three pristine errors are the `No derive declared for Show` above. A deliberately broken file in the same harness exits 1 with a different error, so the exit codes are discriminating and not an artefact of the setup.

Two caveats on those numbers, since neither is ideal:

- The ConCert installed in that switch — which the three files `Require` — was itself built with this patch applied. That cannot affect whether `QCDerive` parses (which is what is being measured), but it does mean these are not compiles against a pristine installed ConCert.
- A whole-tree build of the branch this came from produces 180 `.vo` under `ConCert/`, but that tree also carries the MetaRocq change described below, so I am not offering it as evidence for *this* patch.

## `Derive` elsewhere in the tree is unaffected

There are 197 lines mentioning `Derive` in the repository, and only the six above are the QuickChick vernac. The rest are your own term-level notations and are untouched by a vernac rename:

- `Derive Ser` — 150 uses, declared at `execution/theories/SerializableDerive.v:170`
- `Derive Show Msg < … >` — 10 uses, declared at `execution/test/ChainPrinters.v:324`, always as the body of `Instance showSerializedMsg : Show SerializedValue := …`
- 4 `Notation` declarations, and 27 lines naming the `DeriveSer` module

## Open PRs

`AU-COBRA/ConCert` has no open pull requests, so nothing here competes with work already in flight.

## Deliberately not included

- **A MetaRocq compatibility change.** `Monomorphic_entry` takes an argument at `v1.5.1-9.1` and takes none from `v1.5.1-9.2` onward. Your lockfile pins `rocq-metarocq-erasure {= "1.5.1+9.1"}`, so adapting to the newer signature would turn your CI red immediately. It is genuinely needed on newer MetaRocq, so I have kept it on a separate branch, `claude/upstream-send-metarocq` on the same fork, and can open it whenever you move that pin. It is not in this PR precisely because it is not safe to land today.
- **Packaging changes.** I have a commit adding a `dev` alternative alongside each existing bound in `rocq-concert.opam`, preserving every current bound verbatim, which is what lets the package resolve on a development switch. Happy to send it separately if useful. One note if you ever write such an arm yourself: `= "dev"` works for `rocq-core` and `rocq-stdlib`, but `rocq-stdpp` publishes its development versions as dated `dev.<date>.<n>.<sha>` strings and has no version literally named `dev`, so a `= "dev"` arm there selects nothing — it needs `>= "dev"`.

## Environment

Rocq `9.4+alpha` (OCaml 4.14.2), `coq-quickchick` at `dev` (`QuickChick/QuickChick@3d4d6c0e`, 2026-07-07), `rocq-equations` at `dev` from `mattam82/Coq-Equations#main`.

One provenance note: the prover is built from theorem-labs/rocq@7478cd16, a fork of `rocq-prover/rocq` master whose substantive addition is a kernel module-subtyping *performance* fix. It cannot turn a parse error into a success, and the grammar question here is settled by QuickChick's own source at each tag rather than by any build.

## Not claimed

Only that these three files compile. I did not run the test suites, and I have not measured anything downstream of these printers.
